### PR TITLE
Completed Issue 20: Country Profile Endpoint

### DIFF
--- a/Documents/mp3li implementation timeline document.txt
+++ b/Documents/mp3li implementation timeline document.txt
@@ -2,6 +2,58 @@ mp3li implementation timeline document
 
 Updated: April 29, 2026
 
+Comparison Endpoint Verification + Hardening + SP Contract Cross-Check (April 29, 2026)
+- Goal for this task:
+  - Validate the Country Comparison endpoint behavior, add robust error handling, cross-check backend mapper contracts against comparison SP outputs, confirm whether additional SPs are needed, and document implementation details for team handoff.
+- Endpoint status and initial validation context:
+  - Existing comparison route implementation is present and wired:
+    - `GET /api/comparison?countryA={code}&countryB={code}&year={year}`
+    - `GET /api/comparison/hidden-gems?countryA={code}&countryB={code}&year={year}`
+  - User-reported browser validation confirms the main comparison endpoint returns payload data for:
+    - `http://localhost:5140/api/comparison?countryA=US&countryB=GB&year=2021`
+- SP and mapper cross-check findings:
+  - Comparison repository calls:
+    - `sp_GetCountryComparison`
+    - `sp_GetComparisonHiddenGems`
+  - SQL script outputs currently include aliases such as:
+    - `iso_code`, `full_name`, `song_title`, `countries_charting`
+  - Existing repository mappers were still expecting older alias names in several properties:
+    - `country_code`, `country_name`, `song_name`, `countries_charting_count`
+  - Impact:
+    - Endpoint could still return `200 OK`, but selected DTO fields could be null/default when alias keys do not match.
+- Backend hardening added in this task:
+  - `ComparisonController` now validates:
+    - `countryA` is exactly 2 letters
+    - `countryB` is exactly 2 letters
+    - `countryA` and `countryB` are not the same code
+    - year must be between `1975..2021`
+    - year excludes unavailable gap years `2007..2010`
+  - `ComparisonController` now applies structured exception handling on both comparison endpoints:
+    - `503` for `SqlException` with logging
+    - `500` for unexpected exceptions with logging
+    - `400` for invalid input
+    - `404` retained for no comparison result row set on primary compare endpoint
+- Mapper compatibility fixes completed:
+  - Comparison repository mapping now supports both legacy and current SP aliases:
+    - country code: `country_code` or `iso_code`
+    - country name: `country_name` or `full_name`
+    - song name: `song_name` or `song_title`
+    - countries charting count: `countries_charting_count` or `countries_charting`
+  - This ensures DTO population remains stable while DB/SP aliases evolve.
+- Additional SP requirement outcome:
+  - No additional stored procedures were required for this task.
+  - Existing procedures already cover required comparison data paths once mapper alias compatibility is enforced.
+- Runtime verification completion (final pass):
+  - Initial 500 failures were traced to environment config, not endpoint logic:
+    - API was running in `Production`, while `DefaultConnection` existed only in `appsettings.Development.json`.
+    - Added `ConnectionStrings:DefaultConnection` to `appsettings.json` so default run path resolves the DB connection consistently.
+  - Final endpoint checks after restart:
+    - `GET /api/comparison?countryA=US&countryB=GB&year=2021` -> returns large populated JSON payload (`countryA`, `countryB`, `sharedSongs`, `uniqueToA`, `uniqueToB`).
+    - `GET /api/comparison/hidden-gems?countryA=US&countryB=GB&year=2021` -> `200` with populated `songName`, `artistName`, `trendScore`, and non-zero `countriesChartingCount`.
+    - `GET /api/comparison?countryA=U1&countryB=GB&year=2021` -> `400` with ISO-format validation message.
+    - `GET /api/comparison?countryA=US&countryB=US&year=2021` -> `400` with same-country validation message.
+    - `GET /api/comparison?countryA=US&countryB=GB&year=1900` -> `400` with supported-year-range validation message.
+
 Country + Preview Endpoint Verification, Failure Analysis, SQL Fix, and Repro Handoff (April 29, 2026)
 - Goal for this task:
   - Verify both Country endpoints against my restored local DB, harden backend behavior, and document exactly what failed and how it was fixed so Leena can apply the same DB-side correction before future backup zips.

--- a/Documents/mp3li implementation timeline document.txt
+++ b/Documents/mp3li implementation timeline document.txt
@@ -2,6 +2,60 @@ mp3li implementation timeline document
 
 Updated: April 29, 2026
 
