### PR TITLE
Added api.ts and apiMappers.ts

### DIFF
--- a/hidden-gem-music-app/src/data/apiMappers.ts
+++ b/hidden-gem-music-app/src/data/apiMappers.ts
@@ -1,0 +1,143 @@
+import type {
+  ApiComparisonResult,
+  ApiCountryComparisonSide,
+  ApiCountryGlobeSummary,
+  ApiCountryProfile,
+  ApiHiddenGem,
+  ApiHiddenGemResponse,
+  ApiSharedSong,
+  ApiSong,
+} from "../types/api";
+
+export type UiSongPreview = {
+  title: string;
+  artist: string;
+  album: string;
+};
+
+export type UiSharedSongPreview = UiSongPreview & {
+  rankA: number;
+  rankB: number;
+};
+
+export type UiCountryProfile = {
+  countryCode: string;
+  countryName: string;
+  year: number;
+  totalCharted: number;
+  sharedCount: number;
+  uniqueCount: number;
+  overlapPercent: number;
+  topSharedSongs: UiSongPreview[];
+  topUniqueSongs: UiSongPreview[];
+};
+
+export type UiCountryComparisonSide = {
+  countryCode: string;
+  countryName: string;
+  totalCharted: number;
+  sharedCount: number;
+  uniqueCount: number;
+  overlapPercent: number;
+};
+
+export type UiComparisonResult = {
+  countryA: UiCountryComparisonSide | null;
+  countryB: UiCountryComparisonSide | null;
+  sharedSongs: UiSharedSongPreview[];
+  uniqueToA: UiSongPreview[];
+  uniqueToB: UiSongPreview[];
+};
+
+export type UiHiddenGem = UiSongPreview & {
+  genre: string;
+  previewUrl: string;
+  trendScore: number;
+  countriesChartingCount: number;
+};
+
+export type UiHiddenGemPage = {
+  items: UiHiddenGem[];
+  page: number;
+  pageSize: number;
+};
+
+export type UiCountryGlobeSummary = {
+  countryCode: string;
+  countryName: string;
+  lat: number;
+  long: number;
+  hiddenSongs: number;
+  topAlbum: string;
+};
+
+const toNonEmpty = (value: string | null | undefined, fallback: string) => {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : fallback;
+};
+
+export const mapApiSong = (song: ApiSong): UiSongPreview => ({
+  title: toNonEmpty(song.songName, "Unknown Song"),
+  artist: toNonEmpty(song.artistName, "Unknown Artist"),
+  album: toNonEmpty(song.albumName, "Unknown Album"),
+});
+
+export const mapApiSharedSong = (song: ApiSharedSong): UiSharedSongPreview => ({
+  title: toNonEmpty(song.songName, "Unknown Song"),
+  artist: toNonEmpty(song.artistName, "Unknown Artist"),
+  album: "Unknown Album",
+  rankA: song.rankA,
+  rankB: song.rankB,
+});
+
+export const mapApiCountryProfile = (profile: ApiCountryProfile): UiCountryProfile => ({
+  countryCode: toNonEmpty(profile.countryCode, ""),
+  countryName: toNonEmpty(profile.countryName, "Unknown Country"),
+  year: profile.year,
+  totalCharted: profile.totalCharted,
+  sharedCount: profile.sharedCount,
+  uniqueCount: profile.uniqueCount,
+  overlapPercent: profile.overlapPct,
+  topSharedSongs: profile.topSharedSongs.map(mapApiSong),
+  topUniqueSongs: profile.topUniqueSongs.map(mapApiSong),
+});
+
+export const mapApiComparisonSide = (side: ApiCountryComparisonSide): UiCountryComparisonSide => ({
+  countryCode: toNonEmpty(side.countryCode, ""),
+  countryName: toNonEmpty(side.countryName, "Unknown Country"),
+  totalCharted: side.totalCharted,
+  sharedCount: side.sharedCount,
+  uniqueCount: side.uniqueCount,
+  overlapPercent: side.overlapPct,
+});
+
+export const mapApiComparisonResult = (result: ApiComparisonResult): UiComparisonResult => ({
+  countryA: result.countryA ? mapApiComparisonSide(result.countryA) : null,
+  countryB: result.countryB ? mapApiComparisonSide(result.countryB) : null,
+  sharedSongs: result.sharedSongs.map(mapApiSharedSong),
+  uniqueToA: result.uniqueToA.map(mapApiSong),
+  uniqueToB: result.uniqueToB.map(mapApiSong),
+});
+
+export const mapApiHiddenGem = (item: ApiHiddenGem): UiHiddenGem => ({
+  ...mapApiSong(item),
+  genre: toNonEmpty(item.genre, "Unknown Genre"),
+  previewUrl: toNonEmpty(item.previewUrl, ""),
+  trendScore: item.trendScore,
+  countriesChartingCount: item.countriesChartingCount,
+});
+
+export const mapApiHiddenGemPage = (response: ApiHiddenGemResponse): UiHiddenGemPage => ({
+  items: response.items.map(mapApiHiddenGem),
+  page: response.page,
+  pageSize: response.pageSize,
+});
+
+export const mapApiCountryGlobeSummary = (item: ApiCountryGlobeSummary): UiCountryGlobeSummary => ({
+  countryCode: toNonEmpty(item.countryCode, ""),
+  countryName: toNonEmpty(item.countryName, "Unknown Country"),
+  lat: item.lat,
+  long: item.long,
+  hiddenSongs: item.hiddenGemCount,
+  topAlbum: toNonEmpty(item.topAlbumName, "Unknown Album"),
+});