+Country + Preview Endpoint Verification, Failure Analysis, SQL Fix, and Repro Handoff (April 29, 2026)
+- Goal for this task:
+  - Verify both Country endpoints against my restored local DB, harden backend behavior, and document exactly what failed and how it was fixed so Leena can apply the same DB-side correction before future backup zips.
+- Environment/setup context:
+  - SQL Server running via Docker on macOS.
+  - DB restored and queried through SSMS in Windows 11 via Parallels.
+  - API run locally with `dotnet run --project backend/Capstone.API` on `http://localhost:5140`.
+- Browser endpoint tests run (initial pass) and outputs:
+  - `GET /api/country/US?year=2021` returned populated JSON (`countryCode`, `countryName`, chart stats, song lists).
+  - `GET /api/country/ZZ?year=2021` returned `404 Not Found`.
+  - `GET /api/country/US?year=1900` returned `404 Not Found` (this was later flagged for stricter validation behavior because year selectors are dataset-bounded).
+  - `GET /api/country/US/hidden-gems/preview?year=2021` returned `500` message: `An unexpected error occurred while retrieving hidden gems preview data.`
+  - `GET /api/country/ZZ/hidden-gems/preview?year=2021` returned same `500` message.
+- Failure encountered:
+  - Hidden-gems preview endpoint failed (`500`) for both valid and invalid country code inputs.
+- SSMS diagnostic queries run and exact error:
+  - Ran:
+    - `EXEC sp_GetCountryHiddenGemsPreview @CountryCode='US', @Year=2021;`
+    - `EXEC sp_GetCountryHiddenGemsPreview @CountryCode='ZZ', @Year=2021;`
+  - SQL Server error:
+    - `Msg 208, Level 16, State 1, Procedure sp_GetCountryHiddenGemsPreview, Line 8`
+    - `Invalid object name 'Song'.`
+- Root cause:
+  - Restored DB had an outdated procedure version of `sp_GetCountryHiddenGemsPreview` still referencing legacy table `Song` instead of current star schema tables.
+- Exact remediation SQL executed in SSMS:
+  - Applied `CREATE OR ALTER PROCEDURE dbo.sp_GetCountryHiddenGemsPreview` using:
+    - `HiddenGems` + `Country` core join
+    - `DIM_Song`
+    - `Bridge_SongArtist` with `artist_order = 1`
+    - `DIM_Artist`
+    - `TOP 5 ... ORDER BY hg.trend_score DESC`
+- Validation after fix:
+  - SSMS proc re-test returned rows for `US, 2021` (no SQL errors).
+  - Browser re-test:
+    - `GET /api/country/US/hidden-gems/preview?year=2021` returned expected JSON list of 5 hidden gems.
+    - `GET /api/country/ZZ/hidden-gems/preview?year=2021` returned empty behavior (no server error).
+- Backend hardening completed after verification:
+  - `CountryController` now validates:
+    - country code must be exactly 2 letters
+    - year must be in supported dataset window (`1975..2021`) and excludes unavailable gap years (`2007..2010`)
+  - Country endpoint response behavior now explicitly differentiates:
+    - `400` invalid code/year input
+    - `404` no profile row for valid profile lookup
+    - `503` SQL/database failures
+    - `500` unexpected failures
+- SP contract and mapper cross-check outcome:
+  - Confirmed Country repository bindings to:
+    - `sp_GetCountryProfile`
+    - `sp_GetCountryHiddenGemsPreview`
+  - Confirmed no additional SP was required for this task once preview proc was corrected in DB.
+- Repro/handoff note for Leena:
+  - Apply the same `CREATE OR ALTER PROCEDURE dbo.sp_GetCountryHiddenGemsPreview` star-schema version in source DB before producing future backup zips.
+  - Without this, restored environments can reproduce the same `Invalid object name 'Song'` failure on preview endpoint.
+
 Backend Database Connection + Endpoint Validation + Mapper Alignment (April 29, 2026)
 - Local SQL Server database restore was validated through SSMS in Windows 11 on Parallels, and API local hosting was confirmed in macOS Docker setup context.
 - API startup was confirmed working on local dev host:

--- a/Documents/mp3li implementation timeline document.txt
+++ b/Documents/mp3li implementation timeline document.txt
@@ -1,6 +1,30 @@
-mp3li's Feature Implementation Timeline for Hidden Gem Music
+mp3li implementation timeline document
 
-Updated: April 26, 2026
+Updated: April 29, 2026
+
+Backend Database Connection + Endpoint Validation + Mapper Alignment (April 29, 2026)
+- Local SQL Server database restore was validated through SSMS in Windows 11 on Parallels, and API local hosting was confirmed in macOS Docker setup context.
+- API startup was confirmed working on local dev host:
+  - `dotnet run --project backend/Capstone.API`
+  - `Now listening on: http://localhost:5140`
+- Branch sync work was completed so current feature branch included latest `origin/main` updates:
+  - Local main was updated from origin
+  - `testing-endpoints` was merged forward with latest main
+  - Local uncommitted backend changes were preserved through stash/restore flow
+- Connection string in backend development settings was updated to active working SQL host credentials:
+  - `Server=192.168.111.9,1433;Database=HiddenGemMusic;User Id=sa;Password=Capstone123!;TrustServerCertificate=True;`
+- Endpoint validation exposed a schema-alias mismatch between stored procedure outputs and backend mapping keys:
+  - Stored procedures currently return fields such as `iso_code`, `full_name`, and `song_title`
+  - Existing mapper expected `country_code`, `country_name`, and `song_name`
+- Country repository mapping was updated to support both naming patterns for compatibility with current stored procedure outputs:
+  - Country fields now resolve across old/new alias variants
+  - Song name fields now resolve across `song_name` and `song_title`
+  - Hidden gems country count mapping now supports both `countries_charting_count` and `countries_charting`
+- Build verification succeeded after mapper updates:
+  - `dotnet build backend/Capstone.API` completed with 0 errors
+- Endpoint re-test confirmed successful populated response for country profile:
+  - `http://localhost:5140/api/country/US?year=2021`
+  - `countryCode`, `countryName`, and `songName` now return populated values instead of null
 
 All Web Screens Completed with Placeholder Data (April 26, 2026)
 - All planned web UI screens are now completed in a styled and functional placeholder-data state:

--- a/backend/Capstone.API/Controllers/ComparisonController.cs
+++ b/backend/Capstone.API/Controllers/ComparisonController.cs
@@ -1,5 +1,7 @@
 using Capstone.API.Infrastructure.Interfaces;
+using Microsoft.Data.SqlClient;
 using Microsoft.AspNetCore.Mvc;
+using System.Text.RegularExpressions;
 
 namespace Capstone.API.Controllers
 {
@@ -10,14 +12,22 @@ namespace Capstone.API.Controllers
     [Route("api/comparison")]
     public class ComparisonController : ControllerBase
     {
+        private static readonly Regex CountryCodeRegex = new("^[A-Za-z]{2}$", RegexOptions.Compiled);
+        private const int MinSupportedYear = 1975;
+        private const int MaxSupportedYear = 2021;
+        private const int UnavailableGapStartYear = 2007;
+        private const int UnavailableGapEndYear = 2010;
+
         private readonly IComparisonRepository _repo;
+        private readonly ILogger<ComparisonController> _logger;
 
         /// <summary>
         /// Initializes a new instance of ComparisonController.
         /// </summary>
-        public ComparisonController(IComparisonRepository repo)
+        public ComparisonController(IComparisonRepository repo, ILogger<ComparisonController> logger)
         {
             _repo = repo;
+            _logger = logger;
         }
 
         /// <summary>
@@ -33,11 +43,41 @@ namespace Capstone.API.Controllers
             [FromQuery] string countryB,
             [FromQuery] int year = 2021)
         {
-            var result = await _repo.GetCountryComparisonAsync(countryA.ToUpper(), countryB.ToUpper(), year);
-            if (result == null)
-                return NotFound();
+            if (!TryValidateInputs(countryA, countryB, year, out var validationError))
+                return BadRequest(new { message = validationError });
 
-            return Ok(result);
+            try
+            {
+                var result = await _repo.GetCountryComparisonAsync(
+                    countryA.ToUpperInvariant(),
+                    countryB.ToUpperInvariant(),
+                    year);
+
+                if (result == null)
+                    return NotFound();
+
+                return Ok(result);
+            }
+            catch (SqlException ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "SQL error getting country comparison for {CountryA} vs {CountryB} year {Year}",
+                    countryA,
+                    countryB,
+                    year);
+                return StatusCode(503, new { message = "Database temporarily unavailable while retrieving country comparison data." });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "Error getting country comparison for {CountryA} vs {CountryB} year {Year}",
+                    countryA,
+                    countryB,
+                    year);
+                return StatusCode(500, new { message = "An unexpected error occurred while retrieving country comparison data." });
+            }
         }
 
         /// <summary>
@@ -53,8 +93,73 @@ namespace Capstone.API.Controllers
             [FromQuery] string countryB,
             [FromQuery] int year = 2021)
         {
-            var result = await _repo.GetComparisonHiddenGemsAsync(countryA.ToUpper(), countryB.ToUpper(), year);
-            return Ok(result);
+            if (!TryValidateInputs(countryA, countryB, year, out var validationError))
+                return BadRequest(new { message = validationError });
+
+            try
+            {
+                var result = await _repo.GetComparisonHiddenGemsAsync(
+                    countryA.ToUpperInvariant(),
+                    countryB.ToUpperInvariant(),
+                    year);
+                return Ok(result);
+            }
+            catch (SqlException ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "SQL error getting comparison hidden gems for {CountryA} vs {CountryB} year {Year}",
+                    countryA,
+                    countryB,
+                    year);
+                return StatusCode(503, new { message = "Database temporarily unavailable while retrieving comparison hidden gems data." });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "Error getting comparison hidden gems for {CountryA} vs {CountryB} year {Year}",
+                    countryA,
+                    countryB,
+                    year);
+                return StatusCode(500, new { message = "An unexpected error occurred while retrieving comparison hidden gems data." });
+            }
+        }
+
+        private static bool TryValidateInputs(string countryA, string countryB, int year, out string validationError)
+        {
+            if (string.IsNullOrWhiteSpace(countryA) || !CountryCodeRegex.IsMatch(countryA))
+            {
+                validationError = "countryA must be exactly 2 letters (ISO format, e.g. 'US').";
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(countryB) || !CountryCodeRegex.IsMatch(countryB))
+            {
+                validationError = "countryB must be exactly 2 letters (ISO format, e.g. 'GB').";
+                return false;
+            }
+
+            if (countryA.Equals(countryB, StringComparison.OrdinalIgnoreCase))
+            {
+                validationError = "countryA and countryB must be different countries.";
+                return false;
+            }
+
+            if (year < MinSupportedYear || year > MaxSupportedYear)
+            {
+                validationError = $"Year must be between {MinSupportedYear} and {MaxSupportedYear}.";
+                return false;
+            }
+
+            if (year >= UnavailableGapStartYear && year <= UnavailableGapEndYear)
+            {
+                validationError = $"Year {year} is unavailable in this dataset window.";
+                return false;
+            }
+
+            validationError = string.Empty;
+            return true;
         }
     }
 }