--- a/hidden-gem-music-app/src/types/api.ts
+++ b/hidden-gem-music-app/src/types/api.ts
@@ -1,0 +1,66 @@
+export type ApiSong = {
+  songName: string | null;
+  artistName: string | null;
+  albumName: string | null;
+};
+
+export type ApiSharedSong = {
+  songName: string | null;
+  artistName: string | null;
+  rankA: number;
+  rankB: number;
+};
+
+export type ApiCountryProfile = {
+  countryCode: string | null;
+  countryName: string | null;
+  year: number;
+  totalCharted: number;
+  sharedCount: number;
+  uniqueCount: number;
+  overlapPct: number;
+  topSharedSongs: ApiSong[];
+  topUniqueSongs: ApiSong[];
+};
+
+export type ApiCountryComparisonSide = {
+  countryCode: string | null;
+  countryName: string | null;
+  totalCharted: number;
+  sharedCount: number;
+  uniqueCount: number;
+  overlapPct: number;
+};
+
+export type ApiComparisonResult = {
+  countryA: ApiCountryComparisonSide | null;
+  countryB: ApiCountryComparisonSide | null;
+  sharedSongs: ApiSharedSong[];
+  uniqueToA: ApiSong[];
+  uniqueToB: ApiSong[];
+};
+
+export type ApiHiddenGem = {
+  songName: string | null;
+  albumName: string | null;
+  artistName: string | null;
+  genre: string | null;
+  previewUrl: string | null;
+  trendScore: number;
+  countriesChartingCount: number;
+};
+
+export type ApiHiddenGemResponse = {
+  items: ApiHiddenGem[];
+  page: number;
+  pageSize: number;
+};
+
+export type ApiCountryGlobeSummary = {
+  countryCode: string | null;
+  countryName: string | null;
+  lat: number;
+  long: number;
+  hiddenGemCount: number;
+  topAlbumName: string | null;
+};


### PR DESCRIPTION
## Summary
Added two frontend data-integration files to support backend/API wiring while keeping UI naming clean and consistent.

## Changes
- Added `hidden-gem-music-app/src/types/api.ts`
  - Defines TypeScript DTO types that match backend response shapes and naming.
- Added `hidden-gem-music-app/src/data/apiMappers.ts`
  - Maps backend field names to frontend-friendly names used in UI code.

## Why
Backend JSON and frontend UI currently use different naming conventions (example: `songName` vs `title`, `overlapPct` vs `overlapPercent`).  
This PR introduces a dedicated mapping layer so we can plug in real API data without renaming UI fields across screens.

## Scope
This PR intentionally includes only:
- `api.ts`
- `apiMappers.ts`

No controller/backend/config changes are included in this PR.

## Validation
- TypeScript compile check passed (`npx tsc --noEmit`).
- Mapping coverage includes:
  - Country profile
  - Comparison result
  - Hidden gems (including paginated response shape)
  - Globe summary
  - Shared/basic song mapping