--- a/backend/Capstone.API/Controllers/CountryController.cs
+++ b/backend/Capstone.API/Controllers/CountryController.cs
@@ -1,5 +1,7 @@
 using Capstone.API.Infrastructure.Interfaces;
+using Microsoft.Data.SqlClient;
 using Microsoft.AspNetCore.Mvc;
+using System.Text.RegularExpressions;
 
 namespace Capstone.API.Controllers
 {
@@ -8,19 +10,27 @@ namespace Capstone.API.Controllers
     /// </summary>
     [ApiController]
     [Route("api/country")]
-public class CountryController : ControllerBase
-{
-    private readonly ICountryRepository _repo;
-    private readonly ILogger<CountryController> _logger;
+    public class CountryController : ControllerBase
+    {
+        private static readonly Regex CountryCodeRegex = new("^[A-Za-z]{2}$", RegexOptions.Compiled);
+
+        // Keep backend year validation aligned with frontend selectable years.
+        private const int MinSupportedYear = 1975;
+        private const int MaxSupportedYear = 2021;
+        private const int UnavailableGapStartYear = 2007;
+        private const int UnavailableGapEndYear = 2010;
+
+        private readonly ICountryRepository _repo;
+        private readonly ILogger<CountryController> _logger;
 
         /// <summary>
         /// Initializes a new instance of CountryController.
         /// </summary>
-    public CountryController(ICountryRepository repo, ILogger<CountryController> logger)
-    {
-        _repo = repo;
-        _logger = logger;
-    }
+        public CountryController(ICountryRepository repo, ILogger<CountryController> logger)
+        {
+            _repo = repo;
+            _logger = logger;
+        }
 
         /// <summary>
         /// Returns full chart statistics and top song lists for a single country and year.
@@ -28,23 +38,32 @@ public class CountryController : ControllerBase
         /// </summary>
         /// <param name="code">2-letter ISO country code (e.g. "US", "JP").</param>
         /// <param name="year">The chart year to display. Defaults to 2021.</param>
-    [HttpGet("{code}")]
-    public async Task<IActionResult> GetCountryProfile(string code, [FromQuery] int year = 2021)
-    {
-        try
+        [HttpGet("{code}")]
+        public async Task<IActionResult> GetCountryProfile(string code, [FromQuery] int year = 2021)
         {
-            var result = await _repo.GetCountryProfileAsync(code.ToUpper(), year);
-            if (result == null)
-                return NotFound();
+            if (!TryValidateInputs(code, year, out var validationError))
+                return BadRequest(new { message = validationError });
 
-            return Ok(result);
+            try
+            {
+                var normalizedCode = code.ToUpperInvariant();
+                var result = await _repo.GetCountryProfileAsync(normalizedCode, year);
+                if (result == null)
+                    return NotFound();
+
+                return Ok(result);
+            }
+            catch (SqlException ex)
+            {
+                _logger.LogError(ex, "SQL error getting country profile for {CountryCode} year {Year}", code, year);
+                return StatusCode(503, new { message = "Database temporarily unavailable while retrieving country profile data." });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error getting country profile for {CountryCode} year {Year}", code, year);
+                return StatusCode(500, new { message = "An unexpected error occurred while retrieving country profile data." });
+            }
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error getting country profile for {CountryCode} year {Year}", code, year);
-            return StatusCode(500, new { message = "An unexpected error occurred while retrieving country profile data." });
-        }
-    }
 
         /// <summary>
         /// Returns the top 5 hidden gems for the teaser widget on the country profile page.
@@ -52,19 +71,52 @@ public class CountryController : ControllerBase
         /// </summary>
         /// <param name="code">2-letter ISO country code.</param>
         /// <param name="year">The chart year to display. Defaults to 2021.</param>
-    [HttpGet("{code}/hidden-gems/preview")]
-    public async Task<IActionResult> GetHiddenGemsPreview(string code, [FromQuery] int year = 2021)
-    {
-        try
+        [HttpGet("{code}/hidden-gems/preview")]
+        public async Task<IActionResult> GetHiddenGemsPreview(string code, [FromQuery] int year = 2021)
         {
-            var result = await _repo.GetHiddenGemsPreviewAsync(code.ToUpper(), year);
-            return Ok(result);
+            if (!TryValidateInputs(code, year, out var validationError))
+                return BadRequest(new { message = validationError });
+
+            try
+            {
+                var normalizedCode = code.ToUpperInvariant();
+                var result = await _repo.GetHiddenGemsPreviewAsync(normalizedCode, year);
+                return Ok(result);
+            }
+            catch (SqlException ex)
+            {
+                _logger.LogError(ex, "SQL error getting hidden gems preview for {CountryCode} year {Year}", code, year);
+                return StatusCode(503, new { message = "Database temporarily unavailable while retrieving hidden gems preview data." });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error getting hidden gems preview for {CountryCode} year {Year}", code, year);
+                return StatusCode(500, new { message = "An unexpected error occurred while retrieving hidden gems preview data." });
+            }
         }
-        catch (Exception ex)
+
+        private static bool TryValidateInputs(string code, int year, out string validationError)
         {
-            _logger.LogError(ex, "Error getting hidden gems preview for {CountryCode} year {Year}", code, year);
-            return StatusCode(500, new { message = "An unexpected error occurred while retrieving hidden gems preview data." });
+            if (string.IsNullOrWhiteSpace(code) || !CountryCodeRegex.IsMatch(code))
+            {
+                validationError = "Country code must be exactly 2 letters (ISO format, e.g. 'US').";
+                return false;
+            }
+
+            if (year < MinSupportedYear || year > MaxSupportedYear)
+            {
+                validationError = $"Year must be between {MinSupportedYear} and {MaxSupportedYear}.";
+                return false;
+            }
+
+            if (year >= UnavailableGapStartYear && year <= UnavailableGapEndYear)
+            {
+                validationError = $"Year {year} is unavailable in this dataset window.";
+                return false;
+            }
+
+            validationError = string.Empty;
+            return true;
         }
     }
-}
 }

--- a/backend/Capstone.API/Controllers/CountryController.cs
+++ b/backend/Capstone.API/Controllers/CountryController.cs
@@ -8,17 +8,19 @@ namespace Capstone.API.Controllers
     /// </summary>
     [ApiController]
     [Route("api/country")]
-    public class CountryController : ControllerBase
-    {
-        private readonly ICountryRepository _repo;
+public class CountryController : ControllerBase
+{
+    private readonly ICountryRepository _repo;
+    private readonly ILogger<CountryController> _logger;
 
         /// <summary>
         /// Initializes a new instance of CountryController.
         /// </summary>
-        public CountryController(ICountryRepository repo)
-        {
-            _repo = repo;
-        }
+    public CountryController(ICountryRepository repo, ILogger<CountryController> logger)
+    {
+        _repo = repo;
+        _logger = logger;
+    }
 
         /// <summary>
         /// Returns full chart statistics and top song lists for a single country and year.
@@ -26,8 +28,10 @@ namespace Capstone.API.Controllers
         /// </summary>
         /// <param name="code">2-letter ISO country code (e.g. "US", "JP").</param>
         /// <param name="year">The chart year to display. Defaults to 2021.</param>
-        [HttpGet("{code}")]
-        public async Task<IActionResult> GetCountryProfile(string code, [FromQuery] int year = 2021)
+    [HttpGet("{code}")]
+    public async Task<IActionResult> GetCountryProfile(string code, [FromQuery] int year = 2021)
+    {
+        try
         {
             var result = await _repo.GetCountryProfileAsync(code.ToUpper(), year);
             if (result == null)
@@ -35,6 +39,12 @@ namespace Capstone.API.Controllers
 
             return Ok(result);
         }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error getting country profile for {CountryCode} year {Year}", code, year);
+            return StatusCode(500, new { message = "An unexpected error occurred while retrieving country profile data." });
+        }
+    }
 
         /// <summary>
         /// Returns the top 5 hidden gems for the teaser widget on the country profile page.
@@ -42,11 +52,19 @@ namespace Capstone.API.Controllers
         /// </summary>
         /// <param name="code">2-letter ISO country code.</param>
         /// <param name="year">The chart year to display. Defaults to 2021.</param>
-        [HttpGet("{code}/hidden-gems/preview")]
-        public async Task<IActionResult> GetHiddenGemsPreview(string code, [FromQuery] int year = 2021)
+    [HttpGet("{code}/hidden-gems/preview")]
+    public async Task<IActionResult> GetHiddenGemsPreview(string code, [FromQuery] int year = 2021)
+    {
+        try
         {
             var result = await _repo.GetHiddenGemsPreviewAsync(code.ToUpper(), year);
             return Ok(result);
         }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error getting hidden gems preview for {CountryCode} year {Year}", code, year);
+            return StatusCode(500, new { message = "An unexpected error occurred while retrieving hidden gems preview data." });
+        }
     }
+}
 }

--- a/backend/Capstone.API/Documentation/ADR-BACKEND-002-Routes-Controllers-DTOs.md
+++ b/backend/Capstone.API/Documentation/ADR-BACKEND-002-Routes-Controllers-DTOs.md
@@ -7,6 +7,20 @@
 
 ---
 
+## April 29, 2026 Verification Addendum (Country Endpoints)
+
+- `CountryController` input validation now enforces:
+  - `code` must be exactly 2 letters (`400` on failure)
+  - `year` must be in dataset-supported range `1975..2021`, excluding known unavailable gap years `2007..2010` (`400` on failure)
+- Error handling for Country endpoints now distinguishes:
+  - `400` invalid input
+  - `404` valid input but no profile row for `/api/country/{code}`
+  - `503` SQL/database failures
+  - `500` unexpected failures
+- `sp_GetCountryHiddenGemsPreview` was cross-checked against a restored local DB that initially had an outdated procedure version referencing legacy table `Song`.
+  - Required/current version uses star schema joins: `DIM_Song`, `Bridge_SongArtist`, `DIM_Artist`.
+  - After applying `CREATE OR ALTER PROCEDURE` with star schema joins, preview endpoint returned valid JSON.
+
 ## Context
 
 This ADR documents the concrete implementation of the API surface: every route, controller action, repository method, stored procedure call, and DTO field mapping. It was written after the code compiled and built successfully, and reflects the actual state of the files — not the planning document.
@@ -83,7 +97,9 @@ All country codes are normalized to uppercase (`.ToUpper()`) at the controller b
 
 **Route params:** `code` (2-letter ISO, normalized to uppercase)
 **Query params:** `year` (int)
+**Input validation:** `code` must be 2 letters; `year` must be `1975..2021` excluding `2007..2010` (`400` on validation failure).
 **Returns 404** if `GetCountryProfileAsync` returns null (country/year combination not found).
+**Returns 503** for SQL/database failures; **500** for unexpected failures.
 
 ---
 
@@ -161,21 +177,21 @@ For each SP: the name as hard-coded in the repository, the parameter names as pa
 | 1 | Top shared songs | `CountryProfile.TopSharedSongs` |
 | 2 | Top unique songs | `CountryProfile.TopUniqueSongs` |
 
-**Set 0 expected columns:**
+**Set 0 expected columns (verified aliases):**
 | Column | C# property | Type |
 |--------|------------|------|
-| `country_code` | `CountryProfile.CountryCode` | string? |
-| `country_name` | `CountryProfile.CountryName` | string? |
+| `country_code` or `iso_code` | `CountryProfile.CountryCode` | string? |
+| `country_name` or `full_name` | `CountryProfile.CountryName` | string? |
 | `chart_year` | `CountryProfile.Year` | int |
 | `total_charted` | `CountryProfile.TotalCharted` | int |
 | `shared_count` | `CountryProfile.SharedCount` | int |
 | `unique_count` | `CountryProfile.UniqueCount` | int |
 | `overlap_pct` | `CountryProfile.OverlapPct` | decimal |
 
-**Sets 1 and 2 expected columns (Song):**
+**Sets 1 and 2 expected columns (Song, verified aliases):**
 | Column | C# property | Type |
 |--------|------------|------|
-| `song_name` | `Song.SongName` | string? |
+| `song_name` or `song_title` | `Song.SongName` | string? |
 | `artist_name` | `Song.ArtistName` | string? |
 | `album_name` | `Song.AlbumName` | string? |
 
@@ -184,7 +200,15 @@ For each SP: the name as hard-coded in the repository, the parameter names as pa
 ### 3.3 `sp_GetCountryHiddenGemsPreview`
 **Repository:** `CountryRepository.GetHiddenGemsPreviewAsync`
 **Params:** `@CountryCode CHAR(2)`, `@Year INT`
-**Expected output columns:** Same as Section 3.5 (HiddenGem shape).
+**Expected output columns (verified aliases):**
+- `song_name` or `song_title` → `HiddenGem.SongName`
+- `album_name` → `HiddenGem.AlbumName`
+- `artist_name` → `HiddenGem.ArtistName`
+- `trend_score` → `HiddenGem.TrendScore`
+- `countries_charting_count` or `countries_charting` → `HiddenGem.CountriesChartingCount`
+
+**Required stored procedure version note:**
+- Procedure must reference star-schema tables (`DIM_Song`, `Bridge_SongArtist`, `DIM_Artist`), not legacy `Song`.
 
 ---
 

--- a/backend/Capstone.API/Infrastructure/Repositories/ComparisonRepository.cs
+++ b/backend/Capstone.API/Infrastructure/Repositories/ComparisonRepository.cs
@@ -71,8 +71,8 @@ namespace Capstone.API.Infrastructure.Repositories
         {
             return new CountryComparisonSide
             {
-                CountryCode = AsString(row, "country_code"),
-                CountryName = AsString(row, "country_name"),
+                CountryCode = AsString(row, "country_code", "iso_code"),
+                CountryName = AsString(row, "country_name", "full_name"),
                 TotalCharted = AsInt(row, "total_charted"),
                 SharedCount = AsInt(row, "shared_count"),
                 UniqueCount = AsInt(row, "unique_count"),
@@ -84,7 +84,7 @@ namespace Capstone.API.Infrastructure.Repositories
         {
             return new SharedSong
             {
-                SongName = AsString(row, "song_name"),
+                SongName = AsString(row, "song_name", "song_title", "title"),
                 ArtistName = AsString(row, "artist_name"),
                 AlbumName = AsString(row, "album_name"),
                 RankInCountryA = AsInt(row, "rank_in_country_a"),
@@ -96,7 +96,7 @@ namespace Capstone.API.Infrastructure.Repositories
         {
             return new Song
             {
-                SongName = AsString(row, "song_name"),
+                SongName = AsString(row, "song_name", "song_title", "title"),
                 ArtistName = AsString(row, "artist_name"),
                 AlbumName = AsString(row, "album_name")
             };
@@ -106,21 +106,45 @@ namespace Capstone.API.Infrastructure.Repositories
         {
             return new ComparisonHiddenGem
             {
-                SongName = AsString(row, "song_name"),
+                SongName = AsString(row, "song_name", "song_title", "title"),
                 AlbumName = AsString(row, "album_name"),
                 ArtistName = AsString(row, "artist_name"),
                 TrendScore = AsDecimal(row, "trend_score"),
-                CountriesChartingCount = AsInt(row, "countries_charting_count")
+                CountriesChartingCount = AsInt(row, "countries_charting_count", "countries_charting", "country_count")
             };
         }
 
-        private static string? AsString(IDictionary<string, object?> row, string key)
-            => row.TryGetValue(key, out var v) ? v?.ToString() : null;
+        private static string? AsString(IDictionary<string, object?> row, params string[] keys)
+        {
+            foreach (var key in keys)
+            {
+                if (row.TryGetValue(key, out var value) && value != null)
+                    return value.ToString();
+            }
 
-        private static int AsInt(IDictionary<string, object?> row, string key)
-            => row.TryGetValue(key, out var v) && v != null ? Convert.ToInt32(v) : 0;
+            return null;
+        }
 
-        private static decimal AsDecimal(IDictionary<string, object?> row, string key)
-            => row.TryGetValue(key, out var v) && v != null ? Convert.ToDecimal(v) : 0m;
+        private static int AsInt(IDictionary<string, object?> row, params string[] keys)
+        {
+            foreach (var key in keys)
+            {
+                if (row.TryGetValue(key, out var value) && value != null)
+                    return Convert.ToInt32(value);
+            }
+
+            return 0;
+        }
+
+        private static decimal AsDecimal(IDictionary<string, object?> row, params string[] keys)
+        {
+            foreach (var key in keys)
+            {
+                if (row.TryGetValue(key, out var value) && value != null)
+                    return Convert.ToDecimal(value);
+            }
+
+            return 0m;
+        }
     }
 }

--- a/backend/Capstone.API/Infrastructure/Repositories/CountryRepository.cs
+++ b/backend/Capstone.API/Infrastructure/Repositories/CountryRepository.cs
@@ -38,13 +38,13 @@ namespace Capstone.API.Infrastructure.Repositories
 
             var profile = new CountryProfile
             {
-                CountryCode = AsString(stats, "country_code"),
-                CountryName = AsString(stats, "country_name"),
-                Year = AsInt(stats, "chart_year"),
-                TotalCharted = AsInt(stats, "total_charted"),
-                SharedCount = AsInt(stats, "shared_count"),
-                UniqueCount = AsInt(stats, "unique_count"),
-                OverlapPct = AsDecimal(stats, "overlap_pct")
+                CountryCode = AsStringAny(stats, "country_code", "iso_code"),
+                CountryName = AsStringAny(stats, "country_name", "full_name"),
+                Year = AsIntAny(stats, "chart_year", "year"),
+                TotalCharted = AsIntAny(stats, "total_charted"),
+                SharedCount = AsIntAny(stats, "shared_count"),
+                UniqueCount = AsIntAny(stats, "unique_count"),
+                OverlapPct = AsDecimalAny(stats, "overlap_pct")
             };
 
             if (sets.Count > 1)
@@ -72,9 +72,9 @@ namespace Capstone.API.Infrastructure.Repositories
         {
             return new Song
             {
-                SongName = AsString(row, "song_name"),
-                ArtistName = AsString(row, "artist_name"),
-                AlbumName = AsString(row, "album_name")
+                SongName = AsStringAny(row, "song_name", "song_title", "title"),
+                ArtistName = AsStringAny(row, "artist_name"),
+                AlbumName = AsStringAny(row, "album_name")
             };
         }
 
@@ -82,23 +82,47 @@ namespace Capstone.API.Infrastructure.Repositories
         {
             return new HiddenGem
             {
-                SongName = AsString(row, "song_name"),
-                AlbumName = AsString(row, "album_name"),
-                ArtistName = AsString(row, "artist_name"),
-                Genre = AsString(row, "genre"),
-                PreviewUrl = AsString(row, "preview_url"),
-                TrendScore = AsDecimal(row, "trend_score"),
-                CountriesChartingCount = AsInt(row, "countries_charting_count")
+                SongName = AsStringAny(row, "song_name", "song_title", "title"),
+                AlbumName = AsStringAny(row, "album_name"),
+                ArtistName = AsStringAny(row, "artist_name"),
+                Genre = AsStringAny(row, "genre"),
+                PreviewUrl = AsStringAny(row, "preview_url"),
+                TrendScore = AsDecimalAny(row, "trend_score"),
+                CountriesChartingCount = AsIntAny(row, "countries_charting_count", "countries_charting")
             };
         }
 
-        private static string? AsString(IDictionary<string, object?> row, string key)
-            => row.TryGetValue(key, out var v) ? v?.ToString() : null;
+        private static string? AsStringAny(IDictionary<string, object?> row, params string[] keys)
+        {
+            foreach (var key in keys)
+            {
+                if (row.TryGetValue(key, out var v) && v != null)
+                    return v.ToString();
+            }
 
-        private static int AsInt(IDictionary<string, object?> row, string key)
-            => row.TryGetValue(key, out var v) && v != null ? Convert.ToInt32(v) : 0;
+            return null;
+        }
 
-        private static decimal AsDecimal(IDictionary<string, object?> row, string key)
-            => row.TryGetValue(key, out var v) && v != null ? Convert.ToDecimal(v) : 0m;
+        private static int AsIntAny(IDictionary<string, object?> row, params string[] keys)
+        {
+            foreach (var key in keys)
+            {
+                if (row.TryGetValue(key, out var v) && v != null)
+                    return Convert.ToInt32(v);
+            }
+
+            return 0;
+        }
+
+        private static decimal AsDecimalAny(IDictionary<string, object?> row, params string[] keys)
+        {
+            foreach (var key in keys)
+            {
+                if (row.TryGetValue(key, out var v) && v != null)
+                    return Convert.ToDecimal(v);
+            }
+
+            return 0m;
+        }
     }
 }

--- a/backend/Capstone.API/appsettings.Development.json
+++ b/backend/Capstone.API/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=192.168.111.9,1433;Database=HiddenGemMusic;User Id=sa;Password=Capstone123!;TrustServerCertificate=True;"
   }
 }

--- a/backend/Capstone.API/appsettings.json
+++ b/backend/Capstone.API/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=192.168.111.9,1433;Database=HiddenGemMusic;User Id=sa;Password=Capstone123!;TrustServerCertificate=True;"
+  },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
## Summary

This PR finishes Issue 20 for both Country endpoints:

- `GET /api/country/{code}`
- `GET /api/country/{code}/hidden-gems/preview`

I verified them against my restored local database, fixed the preview endpoint failure, hardened controller validation/error handling, and updated documentation.

### Work Performed

### 1) Tested both endpoints in browser
I ran these URLs:

- `GET /api/country/US?year=2021` -> worked (`200`) with full data
- `GET /api/country/ZZ?year=2021` -> `404`
- `GET /api/country/US?year=1900` -> originally `404` (later changed to `400` after validation hardening)
- `GET /api/country/US/hidden-gems/preview?year=2021` -> failed (`500`)
- `GET /api/country/ZZ/hidden-gems/preview?year=2021` -> failed (`500`)

### 2) Found what was broken
The preview endpoint failed because the stored procedure in my restored DB was an older version.

That older version still used a table named `Song`, but current schema uses star-schema tables (`DIM_Song`, etc.).

In SSMS, this query failed:

`EXEC sp_GetCountryHiddenGemsPreview @CountryCode='US', @Year=2021;`

Error:

- `Msg 208, Level 16, State 1`
- `Invalid object name 'Song'.`

### 3) Fixed the stored procedure in SSMS
I updated `dbo.sp_GetCountryHiddenGemsPreview` to use current star-schema joins:

- `DIM_Song`
- `Bridge_SongArtist` (`artist_order = 1`)
- `DIM_Artist`
- existing `HiddenGems` + `Country` joins
- `TOP 5` ordered by `hg.trend_score DESC`

Then I re-ran:

`EXEC dbo.sp_GetCountryHiddenGemsPreview @CountryCode='US', @Year=2021;`

and it returned valid rows.

### 4) Hardened backend controller behavior
Updated `CountryController` for both endpoints:

- Added input validation:
  - country code must be exactly 2 letters
  - year must be within supported dataset years (`1975..2021`)
  - unavailable gap years (`2007..2010`) are rejected
- Response behavior now:
  - `400` for invalid input
  - `404` for valid Country Profile input with no row
  - `503` for SQL/database failures (`SqlException`)
  - `500` for unexpected failures

### 5) Cross-checked SP contract and mapping
I cross-checked Country repository usage against:

- `sp_GetCountryProfile`
- `sp_GetCountryHiddenGemsPreview`

I also documented alias compatibility used by mapping (for example `country_code`/`iso_code`, `song_name`/`song_title`).

No new stored procedure was needed after fixing preview proc version.

## Verification After Fix

### SSMS
`sp_GetCountryHiddenGemsPreview` now returns rows for `US, 2021`.

### Browser/API
- `GET /api/country/US?year=2021` -> `200` with populated JSON
- `GET /api/country/ZZ?year=2021` -> `404`
- `GET /api/country/US?year=1900` -> now `400`
- `GET /api/country/US/hidden-gems/preview?year=2021` -> `200` with list
- `GET /api/country/ZZ/hidden-gems/preview?year=2021` -> returns empty list (expected behavior, no server error)

### Build
- `dotnet build backend/Capstone.API` -> success, 0 errors

## Files Changed

- `backend/Capstone.API/Controllers/CountryController.cs`
- `backend/Capstone.API/Documentation/ADR-BACKEND-002-Routes-Controllers-DTOs.md`
- `Documents/mp3li implementation timeline document.txt`

### Note for Leena

Please apply this same updated version of:

- `dbo.sp_GetCountryHiddenGemsPreview`

for the next zipped database for the team. 

Why: if source DB still has the older proc version (the one using `Song`), restored environments can hit the same preview endpoint `500` error again.