### PR TITLE
Discovery Globe Web Screen Data Implementation Nearly Complete

### DIFF
--- a/Documents/mp3li implementation timeline document.txt
+++ b/Documents/mp3li implementation timeline document.txt
@@ -2,6 +2,58 @@ mp3li implementation timeline document
 
 Updated: April 29, 2026
 
+Comparison Endpoint Verification + Hardening + SP Contract Cross-Check (April 29, 2026)
+- Goal for this task:
+  - Validate the Country Comparison endpoint behavior, add robust error handling, cross-check backend mapper contracts against comparison SP outputs, confirm whether additional SPs are needed, and document implementation details for team handoff.
+- Endpoint status and initial validation context:
+  - Existing comparison route implementation is present and wired:
+    - `GET /api/comparison?countryA={code}&countryB={code}&year={year}`
+    - `GET /api/comparison/hidden-gems?countryA={code}&countryB={code}&year={year}`
+  - User-reported browser validation confirms the main comparison endpoint returns payload data for:
+    - `http://localhost:5140/api/comparison?countryA=US&countryB=GB&year=2021`
+- SP and mapper cross-check findings:
+  - Comparison repository calls:
+    - `sp_GetCountryComparison`
+    - `sp_GetComparisonHiddenGems`
+  - SQL script outputs currently include aliases such as:
+    - `iso_code`, `full_name`, `song_title`, `countries_charting`
+  - Existing repository mappers were still expecting older alias names in several properties:
+    - `country_code`, `country_name`, `song_name`, `countries_charting_count`
+  - Impact:
+    - Endpoint could still return `200 OK`, but selected DTO fields could be null/default when alias keys do not match.
+- Backend hardening added in this task:
+  - `ComparisonController` now validates:
+    - `countryA` is exactly 2 letters
+    - `countryB` is exactly 2 letters
+    - `countryA` and `countryB` are not the same code
+    - year must be between `1975..2021`
+    - year excludes unavailable gap years `2007..2010`
+  - `ComparisonController` now applies structured exception handling on both comparison endpoints:
+    - `503` for `SqlException` with logging
+    - `500` for unexpected exceptions with logging
+    - `400` for invalid input
+    - `404` retained for no comparison result row set on primary compare endpoint
+- Mapper compatibility fixes completed:
+  - Comparison repository mapping now supports both legacy and current SP aliases:
+    - country code: `country_code` or `iso_code`
+    - country name: `country_name` or `full_name`
+    - song name: `song_name` or `song_title`
+    - countries charting count: `countries_charting_count` or `countries_charting`
+  - This ensures DTO population remains stable while DB/SP aliases evolve.
+- Additional SP requirement outcome:
+  - No additional stored procedures were required for this task.
+  - Existing procedures already cover required comparison data paths once mapper alias compatibility is enforced.
+- Runtime verification completion (final pass):
+  - Initial 500 failures were traced to environment config, not endpoint logic:
+    - API was running in `Production`, while `DefaultConnection` existed only in `appsettings.Development.json`.
+    - Added `ConnectionStrings:DefaultConnection` to `appsettings.json` so default run path resolves the DB connection consistently.
+  - Final endpoint checks after restart:
+    - `GET /api/comparison?countryA=US&countryB=GB&year=2021` -> returns large populated JSON payload (`countryA`, `countryB`, `sharedSongs`, `uniqueToA`, `uniqueToB`).
+    - `GET /api/comparison/hidden-gems?countryA=US&countryB=GB&year=2021` -> `200` with populated `songName`, `artistName`, `trendScore`, and non-zero `countriesChartingCount`.
+    - `GET /api/comparison?countryA=U1&countryB=GB&year=2021` -> `400` with ISO-format validation message.
+    - `GET /api/comparison?countryA=US&countryB=US&year=2021` -> `400` with same-country validation message.
+    - `GET /api/comparison?countryA=US&countryB=GB&year=1900` -> `400` with supported-year-range validation message.
+
 Country + Preview Endpoint Verification, Failure Analysis, SQL Fix, and Repro Handoff (April 29, 2026)
 - Goal for this task:
   - Verify both Country endpoints against my restored local DB, harden backend behavior, and document exactly what failed and how it was fixed so Leena can apply the same DB-side correction before future backup zips.

--- a/Documents/mp3li implementation timeline document.txt
+++ b/Documents/mp3li implementation timeline document.txt
@@ -2,6 +2,60 @@ mp3li implementation timeline document
 
 Updated: April 29, 2026
 
+Country + Preview Endpoint Verification, Failure Analysis, SQL Fix, and Repro Handoff (April 29, 2026)
+- Goal for this task:
+  - Verify both Country endpoints against my restored local DB, harden backend behavior, and document exactly what failed and how it was fixed so Leena can apply the same DB-side correction before future backup zips.
+- Environment/setup context:
+  - SQL Server running via Docker on macOS.
+  - DB restored and queried through SSMS in Windows 11 via Parallels.
+  - API run locally with `dotnet run --project backend/Capstone.API` on `http://localhost:5140`.
+- Browser endpoint tests run (initial pass) and outputs:
+  - `GET /api/country/US?year=2021` returned populated JSON (`countryCode`, `countryName`, chart stats, song lists).
+  - `GET /api/country/ZZ?year=2021` returned `404 Not Found`.
+  - `GET /api/country/US?year=1900` returned `404 Not Found` (this was later flagged for stricter validation behavior because year selectors are dataset-bounded).
+  - `GET /api/country/US/hidden-gems/preview?year=2021` returned `500` message: `An unexpected error occurred while retrieving hidden gems preview data.`
+  - `GET /api/country/ZZ/hidden-gems/preview?year=2021` returned same `500` message.
+- Failure encountered:
+  - Hidden-gems preview endpoint failed (`500`) for both valid and invalid country code inputs.
+- SSMS diagnostic queries run and exact error:
+  - Ran:
+    - `EXEC sp_GetCountryHiddenGemsPreview @CountryCode='US', @Year=2021;`
+    - `EXEC sp_GetCountryHiddenGemsPreview @CountryCode='ZZ', @Year=2021;`
+  - SQL Server error:
+    - `Msg 208, Level 16, State 1, Procedure sp_GetCountryHiddenGemsPreview, Line 8`
+    - `Invalid object name 'Song'.`
+- Root cause:
+  - Restored DB had an outdated procedure version of `sp_GetCountryHiddenGemsPreview` still referencing legacy table `Song` instead of current star schema tables.
+- Exact remediation SQL executed in SSMS:
+  - Applied `CREATE OR ALTER PROCEDURE dbo.sp_GetCountryHiddenGemsPreview` using:
+    - `HiddenGems` + `Country` core join
+    - `DIM_Song`
+    - `Bridge_SongArtist` with `artist_order = 1`
+    - `DIM_Artist`
+    - `TOP 5 ... ORDER BY hg.trend_score DESC`
+- Validation after fix:
+  - SSMS proc re-test returned rows for `US, 2021` (no SQL errors).
+  - Browser re-test:
+    - `GET /api/country/US/hidden-gems/preview?year=2021` returned expected JSON list of 5 hidden gems.
+    - `GET /api/country/ZZ/hidden-gems/preview?year=2021` returned empty behavior (no server error).
+- Backend hardening completed after verification:
+  - `CountryController` now validates:
+    - country code must be exactly 2 letters
+    - year must be in supported dataset window (`1975..2021`) and excludes unavailable gap years (`2007..2010`)
+  - Country endpoint response behavior now explicitly differentiates:
+    - `400` invalid code/year input
+    - `404` no profile row for valid profile lookup
+    - `503` SQL/database failures
+    - `500` unexpected failures
+- SP contract and mapper cross-check outcome:
+  - Confirmed Country repository bindings to:
+    - `sp_GetCountryProfile`
+    - `sp_GetCountryHiddenGemsPreview`
+  - Confirmed no additional SP was required for this task once preview proc was corrected in DB.
+- Repro/handoff note for Leena:
+  - Apply the same `CREATE OR ALTER PROCEDURE dbo.sp_GetCountryHiddenGemsPreview` star-schema version in source DB before producing future backup zips.
+  - Without this, restored environments can reproduce the same `Invalid object name 'Song'` failure on preview endpoint.
+
 Backend Database Connection + Endpoint Validation + Mapper Alignment (April 29, 2026)
 - Local SQL Server database restore was validated through SSMS in Windows 11 on Parallels, and API local hosting was confirmed in macOS Docker setup context.
 - API startup was confirmed working on local dev host:

--- a/Documents/mp3li implementation timeline document.txt
+++ b/Documents/mp3li implementation timeline document.txt
@@ -1,6 +1,30 @@
-mp3li's Feature Implementation Timeline for Hidden Gem Music
+mp3li implementation timeline document
 
-Updated: April 26, 2026
+Updated: April 29, 2026
+
+Backend Database Connection + Endpoint Validation + Mapper Alignment (April 29, 2026)
+- Local SQL Server database restore was validated through SSMS in Windows 11 on Parallels, and API local hosting was confirmed in macOS Docker setup context.
+- API startup was confirmed working on local dev host:
+  - `dotnet run --project backend/Capstone.API`
+  - `Now listening on: http://localhost:5140`
+- Branch sync work was completed so current feature branch included latest `origin/main` updates:
+  - Local main was updated from origin
+  - `testing-endpoints` was merged forward with latest main
+  - Local uncommitted backend changes were preserved through stash/restore flow
+- Connection string in backend development settings was updated to active working SQL host credentials:
+  - `Server=192.168.111.9,1433;Database=HiddenGemMusic;User Id=sa;Password=Capstone123!;TrustServerCertificate=True;`
+- Endpoint validation exposed a schema-alias mismatch between stored procedure outputs and backend mapping keys:
+  - Stored procedures currently return fields such as `iso_code`, `full_name`, and `song_title`
+  - Existing mapper expected `country_code`, `country_name`, and `song_name`
+- Country repository mapping was updated to support both naming patterns for compatibility with current stored procedure outputs:
+  - Country fields now resolve across old/new alias variants
+  - Song name fields now resolve across `song_name` and `song_title`
+  - Hidden gems country count mapping now supports both `countries_charting_count` and `countries_charting`
+- Build verification succeeded after mapper updates:
+  - `dotnet build backend/Capstone.API` completed with 0 errors
+- Endpoint re-test confirmed successful populated response for country profile:
+  - `http://localhost:5140/api/country/US?year=2021`
+  - `countryCode`, `countryName`, and `songName` now return populated values instead of null
 
 All Web Screens Completed with Placeholder Data (April 26, 2026)
 - All planned web UI screens are now completed in a styled and functional placeholder-data state:

--- a/Documents/mp3li implementation timeline document.txt
+++ b/Documents/mp3li implementation timeline document.txt
@@ -2,6 +2,165 @@ mp3li implementation timeline document
 
 Updated: April 29, 2026
 
+Discovery Globe Data Integration + Discovery Filters Completion + DB Repro Runbook (April 30, 2026)
+- Goal for this task:
+  - Replace Discovery Globe/List mock-country wiring with backend data, complete the Discovery filters popup, and document exact DB-side stored procedure updates required so Leena can recreate the same behavior in SQL Server.
+
+- Branch and scope:
+  - Branch used: `implementing-data-discovery-globe-screen`
+  - Scope intentionally focused on Discovery + Welcome interactions and backend Discovery data contract only.
+
+- Frontend implementation completed:
+  - Discovery country source moved to API-backed loading in app flow:
+    - Added `hidden-gem-music-app/src/data/discoveryApi.ts`
+    - `App.tsx` now loads Discovery countries by year via API and passes that set into `DiscoveryScreen`
+  - Added API normalization/mapping support for Discovery payload:
+    - `hidden-gem-music-app/src/types/api.ts`
+    - `hidden-gem-music-app/src/data/apiMappers.ts`
+  - Discovery list/globe content behavior updates:
+    - Country cards now use consistent stacked layout and bullet details.
+    - Detail copy now uses explicit labels and spacing, including:
+      - `Hidden Gems:  {count}`
+      - `Genre(s):  ...`
+      - `Language(s):  ...`
+    - If a country has no hidden gems in selected year:
+      - `Hidden Gems:  No Hidden Gems for {year}`
+    - If a country has no song data row for that year:
+      - `Most popular album:  No song data for {year}`
+  - Discovery blurb text updated to project-specific copy.
+  - Welcome overlay updates:
+    - Button text updated to `Hidden Gems`
+    - Clicking outside popup closes popup
+  - Discovery filters popup completed and wired functionally:
+    - Smaller header, actual styled Close button with hover/press state
+    - Sort options:
+      - `A--Z`, `Z--A`
+      - Most hidden gems -> least
+      - Least hidden gems -> most
+    - Toggle options:
+      - `Only Show Countries with Hidden Gems`
+      - `Show Countries Without Hidden Gems` (mutually exclusive with above)
+    - Continent filter:
+      - Multi-select
+      - `All Continents` reset option
+      - Region label changed to `Continent`
+      - Display normalization for noisy values:
+        - `Continent info coming soon.` -> `Unknown / Missing`
+        - `Other` -> `Other / Territories`
+    - Filters now apply to BOTH list view and globe from one shared filtered set.
+    - Default state now starts with `Only Show Countries with Hidden Gems` enabled.
+  - Globe-to-list hover interaction refinement:
+    - Auto-scroll now jumps instantly (no visible smooth scrolling) when hover selection changes.
+
+- Backend implementation completed:
+  - Added discovery-specific API route:
+    - `backend/Capstone.API/Controllers/DiscoveryController.cs`
+    - Route: `GET /api/discovery/countries?year={year}`
+  - Discovery backend data model/repository contract expanded:
+    - `backend/Capstone.API/Models/Globe/CountryGlobeSummary.cs`
+      - includes `Region`
+      - includes `TopArtistName`
+    - `backend/Capstone.API/Infrastructure/Repositories/GlobeRepository.cs`
+      - now calls `sp_GetDiscoverPageInfo`
+      - key mapping hardened for multiple alias/casing patterns
+      - maps region, lat/long, hidden gem count, top album, top artist
+  - SQL script rename and contract update:
+    - Removed: `backend/Capstone.API/SQL Scripts/read/sp_GetGlobeSummary.sql`
+    - Added: `backend/Capstone.API/SQL Scripts/read/sp_GetDiscoverPageInfo.sql`
+
+- Critical DB-side reality discovered during verification:
+  - Many countries had `0` chart-entry rows for selected year in `ChartEntry`, so they cannot produce a top song/album/artist for that year.
+  - Non-zero hidden-gem counts and song metadata were present for only part of countries depending on dataset coverage.
+  - `DIM_Song.album_name` is often null; fallback logic is needed if “album” must always show meaningful text.
+  - A pseudo-country row like `-- / Global` can appear in source data and must be filtered out by strict ISO-code constraints.
+
+- Final SQL logic direction for Discovery page info:
+  - Hidden gem count remains sourced from `HiddenGems` by country/year.
+  - Top album/artist is sourced from MOST FREQUENT charted song in country/year from `ChartEntry` (not hidden-gem-only ranking).
+  - This matches “most popular in that country/year” intent.
+
+- DB handoff for Leena:
+  - Apply/refresh procedure: `sp_GetDiscoverPageInfo`
+  - Use the following SQL definition:
+
+```sql
+USE HiddenGemMusic;
+GO
+
+CREATE OR ALTER PROCEDURE sp_GetDiscoverPageInfo
+    @Year INT
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    SELECT
+        c.iso_code AS country_code,
+        c.full_name AS country_name,
+        c.latitude,
+        c.longitude,
+        c.region,
+        ISNULL(hg_agg.hidden_gem_count, 0) AS hidden_gem_count,
+        top_song.top_album_name AS top_album_name,
+        top_song.top_artist_name AS top_artist_name
+    FROM Country c
+    LEFT JOIN (
+        SELECT
+            country_id,
+            COUNT(*) AS hidden_gem_count
+        FROM HiddenGems
+        WHERE chart_year = @Year
+        GROUP BY country_id
+    ) hg_agg ON hg_agg.country_id = c.country_id
+    LEFT JOIN (
+        SELECT
+            ce.country_id,
+            COALESCE(NULLIF(s_inner.album_name, ''), s_inner.title, 'Unknown Song') AS top_album_name,
+            COALESCE(NULLIF(a_inner.artist_name, ''), 'Unknown Artist') AS top_artist_name,
+            ROW_NUMBER() OVER (
+                PARTITION BY ce.country_id
+                ORDER BY COUNT(*) DESC, ce.song_id ASC
+            ) AS rn
+        FROM ChartEntry ce
+        JOIN DIM_Song s_inner ON s_inner.song_id = ce.song_id
+        LEFT JOIN Bridge_SongArtist bsa_inner
+            ON bsa_inner.song_id = s_inner.song_id
+           AND bsa_inner.artist_order = 1
+        LEFT JOIN DIM_Artist a_inner ON a_inner.artist_id = bsa_inner.artist_id
+        WHERE ce.country_id IS NOT NULL
+          AND YEAR(ce.snapshot_date) = @Year
+        GROUP BY ce.country_id, ce.song_id, s_inner.album_name, s_inner.title, a_inner.artist_name
+    ) top_song ON top_song.country_id = c.country_id AND top_song.rn = 1
+    WHERE c.latitude IS NOT NULL
+      AND c.longitude IS NOT NULL
+      AND c.iso_code IS NOT NULL
+      AND LEN(c.iso_code) = 2
+      AND c.iso_code NOT LIKE '%[^A-Z]%'
+    ORDER BY c.full_name;
+END;
+GO
+```
+
+  - Validation query:
+
+```sql
+USE HiddenGemMusic;
+GO
+EXEC sp_GetDiscoverPageInfo @Year = 2021;
+GO
+```
+
+  - Post-apply runtime check points:
+    - Restart backend API host
+    - Re-test endpoint: `http://localhost:5140/api/discovery/countries?year=2021`
+
+- Validation checklist used after implementation:
+  - API returned region/lat/long for countries.
+  - Non-zero hidden-gem countries showed numeric counts.
+  - Countries with no hidden gems showed year-specific “No Hidden Gems” copy.
+  - Countries lacking chart rows showed year-specific “No song data” copy.
+  - Discovery filters changed both list and globe result sets consistently.
+  - Discovery popup controls retained hover/press style parity with existing UI language.
+
 Comparison Endpoint Verification + Hardening + SP Contract Cross-Check (April 29, 2026)
 - Goal for this task:
   - Validate the Country Comparison endpoint behavior, add robust error handling, cross-check backend mapper contracts against comparison SP outputs, confirm whether additional SPs are needed, and document implementation details for team handoff.

--- a/backend/Capstone.API/Controllers/ComparisonController.cs
+++ b/backend/Capstone.API/Controllers/ComparisonController.cs
@@ -1,5 +1,7 @@
 using Capstone.API.Infrastructure.Interfaces;
+using Microsoft.Data.SqlClient;
 using Microsoft.AspNetCore.Mvc;
+using System.Text.RegularExpressions;
 
 namespace Capstone.API.Controllers
 {
@@ -10,14 +12,22 @@ namespace Capstone.API.Controllers
     [Route("api/comparison")]
     public class ComparisonController : ControllerBase
     {
+        private static readonly Regex CountryCodeRegex = new("^[A-Za-z]{2}$", RegexOptions.Compiled);
+        private const int MinSupportedYear = 1975;
+        private const int MaxSupportedYear = 2021;
+        private const int UnavailableGapStartYear = 2007;
+        private const int UnavailableGapEndYear = 2010;
+
         private readonly IComparisonRepository _repo;
+        private readonly ILogger<ComparisonController> _logger;
 
         /// <summary>
         /// Initializes a new instance of ComparisonController.
         /// </summary>
-        public ComparisonController(IComparisonRepository repo)
+        public ComparisonController(IComparisonRepository repo, ILogger<ComparisonController> logger)
         {
             _repo = repo;
+            _logger = logger;
         }
 
         /// <summary>
@@ -33,11 +43,41 @@ namespace Capstone.API.Controllers
             [FromQuery] string countryB,
             [FromQuery] int year = 2021)
         {
-            var result = await _repo.GetCountryComparisonAsync(countryA.ToUpper(), countryB.ToUpper(), year);
-            if (result == null)
-                return NotFound();
+            if (!TryValidateInputs(countryA, countryB, year, out var validationError))
+                return BadRequest(new { message = validationError });
 
-            return Ok(result);
+            try
+            {
+                var result = await _repo.GetCountryComparisonAsync(
+                    countryA.ToUpperInvariant(),
+                    countryB.ToUpperInvariant(),
+                    year);
+
+                if (result == null)
+                    return NotFound();
+
+                return Ok(result);
+            }
+            catch (SqlException ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "SQL error getting country comparison for {CountryA} vs {CountryB} year {Year}",
+                    countryA,
+                    countryB,
+                    year);
+                return StatusCode(503, new { message = "Database temporarily unavailable while retrieving country comparison data." });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "Error getting country comparison for {CountryA} vs {CountryB} year {Year}",
+                    countryA,
+                    countryB,
+                    year);
+                return StatusCode(500, new { message = "An unexpected error occurred while retrieving country comparison data." });
+            }
         }
 
         /// <summary>
@@ -53,8 +93,73 @@ namespace Capstone.API.Controllers
             [FromQuery] string countryB,
             [FromQuery] int year = 2021)
         {
-            var result = await _repo.GetComparisonHiddenGemsAsync(countryA.ToUpper(), countryB.ToUpper(), year);
-            return Ok(result);
+            if (!TryValidateInputs(countryA, countryB, year, out var validationError))
+                return BadRequest(new { message = validationError });
+
+            try
+            {
+                var result = await _repo.GetComparisonHiddenGemsAsync(
+                    countryA.ToUpperInvariant(),
+                    countryB.ToUpperInvariant(),
+                    year);
+                return Ok(result);
+            }
+            catch (SqlException ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "SQL error getting comparison hidden gems for {CountryA} vs {CountryB} year {Year}",
+                    countryA,
+                    countryB,
+                    year);
+                return StatusCode(503, new { message = "Database temporarily unavailable while retrieving comparison hidden gems data." });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "Error getting comparison hidden gems for {CountryA} vs {CountryB} year {Year}",
+                    countryA,
+                    countryB,
+                    year);
+                return StatusCode(500, new { message = "An unexpected error occurred while retrieving comparison hidden gems data." });
+            }
+        }
+
+        private static bool TryValidateInputs(string countryA, string countryB, int year, out string validationError)
+        {
+            if (string.IsNullOrWhiteSpace(countryA) || !CountryCodeRegex.IsMatch(countryA))
+            {
+                validationError = "countryA must be exactly 2 letters (ISO format, e.g. 'US').";
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(countryB) || !CountryCodeRegex.IsMatch(countryB))
+            {
+                validationError = "countryB must be exactly 2 letters (ISO format, e.g. 'GB').";
+                return false;
+            }
+
+            if (countryA.Equals(countryB, StringComparison.OrdinalIgnoreCase))
+            {
+                validationError = "countryA and countryB must be different countries.";
+                return false;
+            }
+
+            if (year < MinSupportedYear || year > MaxSupportedYear)
+            {
+                validationError = $"Year must be between {MinSupportedYear} and {MaxSupportedYear}.";
+                return false;
+            }
+
+            if (year >= UnavailableGapStartYear && year <= UnavailableGapEndYear)
+            {
+                validationError = $"Year {year} is unavailable in this dataset window.";
+                return false;
+            }
+
+            validationError = string.Empty;
+            return true;
         }
     }
 }

--- a/backend/Capstone.API/Controllers/CountryController.cs
+++ b/backend/Capstone.API/Controllers/CountryController.cs
@@ -1,5 +1,7 @@
 using Capstone.API.Infrastructure.Interfaces;
+using Microsoft.Data.SqlClient;
 using Microsoft.AspNetCore.Mvc;
+using System.Text.RegularExpressions;
 
 namespace Capstone.API.Controllers
 {
@@ -8,19 +10,27 @@ namespace Capstone.API.Controllers
     /// </summary>
     [ApiController]
     [Route("api/country")]
-public class CountryController : ControllerBase
-{
-    private readonly ICountryRepository _repo;
-    private readonly ILogger<CountryController> _logger;
+    public class CountryController : ControllerBase
+    {
+        private static readonly Regex CountryCodeRegex = new("^[A-Za-z]{2}$", RegexOptions.Compiled);
+
+        // Keep backend year validation aligned with frontend selectable years.
+        private const int MinSupportedYear = 1975;
+        private const int MaxSupportedYear = 2021;
+        private const int UnavailableGapStartYear = 2007;
+        private const int UnavailableGapEndYear = 2010;
+
+        private readonly ICountryRepository _repo;
+        private readonly ILogger<CountryController> _logger;
 
         /// <summary>
         /// Initializes a new instance of CountryController.
         /// </summary>
-    public CountryController(ICountryRepository repo, ILogger<CountryController> logger)
-    {
-        _repo = repo;
-        _logger = logger;
-    }
+        public CountryController(ICountryRepository repo, ILogger<CountryController> logger)
+        {
+            _repo = repo;
+            _logger = logger;
+        }
 
         /// <summary>
         /// Returns full chart statistics and top song lists for a single country and year.
@@ -28,23 +38,32 @@ public class CountryController : ControllerBase
         /// </summary>
         /// <param name="code">2-letter ISO country code (e.g. "US", "JP").</param>
         /// <param name="year">The chart year to display. Defaults to 2021.</param>
-    [HttpGet("{code}")]
-    public async Task<IActionResult> GetCountryProfile(string code, [FromQuery] int year = 2021)
-    {
-        try
+        [HttpGet("{code}")]
+        public async Task<IActionResult> GetCountryProfile(string code, [FromQuery] int year = 2021)
         {
-            var result = await _repo.GetCountryProfileAsync(code.ToUpper(), year);
-            if (result == null)
-                return NotFound();
+            if (!TryValidateInputs(code, year, out var validationError))
+                return BadRequest(new { message = validationError });
 
-            return Ok(result);
+            try
+            {
+                var normalizedCode = code.ToUpperInvariant();
+                var result = await _repo.GetCountryProfileAsync(normalizedCode, year);
+                if (result == null)
+                    return NotFound();
+
+                return Ok(result);
+            }
+            catch (SqlException ex)
+            {
+                _logger.LogError(ex, "SQL error getting country profile for {CountryCode} year {Year}", code, year);
+                return StatusCode(503, new { message = "Database temporarily unavailable while retrieving country profile data." });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error getting country profile for {CountryCode} year {Year}", code, year);
+                return StatusCode(500, new { message = "An unexpected error occurred while retrieving country profile data." });
+            }
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error getting country profile for {CountryCode} year {Year}", code, year);
-            return StatusCode(500, new { message = "An unexpected error occurred while retrieving country profile data." });
-        }
-    }
 
         /// <summary>
         /// Returns the top 5 hidden gems for the teaser widget on the country profile page.
@@ -52,19 +71,52 @@ public class CountryController : ControllerBase
         /// </summary>
         /// <param name="code">2-letter ISO country code.</param>
         /// <param name="year">The chart year to display. Defaults to 2021.</param>
-    [HttpGet("{code}/hidden-gems/preview")]
-    public async Task<IActionResult> GetHiddenGemsPreview(string code, [FromQuery] int year = 2021)
-    {
-        try
+        [HttpGet("{code}/hidden-gems/preview")]
+        public async Task<IActionResult> GetHiddenGemsPreview(string code, [FromQuery] int year = 2021)
         {
-            var result = await _repo.GetHiddenGemsPreviewAsync(code.ToUpper(), year);
-            return Ok(result);
+            if (!TryValidateInputs(code, year, out var validationError))
+                return BadRequest(new { message = validationError });
+
+            try
+            {
+                var normalizedCode = code.ToUpperInvariant();
+                var result = await _repo.GetHiddenGemsPreviewAsync(normalizedCode, year);
+                return Ok(result);
+            }
+            catch (SqlException ex)
+            {
+                _logger.LogError(ex, "SQL error getting hidden gems preview for {CountryCode} year {Year}", code, year);
+                return StatusCode(503, new { message = "Database temporarily unavailable while retrieving hidden gems preview data." });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error getting hidden gems preview for {CountryCode} year {Year}", code, year);
+                return StatusCode(500, new { message = "An unexpected error occurred while retrieving hidden gems preview data." });
+            }
         }
-        catch (Exception ex)
+
+        private static bool TryValidateInputs(string code, int year, out string validationError)
         {
-            _logger.LogError(ex, "Error getting hidden gems preview for {CountryCode} year {Year}", code, year);
-            return StatusCode(500, new { message = "An unexpected error occurred while retrieving hidden gems preview data." });
+            if (string.IsNullOrWhiteSpace(code) || !CountryCodeRegex.IsMatch(code))
+            {
+                validationError = "Country code must be exactly 2 letters (ISO format, e.g. 'US').";
+                return false;
+            }
+
+            if (year < MinSupportedYear || year > MaxSupportedYear)
+            {
+                validationError = $"Year must be between {MinSupportedYear} and {MaxSupportedYear}.";
+                return false;
+            }
+
+            if (year >= UnavailableGapStartYear && year <= UnavailableGapEndYear)
+            {
+                validationError = $"Year {year} is unavailable in this dataset window.";
+                return false;
+            }
+
+            validationError = string.Empty;
+            return true;
         }
     }
-}
 }

--- a/backend/Capstone.API/Controllers/CountryController.cs
+++ b/backend/Capstone.API/Controllers/CountryController.cs
@@ -8,17 +8,19 @@ namespace Capstone.API.Controllers
     /// </summary>
     [ApiController]
     [Route("api/country")]
-    public class CountryController : ControllerBase
-    {
-        private readonly ICountryRepository _repo;
+public class CountryController : ControllerBase
+{
+    private readonly ICountryRepository _repo;
+    private readonly ILogger<CountryController> _logger;
 
         /// <summary>
         /// Initializes a new instance of CountryController.
         /// </summary>
-        public CountryController(ICountryRepository repo)
-        {
-            _repo = repo;
-        }
+    public CountryController(ICountryRepository repo, ILogger<CountryController> logger)
+    {
+        _repo = repo;
+        _logger = logger;
+    }
 
         /// <summary>
         /// Returns full chart statistics and top song lists for a single country and year.
@@ -26,8 +28,10 @@ namespace Capstone.API.Controllers
         /// </summary>
         /// <param name="code">2-letter ISO country code (e.g. "US", "JP").</param>
         /// <param name="year">The chart year to display. Defaults to 2021.</param>
-        [HttpGet("{code}")]
-        public async Task<IActionResult> GetCountryProfile(string code, [FromQuery] int year = 2021)
+    [HttpGet("{code}")]
+    public async Task<IActionResult> GetCountryProfile(string code, [FromQuery] int year = 2021)
+    {
+        try
         {
             var result = await _repo.GetCountryProfileAsync(code.ToUpper(), year);
             if (result == null)
@@ -35,6 +39,12 @@ namespace Capstone.API.Controllers
 
             return Ok(result);
         }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error getting country profile for {CountryCode} year {Year}", code, year);
+            return StatusCode(500, new { message = "An unexpected error occurred while retrieving country profile data." });
+        }
+    }
 
         /// <summary>
         /// Returns the top 5 hidden gems for the teaser widget on the country profile page.
@@ -42,11 +52,19 @@ namespace Capstone.API.Controllers
         /// </summary>
         /// <param name="code">2-letter ISO country code.</param>
         /// <param name="year">The chart year to display. Defaults to 2021.</param>
-        [HttpGet("{code}/hidden-gems/preview")]
-        public async Task<IActionResult> GetHiddenGemsPreview(string code, [FromQuery] int year = 2021)
+    [HttpGet("{code}/hidden-gems/preview")]
+    public async Task<IActionResult> GetHiddenGemsPreview(string code, [FromQuery] int year = 2021)
+    {
+        try
         {
             var result = await _repo.GetHiddenGemsPreviewAsync(code.ToUpper(), year);
             return Ok(result);
         }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error getting hidden gems preview for {CountryCode} year {Year}", code, year);
+            return StatusCode(500, new { message = "An unexpected error occurred while retrieving hidden gems preview data." });
+        }
     }
+}
 }

--- a/backend/Capstone.API/Controllers/DiscoveryController.cs
+++ b/backend/Capstone.API/Controllers/DiscoveryController.cs
@@ -1,0 +1,32 @@
+using Capstone.API.Infrastructure.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Capstone.API.Controllers
+{
+    /// <summary>
+    /// Serves shared country summary data for the Discovery experience.
+    /// The globe and list consume this same payload and render it differently.
+    /// </summary>
+    [ApiController]
+    [Route("api/discovery")]
+    public class DiscoveryController : ControllerBase
+    {
+        private readonly IGlobeRepository _repo;
+
+        public DiscoveryController(IGlobeRepository repo)
+        {
+            _repo = repo;
+        }
+
+        /// <summary>
+        /// Returns one summary row per country for Discovery list + globe.
+        /// GET /api/discovery/countries?year={year}
+        /// </summary>
+        [HttpGet("countries")]
+        public async Task<IActionResult> GetDiscoveryCountries([FromQuery] int year = 2021)
+        {
+            var result = await _repo.GetGlobeSummaryAsync(year);
+            return Ok(result);
+        }
+    }
+}

--- a/backend/Capstone.API/Documentation/ADR-BACKEND-002-Routes-Controllers-DTOs.md
+++ b/backend/Capstone.API/Documentation/ADR-BACKEND-002-Routes-Controllers-DTOs.md
@@ -7,6 +7,20 @@
 
 ---
 
+## April 29, 2026 Verification Addendum (Country Endpoints)
+
+- `CountryController` input validation now enforces:
+  - `code` must be exactly 2 letters (`400` on failure)
+  - `year` must be in dataset-supported range `1975..2021`, excluding known unavailable gap years `2007..2010` (`400` on failure)
+- Error handling for Country endpoints now distinguishes:
+  - `400` invalid input
+  - `404` valid input but no profile row for `/api/country/{code}`
+  - `503` SQL/database failures
+  - `500` unexpected failures
+- `sp_GetCountryHiddenGemsPreview` was cross-checked against a restored local DB that initially had an outdated procedure version referencing legacy table `Song`.
+  - Required/current version uses star schema joins: `DIM_Song`, `Bridge_SongArtist`, `DIM_Artist`.
+  - After applying `CREATE OR ALTER PROCEDURE` with star schema joins, preview endpoint returned valid JSON.
+
 ## Context
 
 This ADR documents the concrete implementation of the API surface: every route, controller action, repository method, stored procedure call, and DTO field mapping. It was written after the code compiled and built successfully, and reflects the actual state of the files — not the planning document.
@@ -83,7 +97,9 @@ All country codes are normalized to uppercase (`.ToUpper()`) at the controller b
 
 **Route params:** `code` (2-letter ISO, normalized to uppercase)
 **Query params:** `year` (int)
+**Input validation:** `code` must be 2 letters; `year` must be `1975..2021` excluding `2007..2010` (`400` on validation failure).
 **Returns 404** if `GetCountryProfileAsync` returns null (country/year combination not found).
+**Returns 503** for SQL/database failures; **500** for unexpected failures.
 
 ---
 
@@ -161,21 +177,21 @@ For each SP: the name as hard-coded in the repository, the parameter names as pa
 | 1 | Top shared songs | `CountryProfile.TopSharedSongs` |
 | 2 | Top unique songs | `CountryProfile.TopUniqueSongs` |
 
-**Set 0 expected columns:**
+**Set 0 expected columns (verified aliases):**
 | Column | C# property | Type |
 |--------|------------|------|
-| `country_code` | `CountryProfile.CountryCode` | string? |
-| `country_name` | `CountryProfile.CountryName` | string? |
+| `country_code` or `iso_code` | `CountryProfile.CountryCode` | string? |
+| `country_name` or `full_name` | `CountryProfile.CountryName` | string? |
 | `chart_year` | `CountryProfile.Year` | int |
 | `total_charted` | `CountryProfile.TotalCharted` | int |
 | `shared_count` | `CountryProfile.SharedCount` | int |
 | `unique_count` | `CountryProfile.UniqueCount` | int |
 | `overlap_pct` | `CountryProfile.OverlapPct` | decimal |
 
-**Sets 1 and 2 expected columns (Song):**
+**Sets 1 and 2 expected columns (Song, verified aliases):**
 | Column | C# property | Type |
 |--------|------------|------|
-| `song_name` | `Song.SongName` | string? |
+| `song_name` or `song_title` | `Song.SongName` | string? |
 | `artist_name` | `Song.ArtistName` | string? |
 | `album_name` | `Song.AlbumName` | string? |
 
@@ -184,7 +200,15 @@ For each SP: the name as hard-coded in the repository, the parameter names as pa
 ### 3.3 `sp_GetCountryHiddenGemsPreview`
 **Repository:** `CountryRepository.GetHiddenGemsPreviewAsync`
 **Params:** `@CountryCode CHAR(2)`, `@Year INT`
-**Expected output columns:** Same as Section 3.5 (HiddenGem shape).
+**Expected output columns (verified aliases):**
+- `song_name` or `song_title` → `HiddenGem.SongName`
+- `album_name` → `HiddenGem.AlbumName`
+- `artist_name` → `HiddenGem.ArtistName`
+- `trend_score` → `HiddenGem.TrendScore`
+- `countries_charting_count` or `countries_charting` → `HiddenGem.CountriesChartingCount`
+
+**Required stored procedure version note:**
+- Procedure must reference star-schema tables (`DIM_Song`, `Bridge_SongArtist`, `DIM_Artist`), not legacy `Song`.
 
 ---
 

--- a/backend/Capstone.API/Infrastructure/Repositories/ComparisonRepository.cs
+++ b/backend/Capstone.API/Infrastructure/Repositories/ComparisonRepository.cs
@@ -71,8 +71,8 @@ namespace Capstone.API.Infrastructure.Repositories
         {
             return new CountryComparisonSide
             {
-                CountryCode = AsString(row, "country_code"),
-                CountryName = AsString(row, "country_name"),
+                CountryCode = AsString(row, "country_code", "iso_code"),
+                CountryName = AsString(row, "country_name", "full_name"),
                 TotalCharted = AsInt(row, "total_charted"),
                 SharedCount = AsInt(row, "shared_count"),
                 UniqueCount = AsInt(row, "unique_count"),
@@ -84,7 +84,7 @@ namespace Capstone.API.Infrastructure.Repositories
         {
             return new SharedSong
             {
-                SongName = AsString(row, "song_name"),
+                SongName = AsString(row, "song_name", "song_title", "title"),
                 ArtistName = AsString(row, "artist_name"),
                 AlbumName = AsString(row, "album_name"),
                 RankInCountryA = AsInt(row, "rank_in_country_a"),
@@ -96,7 +96,7 @@ namespace Capstone.API.Infrastructure.Repositories
         {
             return new Song
             {
-                SongName = AsString(row, "song_name"),
+                SongName = AsString(row, "song_name", "song_title", "title"),
                 ArtistName = AsString(row, "artist_name"),
                 AlbumName = AsString(row, "album_name")
             };
@@ -106,21 +106,45 @@ namespace Capstone.API.Infrastructure.Repositories
         {
             return new ComparisonHiddenGem
             {
-                SongName = AsString(row, "song_name"),
+                SongName = AsString(row, "song_name", "song_title", "title"),
                 AlbumName = AsString(row, "album_name"),
                 ArtistName = AsString(row, "artist_name"),
                 TrendScore = AsDecimal(row, "trend_score"),
-                CountriesChartingCount = AsInt(row, "countries_charting_count")
+                CountriesChartingCount = AsInt(row, "countries_charting_count", "countries_charting", "country_count")
             };
         }
 
-        private static string? AsString(IDictionary<string, object?> row, string key)
-            => row.TryGetValue(key, out var v) ? v?.ToString() : null;
+        private static string? AsString(IDictionary<string, object?> row, params string[] keys)
+        {
+            foreach (var key in keys)
+            {
+                if (row.TryGetValue(key, out var value) && value != null)
+                    return value.ToString();
+            }
 
-        private static int AsInt(IDictionary<string, object?> row, string key)
-            => row.TryGetValue(key, out var v) && v != null ? Convert.ToInt32(v) : 0;
+            return null;
+        }
 
-        private static decimal AsDecimal(IDictionary<string, object?> row, string key)
-            => row.TryGetValue(key, out var v) && v != null ? Convert.ToDecimal(v) : 0m;
+        private static int AsInt(IDictionary<string, object?> row, params string[] keys)
+        {
+            foreach (var key in keys)
+            {
+                if (row.TryGetValue(key, out var value) && value != null)
+                    return Convert.ToInt32(value);
+            }
+
+            return 0;
+        }
+
+        private static decimal AsDecimal(IDictionary<string, object?> row, params string[] keys)
+        {
+            foreach (var key in keys)
+            {
+                if (row.TryGetValue(key, out var value) && value != null)
+                    return Convert.ToDecimal(value);
+            }
+
+            return 0m;
+        }
     }
 }

--- a/backend/Capstone.API/Infrastructure/Repositories/CountryRepository.cs
+++ b/backend/Capstone.API/Infrastructure/Repositories/CountryRepository.cs
@@ -38,13 +38,13 @@ namespace Capstone.API.Infrastructure.Repositories
 
             var profile = new CountryProfile
             {
-                CountryCode = AsString(stats, "country_code"),
-                CountryName = AsString(stats, "country_name"),
-                Year = AsInt(stats, "chart_year"),
-                TotalCharted = AsInt(stats, "total_charted"),
-                SharedCount = AsInt(stats, "shared_count"),
-                UniqueCount = AsInt(stats, "unique_count"),
-                OverlapPct = AsDecimal(stats, "overlap_pct")
+                CountryCode = AsStringAny(stats, "country_code", "iso_code"),
+                CountryName = AsStringAny(stats, "country_name", "full_name"),
+                Year = AsIntAny(stats, "chart_year", "year"),
+                TotalCharted = AsIntAny(stats, "total_charted"),
+                SharedCount = AsIntAny(stats, "shared_count"),
+                UniqueCount = AsIntAny(stats, "unique_count"),
+                OverlapPct = AsDecimalAny(stats, "overlap_pct")
             };
 
             if (sets.Count > 1)
@@ -72,9 +72,9 @@ namespace Capstone.API.Infrastructure.Repositories
         {
             return new Song
             {
-                SongName = AsString(row, "song_name"),
-                ArtistName = AsString(row, "artist_name"),
-                AlbumName = AsString(row, "album_name")
+                SongName = AsStringAny(row, "song_name", "song_title", "title"),
+                ArtistName = AsStringAny(row, "artist_name"),
+                AlbumName = AsStringAny(row, "album_name")
             };
         }
 
@@ -82,23 +82,47 @@ namespace Capstone.API.Infrastructure.Repositories
         {
             return new HiddenGem
             {
-                SongName = AsString(row, "song_name"),
-                AlbumName = AsString(row, "album_name"),
-                ArtistName = AsString(row, "artist_name"),
-                Genre = AsString(row, "genre"),
-                PreviewUrl = AsString(row, "preview_url"),
-                TrendScore = AsDecimal(row, "trend_score"),
-                CountriesChartingCount = AsInt(row, "countries_charting_count")
+                SongName = AsStringAny(row, "song_name", "song_title", "title"),
+                AlbumName = AsStringAny(row, "album_name"),
+                ArtistName = AsStringAny(row, "artist_name"),
+                Genre = AsStringAny(row, "genre"),
+                PreviewUrl = AsStringAny(row, "preview_url"),
+                TrendScore = AsDecimalAny(row, "trend_score"),
+                CountriesChartingCount = AsIntAny(row, "countries_charting_count", "countries_charting")
             };
         }
 
-        private static string? AsString(IDictionary<string, object?> row, string key)
-            => row.TryGetValue(key, out var v) ? v?.ToString() : null;
+        private static string? AsStringAny(IDictionary<string, object?> row, params string[] keys)
+        {
+            foreach (var key in keys)
+            {
+                if (row.TryGetValue(key, out var v) && v != null)
+                    return v.ToString();
+            }
 
-        private static int AsInt(IDictionary<string, object?> row, string key)
-            => row.TryGetValue(key, out var v) && v != null ? Convert.ToInt32(v) : 0;
+            return null;
+        }
 
-        private static decimal AsDecimal(IDictionary<string, object?> row, string key)
-            => row.TryGetValue(key, out var v) && v != null ? Convert.ToDecimal(v) : 0m;
+        private static int AsIntAny(IDictionary<string, object?> row, params string[] keys)
+        {
+            foreach (var key in keys)
+            {
+                if (row.TryGetValue(key, out var v) && v != null)
+                    return Convert.ToInt32(v);
+            }
+
+            return 0;
+        }
+
+        private static decimal AsDecimalAny(IDictionary<string, object?> row, params string[] keys)
+        {
+            foreach (var key in keys)
+            {
+                if (row.TryGetValue(key, out var v) && v != null)
+                    return Convert.ToDecimal(v);
+            }
+
+            return 0m;
+        }
     }
 }

--- a/backend/Capstone.API/Infrastructure/Repositories/GlobeRepository.cs
+++ b/backend/Capstone.API/Infrastructure/Repositories/GlobeRepository.cs
@@ -4,7 +4,7 @@ using Capstone.API.Models.Globe;
 namespace Capstone.API.Infrastructure.Repositories
 {
     /// <summary>
-    /// Retrieves globe summary data by calling sp_GetGlobeSummary on the pre-computed summary tables.
+    /// Retrieves discovery country data by calling sp_GetDiscoverPageInfo on the pre-computed summary tables.
     /// Never touches ChartEntry directly.
     /// </summary>
     public class GlobeRepository : IGlobeRepository
@@ -22,7 +22,7 @@ namespace Capstone.API.Infrastructure.Repositories
         /// <inheritdoc/>
         public async Task<IEnumerable<CountryGlobeSummary>> GetGlobeSummaryAsync(int year)
         {
-            var rows = await _db.GetDataAsync("sp_GetGlobeSummary", new Dictionary<string, object?>
+            var rows = await _db.GetDataAsync("sp_GetDiscoverPageInfo", new Dictionary<string, object?>
             {
                 { "@Year", year }
             });
@@ -34,22 +34,48 @@ namespace Capstone.API.Infrastructure.Repositories
         {
             return new CountryGlobeSummary
             {
-                CountryCode = AsString(row, "country_code"),
-                CountryName = AsString(row, "country_name"),
-                Lat = AsDouble(row, "lat"),
-                Long = AsDouble(row, "long"),
-                HiddenGemCount = AsInt(row, "hidden_gem_count"),
-                TopAlbumName = AsString(row, "top_album_name")
+                CountryCode = AsStringAny(row, "country_code", "countryCode", "CountryCode", "iso_code"),
+                CountryName = AsStringAny(row, "country_name", "countryName", "CountryName", "full_name"),
+                Region = AsStringAny(row, "region", "Region"),
+                Lat = AsDoubleAny(row, "latitude", "lat", "Latitude", "Lat"),
+                Long = AsDoubleAny(row, "longitude", "long", "Longitude", "Long"),
+                HiddenGemCount = AsIntAny(row, "hidden_gem_count", "hiddenGemCount", "HiddenGemCount"),
+                TopAlbumName = AsStringAny(row, "top_album_name", "topAlbumName", "TopAlbumName"),
+                TopArtistName = AsStringAny(row, "top_artist_name", "topArtistName", "TopArtistName")
             };
         }
 
-        private static string? AsString(IDictionary<string, object?> row, string key)
-            => row.TryGetValue(key, out var v) ? v?.ToString() : null;
+        private static string? AsStringAny(IDictionary<string, object?> row, params string[] keys)
+        {
+            foreach (var key in keys)
+            {
+                if (row.TryGetValue(key, out var v) && v != null)
+                    return v.ToString();
+            }
 
-        private static int AsInt(IDictionary<string, object?> row, string key)
-            => row.TryGetValue(key, out var v) && v != null ? Convert.ToInt32(v) : 0;
+            return null;
+        }
 
-        private static double AsDouble(IDictionary<string, object?> row, string key)
-            => row.TryGetValue(key, out var v) && v != null ? Convert.ToDouble(v) : 0.0;
+        private static int AsIntAny(IDictionary<string, object?> row, params string[] keys)
+        {
+            foreach (var key in keys)
+            {
+                if (row.TryGetValue(key, out var v) && v != null)
+                    return Convert.ToInt32(v);
+            }
+
+            return 0;
+        }
+
+        private static double AsDoubleAny(IDictionary<string, object?> row, params string[] keys)
+        {
+            foreach (var key in keys)
+            {
+                if (row.TryGetValue(key, out var v) && v != null)
+                    return Convert.ToDouble(v);
+            }
+
+            return 0.0;
+        }
     }
 }

--- a/backend/Capstone.API/Models/Globe/CountryGlobeSummary.cs
+++ b/backend/Capstone.API/Models/Globe/CountryGlobeSummary.cs
@@ -17,6 +17,11 @@ namespace Capstone.API.Models.Globe
         public string? CountryName { get; set; }
 
         /// <summary>
+        /// Gets or sets the geographic region/continent label for this country.
+        /// </summary>
+        public string? Region { get; set; }
+
+        /// <summary>
         /// Gets or sets the latitude for Mapbox dot placement.
         /// </summary>
         public double Lat { get; set; }
@@ -36,5 +41,11 @@ namespace Capstone.API.Models.Globe
         /// Nullable — may not be available for all countries.
         /// </summary>
         public string? TopAlbumName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the primary artist associated with the top discovery item.
+        /// Nullable — may not be available for all countries.
+        /// </summary>
+        public string? TopArtistName { get; set; }
     }
 }

--- a/backend/Capstone.API/SQL Scripts/read/sp_GetDiscoverPageInfo.sql
+++ b/backend/Capstone.API/SQL Scripts/read/sp_GetDiscoverPageInfo.sql
@@ -7,13 +7,13 @@
 --              on DIM_Song, no album_id FK needed.
 -- Description: One lightweight row per country for globe dots and country list sidebar.
 -- Also feeds Mapbox tileset export. Reads only pre-computed tables.
--- EXEC sp_GetGlobeSummary @Year = 2021;
+-- EXEC sp_GetDiscoverPageInfo @Year = 2021;
 -- =============================================
 
 USE HiddenGemMusic;
 GO
 
-CREATE OR ALTER PROCEDURE sp_GetGlobeSummary
+CREATE OR ALTER PROCEDURE sp_GetDiscoverPageInfo
     @Year INT
 AS
 BEGIN
@@ -26,7 +26,8 @@ BEGIN
         c.longitude,
         c.region,
         ISNULL(hg_agg.hidden_gem_count, 0)  AS hidden_gem_count,
-        top_alb.album_name                  AS top_album_name
+        top_song.album_name                 AS top_album_name,
+        top_song.artist_name                AS top_artist_name
     FROM Country c
     -- hidden gem count per country
     LEFT JOIN (
@@ -37,22 +38,27 @@ BEGIN
         WHERE chart_year = @Year
         GROUP BY country_id
     ) hg_agg ON hg_agg.country_id = c.country_id
-    -- top album: album_name appearing most in this country's hidden gems this year
-    -- simplified from original — album_name is now a plain string on DIM_Song
+    -- top song detail: most frequent charted song in each country/year
+    -- this is independent from hidden gems and reflects overall country popularity
     LEFT JOIN (
         SELECT
-            hg_src.country_id,
+            ce.country_id,
             s_inner.album_name,
+            a_inner.artist_name,
             ROW_NUMBER() OVER (
-                PARTITION BY hg_src.country_id
-                ORDER BY COUNT(*) DESC
+                PARTITION BY ce.country_id
+                ORDER BY COUNT(*) DESC, ce.song_id ASC
             ) AS rn
-        FROM HiddenGems hg_src
-        JOIN DIM_Song s_inner ON s_inner.song_id = hg_src.song_id
-        WHERE hg_src.chart_year    = @Year
-          AND s_inner.album_name   IS NOT NULL
-        GROUP BY hg_src.country_id, s_inner.album_name
-    ) top_alb ON top_alb.country_id = c.country_id AND top_alb.rn = 1
+        FROM ChartEntry ce
+        JOIN DIM_Song s_inner ON s_inner.song_id = ce.song_id
+        LEFT JOIN Bridge_SongArtist bsa_inner
+            ON bsa_inner.song_id = s_inner.song_id
+           AND bsa_inner.artist_order = 1
+        LEFT JOIN DIM_Artist a_inner ON a_inner.artist_id = bsa_inner.artist_id
+        WHERE ce.country_id IS NOT NULL
+          AND YEAR(ce.snapshot_date) = @Year
+        GROUP BY ce.country_id, ce.song_id, s_inner.album_name, a_inner.artist_name
+    ) top_song ON top_song.country_id = c.country_id AND top_song.rn = 1
     WHERE c.latitude  IS NOT NULL
       AND c.longitude IS NOT NULL
     ORDER BY c.full_name;

--- a/backend/Capstone.API/appsettings.Development.json
+++ b/backend/Capstone.API/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=192.168.111.9,1433;Database=HiddenGemMusic;User Id=sa;Password=Capstone123!;TrustServerCertificate=True;"
   }
 }

--- a/backend/Capstone.API/appsettings.json
+++ b/backend/Capstone.API/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=192.168.111.9,1433;Database=HiddenGemMusic;User Id=sa;Password=Capstone123!;TrustServerCertificate=True;"
+  },
   "AllowedHosts": "*"
 }

--- a/hidden-gem-music-app/App.tsx
+++ b/hidden-gem-music-app/App.tsx
@@ -15,6 +15,7 @@ import { DashboardScreen } from "./src/screens/DashboardScreen";
 import { DiscoveryScreen } from "./src/screens/DiscoveryScreen";
 import { HiddenGemsScreen } from "./src/screens/HiddenGemsScreen";
 import { WelcomeScreen } from "./src/screens/WelcomeScreen";
+import { loadDiscoveryCountries } from "./src/data/discoveryApi";
 import {
   availableYears,
   getCountriesForYear,
@@ -155,6 +156,7 @@ export default function App() {
   const [searchOpen, setSearchOpen] = useState(false);
 
   const countries = useMemo(() => getCountriesForYear(selectedYear), [selectedYear]);
+  const [discoveryCountries, setDiscoveryCountries] = useState<Country[]>(countries);
   const featuredCountry = useMemo(() => getFeaturedCountry(selectedYear), [selectedYear]);
   const songs = useMemo(() => getSongsForCountryYear(selectedCountryId, selectedYear), [selectedCountryId, selectedYear]);
 
@@ -326,6 +328,15 @@ export default function App() {
     });
   };
 
+  const openCountryFromDiscovery = (countryId: string) => {
+    if (countries.some((country) => country.id === countryId)) {
+      openCountry(countryId);
+      return;
+    }
+
+    setSelectedCountryId(countryId);
+  };
+
   const openHiddenGemsForCountry = (countryId: string, selection?: { songTitle?: string; artist?: string }) => {
     const countrySongs = getSongsForCountryYear(countryId, selectedYear);
     const normalize = (value?: string) => value?.trim().toLowerCase() ?? "";
@@ -364,10 +375,14 @@ export default function App() {
   }, [songs, selectedSongId]);
 
   useEffect(() => {
+    if (currentRoute === "discovery") {
+      return;
+    }
+
     if (!countries.some((country) => country.id === selectedCountryId)) {
       setSelectedCountryId(featuredCountry.id);
     }
-  }, [countries, featuredCountry.id, selectedCountryId]);
+  }, [countries, currentRoute, featuredCountry.id, selectedCountryId]);
 
   useEffect(() => {
     setComparisonIds((current) => current.filter((id) => countries.some((country) => country.id === id)).slice(0, 2));
@@ -399,6 +414,29 @@ export default function App() {
       navigationRef.dispatch(CommonActions.setParams(nextParams));
     }
   }, [currentRoute, navigationReady, navigationRef, selectedCountryId, selectedYear]);
+
+  useEffect(() => {
+    let isCancelled = false;
+    setDiscoveryCountries(countries);
+
+    loadDiscoveryCountries(selectedYear, countries)
+      .then((apiCountries) => {
+        if (isCancelled || apiCountries.length === 0) {
+          return;
+        }
+
+        setDiscoveryCountries(apiCountries);
+      })
+      .catch((error) => {
+        if (!isCancelled) {
+          console.warn("Failed to load discovery countries from API; using local mock countries.", error);
+        }
+      });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [countries, selectedYear]);
 
   useEffect(() => {
     if (typeof document === "undefined") {
@@ -609,10 +647,10 @@ export default function App() {
               <Stack.Screen name="discovery" options={{ title: "Discovery Globe" }}>
                 {() => (
                   <DiscoveryScreen
-                    countries={countries}
+                    countries={discoveryCountries}
                     selectedCountryId={selectedCountryId}
                     onSelectCountry={(countryId) => setSelectedCountryId(countryId)}
-                    onOpenCountry={openCountry}
+                    onOpenCountry={openCountryFromDiscovery}
                     selectedYear={selectedYear}
                     onChangeYear={(year) => handleYearChange(year, "Discovery Globe")}
                   />

--- a/hidden-gem-music-app/src/components/CountryCard.tsx
+++ b/hidden-gem-music-app/src/components/CountryCard.tsx
@@ -9,14 +9,19 @@ import { Panel } from "./Panel";
 
 type Props = {
   country: Country;
+  selectedYear?: number;
   selected?: boolean;
   onPress: () => void;
   onTitlePress?: () => void;
   onHover?: () => void;
 };
 
-export function CountryCard({ country, selected, onPress, onTitlePress, onHover }: Props) {
+export function CountryCard({ country, selectedYear, selected, onPress, onTitlePress, onHover }: Props) {
   const [hovered, setHovered] = useState(false);
+  const hasHiddenGems = country.hiddenSongs > 0;
+  const noHiddenGemsCopy = selectedYear ? `No Hidden Gems for ${selectedYear}` : "No Hidden Gems for this year";
+  const hasNoSongData = country.album === "Unknown Album" && country.albumArtist === "Unknown Artist";
+  const noSongDataCopy = selectedYear ? `No song data for ${selectedYear}` : "No song data for this year";
 
   return (
     <Pressable
@@ -46,11 +51,18 @@ export function CountryCard({ country, selected, onPress, onTitlePress, onHover 
               <Text style={styles.region}>{country.region}</Text>
             </View>
             <View style={styles.right}>
-              <Text style={styles.detail}>Hidden Songs: {country.hiddenSongs}</Text>
-              <Text style={styles.detail}>Most popular genres: {country.genres.join(", ")}</Text>
               <Text style={styles.detail}>
-                Most popular album: {country.album} by {country.albumArtist}
+                • Hidden Gems:  {hasHiddenGems ? `${country.hiddenSongs}` : noHiddenGemsCopy}
               </Text>
+              <Text style={styles.detail}>• Genre(s):  Genre info coming soon.</Text>
+              <Text style={styles.detail}>• Language(s):  Language info coming soon.</Text>
+              {hasNoSongData ? (
+                <Text style={styles.detail}>• Most popular album:  {noSongDataCopy}</Text>
+              ) : (
+                <Text style={styles.detail}>
+                  • Most popular album:  {country.album} by {country.albumArtist}
+                </Text>
+              )}
             </View>
           </View>
         </LinearGradient>
@@ -88,18 +100,15 @@ const styles = StyleSheet.create({
     borderRadius: 20,
   },
   row: {
-    flexDirection: "row",
-    gap: 18,
-    flexWrap: "wrap",
+    flexDirection: "column",
+    gap: 12,
   },
   left: {
-    minWidth: 170,
     gap: 10,
   },
   right: {
-    flex: 1,
     gap: 10,
-    minWidth: 240,
+    width: "100%",
   },
   countryName: {
     color: colors.textStrong,

--- a/hidden-gem-music-app/src/components/DiscoveryBlurb.tsx
+++ b/hidden-gem-music-app/src/components/DiscoveryBlurb.tsx
@@ -12,8 +12,8 @@ type Props = {
 };
 
 export function DiscoveryBlurb({
-  heading = "This is the Blurb",
-  body = "this is the text inside the blurb that will say things about the page you're on and will guide users through the experience. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+  heading = "Discovery Globe",
+  body = "Welcome to Hidden Gem Music's Discovery Globe. The purpose of this app is to find and display the 'discovery gap' -- What music is most loved in what country, and how far did that country's most loved music spread to be shared and loved by other countries? You can apply either Pre-Selected filters like Your Region vs. The World or The Biggest Crossover Years, or more in All Filters like sorting by region, A-Z or Z-A, and more. Navigate countries using the globe or list. Click a country to view it's detail page and to preview it's hidden songs. Also check out comparison mode to compare two countries, in the navigation above or also at the bottom of each country page.",
 }: Props) {
   return (
     <Panel style={styles.panel}>

--- a/hidden-gem-music-app/src/components/DiscoverySidebarPanels.tsx
+++ b/hidden-gem-music-app/src/components/DiscoverySidebarPanels.tsx
@@ -17,6 +17,7 @@ type Props = {
   onSelectCountry: (countryId: string) => void;
   onOpenCountry: (countryId: string) => void;
   autoScrollSignal?: number;
+  selectedYear?: number;
 };
 
 type ExpandedPanel = "filters" | "list";
@@ -24,7 +25,7 @@ type ExpandedPanel = "filters" | "list";
 const hoverGradient = ["rgba(117,82,107,0.52)", "rgba(108,119,142,0.44)", "rgba(108,119,142,0.36)"] as const;
 const activeGradient = [colors.navGradient, colors.backgroundRaised, colors.backgroundRaised] as const;
 
-export function DiscoverySidebarPanels({ countries, selectedCountryId, onSelectCountry, onOpenCountry, autoScrollSignal }: Props) {
+export function DiscoverySidebarPanels({ countries, selectedCountryId, onSelectCountry, onOpenCountry, autoScrollSignal, selectedYear }: Props) {
   const [expandedPanel, setExpandedPanel] = useState<ExpandedPanel>("filters");
   const [activeFilter, setActiveFilter] = useState<string | null>(null);
   const [hoveredFilter, setHoveredFilter] = useState<string | null>(null);
@@ -183,7 +184,7 @@ export function DiscoverySidebarPanels({ countries, selectedCountryId, onSelectC
 
     const y = positionsRef.current[selectedCountryId];
     if (typeof y === "number") {
-      listScrollRef.current?.scrollTo({ y: Math.max(y - 18, 0), animated: true });
+      listScrollRef.current?.scrollTo({ y: Math.max(y - 18, 0), animated: false });
     }
   }, [autoScrollSignal, expandedPanel]);
 
@@ -231,7 +232,9 @@ export function DiscoverySidebarPanels({ countries, selectedCountryId, onSelectC
         <Pressable style={styles.sectionHeader} onPress={() => handleSectionPress("filters")}>
           <View style={styles.sectionHeaderCopy}>
             <Text style={styles.sectionTitle}>Pre-Selected Filters</Text>
-            <Text style={styles.sectionHelper}>Lorem ipsum dolor{"\n"}sit amet elit magna nunc vel</Text>
+            <Text style={styles.sectionHelper}>
+              Select optional pre-selected filters here and use 'All Filters' button on the globe for more filters.
+            </Text>
           </View>
           <Text style={styles.sectionToggle}>{expandedPanel === "filters" ? "−" : "+"}</Text>
         </Pressable>
@@ -282,7 +285,9 @@ export function DiscoverySidebarPanels({ countries, selectedCountryId, onSelectC
         <Pressable style={styles.sectionHeader} onPress={() => handleSectionPress("list")}>
           <View style={styles.sectionHeaderCopy}>
             <Text style={styles.sectionTitle}>List View</Text>
-            <Text style={styles.sectionHelper}>Lorem ipsum dolor{"\n"}sit amet elit magna nunc vel</Text>
+            <Text style={styles.sectionHelper}>
+              Click a country to view its detail page and hear previews of hidden gem songs.
+            </Text>
           </View>
           <Text style={styles.sectionToggle}>{expandedPanel === "list" ? "−" : "+"}</Text>
         </Pressable>
@@ -308,6 +313,7 @@ export function DiscoverySidebarPanels({ countries, selectedCountryId, onSelectC
                 >
                   <CountryCard
                     country={country}
+                    selectedYear={selectedYear}
                     selected={country.id === selectedCountryId}
                     onHover={() => onSelectCountry(country.id)}
                     onTitlePress={() => onOpenCountry(country.id)}
@@ -392,7 +398,7 @@ const styles = StyleSheet.create({
     fontSize: 14,
     lineHeight: 16,
     textAlign: "right",
-    maxWidth: 176,
+    maxWidth: 220,
   },
   sectionToggle: {
     color: colors.textStrong,

--- a/hidden-gem-music-app/src/components/globe/GlobePanel.tsx
+++ b/hidden-gem-music-app/src/components/globe/GlobePanel.tsx
@@ -12,6 +12,7 @@ import { GlobeView } from "./GlobeView";
 type Props = {
   countries: Country[];
   activeCountryId?: string;
+  selectedYear?: number;
   onSelectCountry: (countryId: string) => void;
   onOpenCountry?: (countryId: string) => void;
   title: string;
@@ -26,6 +27,7 @@ type Props = {
 export function GlobePanel({
   countries,
   activeCountryId,
+  selectedYear,
   onSelectCountry,
   onOpenCountry,
   title,
@@ -55,6 +57,7 @@ export function GlobePanel({
         <GlobeView
           countries={countries}
           activeCountry={activeCountry}
+          selectedYear={selectedYear}
           onSelectCountry={onSelectCountry}
           onOpenCountry={onOpenCountry}
           selectOnHover={selectOnHover}

--- a/hidden-gem-music-app/src/components/globe/GlobeView.native.tsx
+++ b/hidden-gem-music-app/src/components/globe/GlobeView.native.tsx
@@ -7,12 +7,17 @@ import { typefaces } from "../../theme/typography";
 type Props = {
   countries: Country[];
   activeCountry?: Country;
+  selectedYear?: number;
   onSelectCountry: (countryId: string) => void;
   onOpenCountry?: (countryId: string) => void;
 };
 
-export function GlobeView({ countries, activeCountry, onSelectCountry, onOpenCountry }: Props) {
+export function GlobeView({ countries, activeCountry, selectedYear, onSelectCountry, onOpenCountry }: Props) {
   const currentCountry = activeCountry ?? countries[0];
+  const hasHiddenGems = (currentCountry?.hiddenSongs ?? 0) > 0;
+  const noHiddenGemsCopy = selectedYear ? `No Hidden Gems for ${selectedYear}` : "No Hidden Gems for this year";
+  const hasNoSongData = currentCountry ? currentCountry.album === "Unknown Album" && currentCountry.albumArtist === "Unknown Artist" : false;
+  const noSongDataCopy = selectedYear ? `No song data for ${selectedYear}` : "No song data for this year";
 
   return (
     <View style={styles.wrapper}>
@@ -54,8 +59,17 @@ export function GlobeView({ countries, activeCountry, onSelectCountry, onOpenCou
             </View>
             <View style={styles.tooltipDivider} />
             <View style={styles.tooltipBody}>
-              <Text style={styles.tooltipCopy}>Hidden Songs: {currentCountry.hiddenSongs}</Text>
+              <Text style={styles.tooltipCopy}>
+                Hidden Gems: {hasHiddenGems ? `${currentCountry.hiddenSongs}` : noHiddenGemsCopy}
+              </Text>
               <Text style={styles.tooltipCopy}>Genres: {currentCountry.genres.join(", ")}</Text>
+              {hasNoSongData ? (
+                <Text style={styles.tooltipCopy}>Most Popular Album: {noSongDataCopy}</Text>
+              ) : (
+                <Text style={styles.tooltipCopy}>
+                  Most Popular Album: {currentCountry.album} by {currentCountry.albumArtist}
+                </Text>
+              )}
             </View>
           </View>
         </Pressable>

--- a/hidden-gem-music-app/src/components/globe/GlobeView.tsx
+++ b/hidden-gem-music-app/src/components/globe/GlobeView.tsx
@@ -7,6 +7,7 @@ import { GlobeView as WebGlobeView } from "./GlobeView.web";
 type Props = {
   countries: Country[];
   activeCountry?: Country;
+  selectedYear?: number;
   onSelectCountry: (countryId: string) => void;
   onOpenCountry?: (countryId: string) => void;
   selectOnHover?: boolean;

--- a/hidden-gem-music-app/src/components/globe/GlobeView.web.tsx
+++ b/hidden-gem-music-app/src/components/globe/GlobeView.web.tsx
@@ -9,12 +9,13 @@ import { typefaces } from "../../theme/typography";
 type Props = {
   countries: Country[];
   activeCountry?: Country;
+  selectedYear?: number;
   onSelectCountry: (countryId: string) => void;
   onOpenCountry?: (countryId: string) => void;
   selectOnHover?: boolean;
 };
 
-export function GlobeView({ countries, activeCountry, onSelectCountry, onOpenCountry, selectOnHover = true }: Props) {
+export function GlobeView({ countries, activeCountry, selectedYear, onSelectCountry, onOpenCountry, selectOnHover = true }: Props) {
   const { width } = useWindowDimensions();
   const [hoveredCountryId, setHoveredCountryId] = useState<string | null>(null);
   const hoverTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -42,6 +43,10 @@ export function GlobeView({ countries, activeCountry, onSelectCountry, onOpenCou
   const connectorDy = tooltipAnchorY - markerY;
   const connectorLength = Math.sqrt(connectorDx * connectorDx + connectorDy * connectorDy);
   const connectorAngle = `${Math.atan2(connectorDy, connectorDx)}rad`;
+  const hasHiddenGems = (hoveredCountry?.hiddenSongs ?? 0) > 0;
+  const noHiddenGemsCopy = selectedYear ? `No Hidden Gems for ${selectedYear}` : "No Hidden Gems for this year";
+  const hasNoSongData = hoveredCountry ? hoveredCountry.album === "Unknown Album" && hoveredCountry.albumArtist === "Unknown Artist" : false;
+  const noSongDataCopy = selectedYear ? `No song data for ${selectedYear}` : "No song data for this year";
 
   return (
     <View style={styles.globeArea}>
@@ -137,11 +142,18 @@ export function GlobeView({ countries, activeCountry, onSelectCountry, onOpenCou
                   </View>
                   <View style={styles.tooltipDivider} />
                   <View style={styles.tooltipBody}>
-                    <Text style={styles.tooltipCopy}>Hidden Songs: {hoveredCountry.hiddenSongs}</Text>
-                    <Text style={styles.tooltipCopy}>Most Popular Genres: {hoveredCountry.genres.join(", ")}</Text>
                     <Text style={styles.tooltipCopy}>
-                      Most Popular Album: {hoveredCountry.album} by {hoveredCountry.albumArtist}
+                      Hidden Gems: {hasHiddenGems ? `${hoveredCountry.hiddenSongs}` : noHiddenGemsCopy}
                     </Text>
+                    <Text style={styles.tooltipCopy}>Genre(s): Genre info coming soon.</Text>
+                    <Text style={styles.tooltipCopy}>Language(s): Language info coming soon.</Text>
+                    {hasNoSongData ? (
+                      <Text style={styles.tooltipCopy}>Most Popular Album: {noSongDataCopy}</Text>
+                    ) : (
+                      <Text style={styles.tooltipCopy}>
+                        Most Popular Album: {hoveredCountry.album} by {hoveredCountry.albumArtist}
+                      </Text>
+                    )}
                   </View>
                 </View>
               </Pressable>

--- a/hidden-gem-music-app/src/data/apiMappers.ts
+++ b/hidden-gem-music-app/src/data/apiMappers.ts
@@ -65,10 +65,12 @@ export type UiHiddenGemPage = {
 export type UiCountryGlobeSummary = {
   countryCode: string;
   countryName: string;
+  region: string;
   lat: number;
   long: number;
   hiddenSongs: number;
   topAlbum: string;
+  topArtist: string;
 };
 
 const toNonEmpty = (value: string | null | undefined, fallback: string) => {
@@ -136,8 +138,10 @@ export const mapApiHiddenGemPage = (response: ApiHiddenGemResponse): UiHiddenGem
 export const mapApiCountryGlobeSummary = (item: ApiCountryGlobeSummary): UiCountryGlobeSummary => ({
   countryCode: toNonEmpty(item.countryCode, ""),
   countryName: toNonEmpty(item.countryName, "Unknown Country"),
+  region: toNonEmpty(item.region, "Continent info coming soon."),
   lat: item.lat,
   long: item.long,
   hiddenSongs: item.hiddenGemCount,
   topAlbum: toNonEmpty(item.topAlbumName, "Unknown Album"),
+  topArtist: toNonEmpty(item.topArtistName, "Unknown Artist"),
 });

--- a/hidden-gem-music-app/src/data/discoveryApi.ts
+++ b/hidden-gem-music-app/src/data/discoveryApi.ts
@@ -1,0 +1,81 @@
+import type { Country } from "../types/content";
+import { mapApiCountryGlobeSummary } from "./apiMappers";
+import type { ApiCountryGlobeSummary } from "../types/api";
+
+const DEFAULT_API_BASE_URL = "http://localhost:5140";
+
+function getApiBaseUrl() {
+  const configuredBaseUrl = process.env.EXPO_PUBLIC_API_BASE_URL?.trim();
+  return configuredBaseUrl && configuredBaseUrl.length > 0 ? configuredBaseUrl : DEFAULT_API_BASE_URL;
+}
+
+export async function loadDiscoveryCountries(year: number, fallbackCountries: Country[]): Promise<Country[]> {
+  const existingByCode = new Map(fallbackCountries.map((country) => [country.code.toUpperCase(), country]));
+  const baseUrl = getApiBaseUrl().replace(/\/$/, "");
+  const endpoint = `${baseUrl}/api/discovery/countries?year=${year}`;
+  const response = await fetch(endpoint);
+
+  if (!response.ok) {
+    throw new Error(`Discovery country request failed with status ${response.status}.`);
+  }
+
+  const payload = ((await response.json()) as unknown[]).map((item) => {
+    const row = item as Record<string, unknown>;
+    const hiddenGemCountRaw =
+      row.hiddenGemCount ??
+      row.HiddenGemCount ??
+      row.hidden_gem_count ??
+      row.hiddenSongCount ??
+      row.hidden_song_count ??
+      row.hiddenSongs ??
+      0;
+    const topAlbumNameRaw =
+      row.topAlbumName ??
+      row.TopAlbumName ??
+      row.top_album_name ??
+      row.albumName ??
+      row.album_name ??
+      null;
+    const topArtistNameRaw =
+      row.topArtistName ??
+      row.TopArtistName ??
+      row.top_artist_name ??
+      row.artistName ??
+      row.artist_name ??
+      null;
+
+    return {
+      countryCode: (row.countryCode ?? row.CountryCode ?? row.country_code ?? "") as string | null,
+      countryName: (row.countryName ?? row.CountryName ?? row.country_name ?? "") as string | null,
+      region: (row.region ?? row.Region ?? null) as string | null,
+      lat: Number(row.lat ?? row.Lat ?? row.latitude ?? row.Latitude ?? 0),
+      long: Number(row.long ?? row.Long ?? row.longitude ?? row.Longitude ?? 0),
+      hiddenGemCount: Number(hiddenGemCountRaw),
+      topAlbumName: topAlbumNameRaw as string | null,
+      topArtistName: topArtistNameRaw as string | null,
+    } satisfies ApiCountryGlobeSummary;
+  });
+
+  return payload.map((item, index) => {
+    const mapped = mapApiCountryGlobeSummary(item);
+    const normalizedCode = mapped.countryCode.toUpperCase();
+    const existing = existingByCode.get(normalizedCode);
+
+    return {
+      id: existing?.id ?? `iso-${normalizedCode.toLowerCase() || index}`,
+      code: normalizedCode,
+      name: mapped.countryName,
+      region: mapped.region,
+      hiddenSongs: mapped.hiddenSongs,
+      genres: existing?.genres?.length ? existing.genres : ["Unknown"],
+      album: mapped.topAlbum,
+      albumArtist: mapped.topArtist,
+      topSong: existing?.topSong ?? "Unknown Song",
+      languages: existing?.languages?.length ? existing.languages : ["Unknown"],
+      sceneNote: existing?.sceneNote ?? "Discovery details will expand as country profile data is connected.",
+      featuredArtists: existing?.featuredArtists ?? [],
+      markerTop: existing?.markerTop ?? "-20%",
+      markerLeft: existing?.markerLeft ?? "-20%",
+    };
+  });
+}

--- a/hidden-gem-music-app/src/screens/DiscoveryScreen.web.tsx
+++ b/hidden-gem-music-app/src/screens/DiscoveryScreen.web.tsx
@@ -1,13 +1,15 @@
 import { LinearGradient } from "expo-linear-gradient";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Platform, Pressable, ScrollView, StyleSheet, Text, useWindowDimensions, View, ViewStyle } from "react-native";
 
 import { Country } from "../types/content";
 import { DiscoveryBlurb } from "../components/DiscoveryBlurb";
 import { DiscoverySidebarPanels } from "../components/DiscoverySidebarPanels";
+import { GemIcon } from "../components/GemIcon";
 import { GlobePanel } from "../components/globe/GlobePanel";
 import { Panel } from "../components/Panel";
 import { ScreenScaffold } from "../components/ScreenScaffold";
+import { SecondarySurfaceFill } from "../components/SecondarySurfaceFill";
 import { YearSlider } from "../components/YearSlider";
 import { colors } from "../theme/colors";
 import { typefaces } from "../theme/typography";
@@ -19,6 +21,18 @@ export type Props = {
   onOpenCountry: (countryId: string) => void;
   selectedYear: number;
   onChangeYear: (year: number) => void;
+};
+
+type SortOption = "a-z" | "z-a" | "gems-desc" | "gems-asc";
+const activeGradient = [colors.navGradient, colors.backgroundRaised, colors.backgroundRaised] as const;
+const normalizeContinent = (region: string) => {
+  if (region === "Continent info coming soon.") {
+    return "Unknown / Missing";
+  }
+  if (region === "Other") {
+    return "Other / Territories";
+  }
+  return region;
 };
 
 export function DiscoveryScreen({
@@ -35,6 +49,60 @@ export function DiscoveryScreen({
   const isStacked = width < 980;
   const [allFiltersOpen, setAllFiltersOpen] = useState(false);
   const [listAutoScrollSignal, setListAutoScrollSignal] = useState(0);
+  const [sortOption, setSortOption] = useState<SortOption | null>(null);
+  const [selectedContinents, setSelectedContinents] = useState<string[]>([]);
+  const [onlyWithHiddenGems, setOnlyWithHiddenGems] = useState(true);
+  const [onlyWithoutHiddenGems, setOnlyWithoutHiddenGems] = useState(false);
+  const [isCloseHovered, setIsCloseHovered] = useState(false);
+  const [isClosePressed, setIsClosePressed] = useState(false);
+
+  const continentOptions = useMemo(() => {
+    const continents = Array.from(
+      new Set(countries.map((country) => normalizeContinent(country.region)).filter(Boolean))
+    ).sort((a, b) =>
+      a.localeCompare(b)
+    );
+    return ["all", ...continents];
+  }, [countries]);
+
+  const filteredCountries = useMemo(() => {
+    let next = [...countries];
+
+    if (selectedContinents.length > 0) {
+      const continentSet = new Set(selectedContinents);
+      next = next.filter((country) => continentSet.has(normalizeContinent(country.region)));
+    }
+
+    if (onlyWithHiddenGems) {
+      next = next.filter((country) => country.hiddenSongs > 0);
+    }
+    if (onlyWithoutHiddenGems) {
+      next = next.filter((country) => country.hiddenSongs <= 0);
+    }
+
+    if (sortOption) {
+      next.sort((a, b) => {
+        switch (sortOption) {
+          case "a-z":
+            return a.name.localeCompare(b.name);
+          case "z-a":
+            return b.name.localeCompare(a.name);
+          case "gems-desc":
+            return b.hiddenSongs - a.hiddenSongs || a.name.localeCompare(b.name);
+          case "gems-asc":
+            return a.hiddenSongs - b.hiddenSongs || a.name.localeCompare(b.name);
+          default:
+            return 0;
+        }
+      });
+    }
+
+    return next;
+  }, [countries, onlyWithHiddenGems, onlyWithoutHiddenGems, selectedContinents, sortOption]);
+
+  const visibleSelectedCountryId = filteredCountries.some((country) => country.id === selectedCountryId)
+    ? selectedCountryId
+    : filteredCountries[0]?.id ?? selectedCountryId;
 
   const handleGlobeFocus = (countryId: string) => {
     onSelectCountry(countryId);
@@ -44,8 +112,9 @@ export function DiscoveryScreen({
   const listColumn = (
     <View style={[styles.leftColumn, isStacked ? styles.columnStacked : null]}>
       <DiscoverySidebarPanels
-        countries={countries}
-        selectedCountryId={selectedCountryId}
+        countries={filteredCountries}
+        selectedYear={selectedYear}
+        selectedCountryId={visibleSelectedCountryId}
         onSelectCountry={onSelectCountry}
         onOpenCountry={onOpenCountry}
         autoScrollSignal={listAutoScrollSignal}
@@ -56,8 +125,9 @@ export function DiscoveryScreen({
   const globeColumn = (
     <View style={[styles.rightColumn, isStacked ? styles.columnStacked : null]}>
       <GlobePanel
-        countries={countries}
-        activeCountryId={selectedCountryId}
+        countries={filteredCountries}
+        activeCountryId={visibleSelectedCountryId}
+        selectedYear={selectedYear}
         onSelectCountry={handleGlobeFocus}
         onOpenCountry={onOpenCountry}
         title="Globe View"
@@ -125,10 +195,180 @@ export function DiscoveryScreen({
           <Panel style={styles.modal}>
             <View style={styles.modalHeader}>
               <Text style={styles.modalTitle}>All Filters</Text>
-              <Pressable onPress={() => setAllFiltersOpen(false)}>
-                <Text style={styles.modalClose}>Close</Text>
+              <Pressable
+                onPress={() => setAllFiltersOpen(false)}
+                onHoverIn={() => setIsCloseHovered(true)}
+                onHoverOut={() => setIsCloseHovered(false)}
+                onPressIn={() => setIsClosePressed(true)}
+                onPressOut={() => setIsClosePressed(false)}
+                style={styles.closeButtonShell}
+              >
+                {isCloseHovered || isClosePressed ? (
+                  <LinearGradient
+                    colors={isClosePressed ? activeGradient : ["rgba(117,82,107,0.52)", "rgba(108,119,142,0.44)", "rgba(108,119,142,0.36)"]}
+                    locations={[0, 0.34, 1]}
+                    start={{ x: 0, y: 0.5 }}
+                    end={{ x: 1, y: 0.5 }}
+                    style={styles.closeButtonGradient}
+                  />
+                ) : null}
+                <View style={[styles.closeButton, isCloseHovered || isClosePressed ? styles.closeButtonActive : null]}>
+                  <Text style={[styles.closeButtonText, isCloseHovered || isClosePressed ? styles.closeButtonTextActive : null]}>
+                    Close
+                  </Text>
+                </View>
               </Pressable>
             </View>
+            <ScrollView
+              style={styles.modalScroll}
+              contentContainerStyle={styles.filtersPanelStack}
+              showsVerticalScrollIndicator={false}
+            >
+              <Panel style={styles.filterSection}>
+                <SecondarySurfaceFill />
+                <Text style={styles.filterSectionTitle}>Sort By</Text>
+                <View style={styles.optionGroup}>
+                  <Pressable style={styles.filterButtonShell} onPress={() => setSortOption((current) => (current === "a-z" ? null : "a-z"))}>
+                    {sortOption === "a-z" ? <LinearGradient colors={activeGradient} locations={[0, 0.34, 1]} start={{ x: 0, y: 0.5 }} end={{ x: 1, y: 0.5 }} style={styles.filterButtonGradient} /> : null}
+                    <View style={[styles.filterButton, sortOption === "a-z" ? styles.filterButtonActive : null]}>
+                      <View style={styles.filterButtonContent}>
+                        <View style={styles.filterButtonLead}>
+                          <GemIcon size={16} />
+                          <Text style={[styles.filterButtonText, sortOption === "a-z" ? styles.filterButtonTextActive : null]}>A--Z</Text>
+                        </View>
+                      </View>
+                    </View>
+                  </Pressable>
+                  <Pressable style={styles.filterButtonShell} onPress={() => setSortOption((current) => (current === "z-a" ? null : "z-a"))}>
+                    {sortOption === "z-a" ? <LinearGradient colors={activeGradient} locations={[0, 0.34, 1]} start={{ x: 0, y: 0.5 }} end={{ x: 1, y: 0.5 }} style={styles.filterButtonGradient} /> : null}
+                    <View style={[styles.filterButton, sortOption === "z-a" ? styles.filterButtonActive : null]}>
+                      <View style={styles.filterButtonContent}>
+                        <View style={styles.filterButtonLead}>
+                          <GemIcon size={16} />
+                          <Text style={[styles.filterButtonText, sortOption === "z-a" ? styles.filterButtonTextActive : null]}>Z--A</Text>
+                        </View>
+                      </View>
+                    </View>
+                  </Pressable>
+                  <Pressable style={styles.filterButtonShell} onPress={() => setSortOption((current) => (current === "gems-desc" ? null : "gems-desc"))}>
+                    {sortOption === "gems-desc" ? <LinearGradient colors={activeGradient} locations={[0, 0.34, 1]} start={{ x: 0, y: 0.5 }} end={{ x: 1, y: 0.5 }} style={styles.filterButtonGradient} /> : null}
+                    <View style={[styles.filterButton, sortOption === "gems-desc" ? styles.filterButtonActive : null]}>
+                      <View style={styles.filterButtonContent}>
+                        <View style={styles.filterButtonLead}>
+                          <GemIcon size={16} />
+                          <Text style={[styles.filterButtonText, sortOption === "gems-desc" ? styles.filterButtonTextActive : null]}>
+                            Most Hidden Gems to Least
+                          </Text>
+                        </View>
+                      </View>
+                    </View>
+                  </Pressable>
+                  <Pressable style={styles.filterButtonShell} onPress={() => setSortOption((current) => (current === "gems-asc" ? null : "gems-asc"))}>
+                    {sortOption === "gems-asc" ? <LinearGradient colors={activeGradient} locations={[0, 0.34, 1]} start={{ x: 0, y: 0.5 }} end={{ x: 1, y: 0.5 }} style={styles.filterButtonGradient} /> : null}
+                    <View style={[styles.filterButton, sortOption === "gems-asc" ? styles.filterButtonActive : null]}>
+                      <View style={styles.filterButtonContent}>
+                        <View style={styles.filterButtonLead}>
+                          <GemIcon size={16} />
+                          <Text style={[styles.filterButtonText, sortOption === "gems-asc" ? styles.filterButtonTextActive : null]}>
+                            Least Hidden Gems to Most
+                          </Text>
+                        </View>
+                      </View>
+                    </View>
+                  </Pressable>
+                  <Pressable
+                    style={styles.filterButtonShell}
+                    onPress={() =>
+                      setOnlyWithHiddenGems((current) => {
+                        const next = !current;
+                        if (next) {
+                          setOnlyWithoutHiddenGems(false);
+                        }
+                        return next;
+                      })
+                    }
+                  >
+                    {onlyWithHiddenGems ? <LinearGradient colors={activeGradient} locations={[0, 0.34, 1]} start={{ x: 0, y: 0.5 }} end={{ x: 1, y: 0.5 }} style={styles.filterButtonGradient} /> : null}
+                    <View style={[styles.filterButton, onlyWithHiddenGems ? styles.filterButtonActive : null]}>
+                      <View style={styles.filterButtonContent}>
+                        <View style={styles.filterButtonLead}>
+                          <GemIcon size={16} />
+                          <Text style={[styles.filterButtonText, onlyWithHiddenGems ? styles.filterButtonTextActive : null]}>
+                            Only Show Countries with Hidden Gems
+                          </Text>
+                        </View>
+                      </View>
+                    </View>
+                  </Pressable>
+                  <Pressable
+                    style={styles.filterButtonShell}
+                    onPress={() =>
+                      setOnlyWithoutHiddenGems((current) => {
+                        const next = !current;
+                        if (next) {
+                          setOnlyWithHiddenGems(false);
+                        }
+                        return next;
+                      })
+                    }
+                  >
+                    {onlyWithoutHiddenGems ? <LinearGradient colors={activeGradient} locations={[0, 0.34, 1]} start={{ x: 0, y: 0.5 }} end={{ x: 1, y: 0.5 }} style={styles.filterButtonGradient} /> : null}
+                    <View style={[styles.filterButton, onlyWithoutHiddenGems ? styles.filterButtonActive : null]}>
+                      <View style={styles.filterButtonContent}>
+                        <View style={styles.filterButtonLead}>
+                          <GemIcon size={16} />
+                          <Text style={[styles.filterButtonText, onlyWithoutHiddenGems ? styles.filterButtonTextActive : null]}>
+                            Show Countries Without Hidden Gems
+                          </Text>
+                        </View>
+                      </View>
+                    </View>
+                  </Pressable>
+                </View>
+              </Panel>
+
+              <Panel style={styles.filterSection}>
+                <SecondarySurfaceFill />
+                <Text style={styles.filterSectionTitle}>Continent</Text>
+                <View style={styles.optionGroup}>
+                  {continentOptions.map((continentOption) => {
+                    const isActive =
+                      continentOption === "all"
+                        ? selectedContinents.length === 0
+                        : selectedContinents.includes(continentOption);
+                    const label = continentOption === "all" ? "All Continents" : continentOption;
+                    return (
+                      <Pressable
+                        key={continentOption}
+                        style={styles.filterButtonShell}
+                        onPress={() => {
+                          if (continentOption === "all") {
+                            setSelectedContinents([]);
+                            return;
+                          }
+
+                          setSelectedContinents((current) =>
+                            current.includes(continentOption)
+                              ? current.filter((continent) => continent !== continentOption)
+                              : [...current, continentOption]
+                          );
+                        }}
+                      >
+                        {isActive ? <LinearGradient colors={activeGradient} locations={[0, 0.34, 1]} start={{ x: 0, y: 0.5 }} end={{ x: 1, y: 0.5 }} style={styles.filterButtonGradient} /> : null}
+                        <View style={[styles.filterButton, isActive ? styles.filterButtonActive : null]}>
+                          <View style={styles.filterButtonContent}>
+                            <View style={styles.filterButtonLead}>
+                              <GemIcon size={16} />
+                              <Text style={[styles.filterButtonText, isActive ? styles.filterButtonTextActive : null]}>{label}</Text>
+                            </View>
+                          </View>
+                        </View>
+                      </Pressable>
+                    );
+                  })}
+                </View>
+              </Panel>
+            </ScrollView>
           </Panel>
         </View>
       ) : null}
@@ -197,11 +437,16 @@ const styles = StyleSheet.create({
   },
   modal: {
     width: "100%",
-    maxWidth: 760,
-    minHeight: 360,
-    paddingVertical: 32,
-    paddingHorizontal: 24,
+    maxWidth: 660,
+    maxHeight: "82%",
+    paddingVertical: 18,
+    paddingHorizontal: 16,
     backgroundColor: colors.panel,
+    gap: 12,
+    borderRadius: 20,
+    borderWidth: 2,
+    borderColor: "rgba(169, 176, 209, 0.24)",
+    overflow: "hidden",
   },
   modalHeader: {
     flexDirection: "row",
@@ -212,12 +457,115 @@ const styles = StyleSheet.create({
   modalTitle: {
     color: colors.textStrong,
     fontFamily: typefaces.display,
-    fontSize: 48,
+    fontSize: 30,
     fontWeight: "700",
   },
-  modalClose: {
-    color: colors.accent,
-    fontFamily: typefaces.body,
+  closeButtonShell: {
+    borderRadius: 12,
+    overflow: "hidden",
+  },
+  closeButtonGradient: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  closeButton: {
+    minHeight: 42,
+    minWidth: 110,
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 12,
+    borderWidth: 2,
+    borderColor: colors.border,
+    backgroundColor: colors.button,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  closeButtonActive: {
+    backgroundColor: "transparent",
+  },
+  closeButtonText: {
+    color: colors.border,
+    fontFamily: typefaces.condensed,
     fontSize: 18,
+    fontWeight: "700",
+    lineHeight: 20,
+  },
+  closeButtonTextActive: {
+    color: colors.text,
+  },
+  modalScroll: {
+    flex: 1,
+    minHeight: 0,
+  },
+  filtersPanelStack: {
+    gap: 14,
+    paddingBottom: 8,
+  },
+  filterSection: {
+    backgroundColor: "transparent",
+    paddingVertical: 14,
+    paddingHorizontal: 14,
+    gap: 12,
+    borderRadius: 16,
+    overflow: "hidden",
+    borderWidth: 1,
+    borderColor: "rgba(169, 176, 209, 0.18)",
+  },
+  filterSectionTitle: {
+    color: colors.textStrong,
+    fontFamily: typefaces.display,
+    fontSize: 22,
+  },
+  optionGroup: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 10,
+    alignItems: "flex-start",
+  },
+  filterButtonShell: {
+    position: "relative",
+    borderRadius: 12,
+    overflow: "hidden",
+    alignSelf: "flex-start",
+    maxWidth: "100%",
+  },
+  filterButtonGradient: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  filterButton: {
+    minHeight: 44,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 12,
+    borderWidth: 2,
+    borderColor: colors.border,
+    backgroundColor: colors.button,
+    justifyContent: "center",
+  },
+  filterButtonActive: {
+    backgroundColor: "transparent",
+  },
+  filterButtonContent: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 10,
+  },
+  filterButtonLead: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    minWidth: 0,
+    flexShrink: 1,
+  },
+  filterButtonText: {
+    color: colors.border,
+    fontFamily: typefaces.body,
+    fontSize: 15,
+    lineHeight: 18,
+    textAlign: "left",
+    flexShrink: 1,
+  },
+  filterButtonTextActive: {
+    color: colors.text,
   },
 });

--- a/hidden-gem-music-app/src/screens/WelcomeScreen.web.tsx
+++ b/hidden-gem-music-app/src/screens/WelcomeScreen.web.tsx
@@ -1,6 +1,6 @@
 import { LinearGradient } from "expo-linear-gradient";
 import { useState } from "react";
-import { StyleSheet, Text, useWindowDimensions, View } from "react-native";
+import { Pressable, StyleSheet, Text, useWindowDimensions, View } from "react-native";
 
 import { Country } from "../types/content";
 import { ActionButton } from "../components/ActionButton";
@@ -26,11 +26,13 @@ export function WelcomeScreen({ countries, onNavigate, onSelectCountry, selected
   const previewCountries = countries.slice(0, 5);
   const { width } = useWindowDimensions();
   const isStacked = width < 980;
+  const [isWelcomeModalVisible, setIsWelcomeModalVisible] = useState(true);
 
   const listColumn = (
     <View style={[styles.leftColumn, isStacked ? styles.columnStacked : null]}>
       <DiscoverySidebarPanels
         countries={previewCountries}
+        selectedYear={selectedYear}
         selectedCountryId={previewCountries[0]?.id}
         onSelectCountry={onSelectCountry}
         onOpenCountry={onSelectCountry}
@@ -43,6 +45,7 @@ export function WelcomeScreen({ countries, onNavigate, onSelectCountry, selected
       <GlobePanel
         countries={countries}
         activeCountryId={countries[0].id}
+        selectedYear={selectedYear}
         onSelectCountry={onSelectCountry}
         onOpenCountry={onSelectCountry}
         title="Globe View"
@@ -62,41 +65,45 @@ export function WelcomeScreen({ countries, onNavigate, onSelectCountry, selected
         </View>
       </View>
 
-      <View style={styles.overlay}>
-        <View style={styles.overlayGradientWrap}>
-          <LinearGradient
-            colors={["rgba(22,26,38,0.62)", "rgba(22,26,38,0.36)", "rgba(66,72,101,0.18)"]}
-            start={{ x: 0.5, y: 0 }}
-            end={{ x: 0.5, y: 1 }}
-            style={styles.overlayGradient}
-          />
-          <LinearGradient
-            colors={["rgba(117,82,107,0.16)", "rgba(117,82,107,0.05)", "rgba(117,82,107,0.00)"]}
-            start={{ x: 0.0, y: 0.04 }}
-            end={{ x: 1.0, y: 0.72 }}
-            style={styles.overlayGradient}
-          />
-          <LinearGradient
-            colors={["rgba(108,119,142,0.16)", "rgba(108,119,142,0.05)", "rgba(108,119,142,0.00)"]}
-            start={{ x: 1.0, y: 0.0 }}
-            end={{ x: 0.08, y: 0.94 }}
-            style={styles.overlayGradient}
-          />
-        </View>
-        <Panel style={styles.modal}>
-          <Text style={styles.brand}>Hidden Gem Music</Text>
-          <Text style={styles.summary}>
-            Insert somewhat long text about the project and the problem and the solution
-          </Text>
-          <View style={styles.buttonStack}>
-            <ActionButton label="Discovery Globe" size="compact" onPress={() => onNavigate("discovery")} />
-            <ActionButton label="Comparison Mode" size="compact" onPress={() => onNavigate("comparisonSelect")} />
-            <ActionButton label="Hidden Songs" size="compact" onPress={() => onNavigate("hiddenGems")} />
-            <ActionButton label="Dashboard" size="compact" onPress={() => onNavigate("dashboard")} />
-            <ActionButton label="Credits" size="compact" onPress={() => onNavigate("credits")} />
+      {isWelcomeModalVisible ? (
+        <Pressable style={styles.overlay} onPress={() => setIsWelcomeModalVisible(false)}>
+          <View style={styles.overlayGradientWrap}>
+            <LinearGradient
+              colors={["rgba(22,26,38,0.62)", "rgba(22,26,38,0.36)", "rgba(66,72,101,0.18)"]}
+              start={{ x: 0.5, y: 0 }}
+              end={{ x: 0.5, y: 1 }}
+              style={styles.overlayGradient}
+            />
+            <LinearGradient
+              colors={["rgba(117,82,107,0.16)", "rgba(117,82,107,0.05)", "rgba(117,82,107,0.00)"]}
+              start={{ x: 0.0, y: 0.04 }}
+              end={{ x: 1.0, y: 0.72 }}
+              style={styles.overlayGradient}
+            />
+            <LinearGradient
+              colors={["rgba(108,119,142,0.16)", "rgba(108,119,142,0.05)", "rgba(108,119,142,0.00)"]}
+              start={{ x: 1.0, y: 0.0 }}
+              end={{ x: 0.08, y: 0.94 }}
+              style={styles.overlayGradient}
+            />
           </View>
-        </Panel>
-      </View>
+          <Pressable style={styles.modalPressTarget} onPress={(event) => event.stopPropagation()}>
+            <Panel style={styles.modal}>
+              <Text style={styles.brand}>Hidden Gem Music</Text>
+              <Text style={styles.summary}>
+                Insert somewhat long text about the project and the problem and the solution
+              </Text>
+              <View style={styles.buttonStack}>
+                <ActionButton label="Discovery Globe" size="compact" onPress={() => onNavigate("discovery")} />
+                <ActionButton label="Comparison Mode" size="compact" onPress={() => onNavigate("comparisonSelect")} />
+                <ActionButton label="Hidden Gems" size="compact" onPress={() => onNavigate("hiddenGems")} />
+                <ActionButton label="Dashboard" size="compact" onPress={() => onNavigate("dashboard")} />
+                <ActionButton label="Credits" size="compact" onPress={() => onNavigate("credits")} />
+              </View>
+            </Panel>
+          </Pressable>
+        </Pressable>
+      ) : null}
     </ScreenScaffold>
   );
 }
@@ -149,6 +156,10 @@ const styles = StyleSheet.create({
     paddingHorizontal: 24,
     backgroundColor: colors.panel,
     gap: 22,
+  },
+  modalPressTarget: {
+    width: "100%",
+    maxWidth: 760,
   },
   brand: {
     color: colors.textStrong,

--- a/hidden-gem-music-app/src/types/api.ts
+++ b/hidden-gem-music-app/src/types/api.ts
@@ -59,8 +59,10 @@ export type ApiHiddenGemResponse = {
 export type ApiCountryGlobeSummary = {
   countryCode: string | null;
   countryName: string | null;
+  region: string | null;
   lat: number;
   long: number;
   hiddenGemCount: number;
   topAlbumName: string | null;
+  topArtistName: string | null;
 };


### PR DESCRIPTION
## Summary

This PR implements Discovery Globe screen data integration and UI completion work, including:

- Shared Discovery countries endpoint wiring for globe + list
- Discovery filters popup completion (functional sorting/filtering)
- Discovery copy/layout interaction refinements
- DB procedure contract update required for Discovery country payload

This PR is near-complete for Discovery Globe. The only intentionally non-functional area is **Pre-Selected Filters logic**, which needs team alignment on expected backend behavior before final endpoint implementation.

### Work Performed:

#### 1) Moved Discovery screen country data to API-backed flow
Updated frontend to load Discovery countries from backend by year and drive both list + globe from the same filtered dataset.

- Added Discovery data loader and mapping normalization:
  - `hidden-gem-music-app/src/data/discoveryApi.ts`
  - `hidden-gem-music-app/src/types/api.ts`
  - `hidden-gem-music-app/src/data/apiMappers.ts`
- App wiring updated so Discovery screen consumes API countries by selected year:
  - `hidden-gem-music-app/App.tsx`

#### 2) Added Discovery-specific backend route + model/repository contract updates
Implemented a Discovery route for shared country payload needs.

- Added controller route:
  - `GET /api/discovery/countries?year={year}`
  - `backend/Capstone.API/Controllers/DiscoveryController.cs`
- Updated model/repository mapping to include Discovery fields needed by UI:
  - `Region`
  - `TopArtistName`
  - alias/casing-safe row key mapping
  - files:
    - `backend/Capstone.API/Models/Globe/CountryGlobeSummary.cs`
    - `backend/Capstone.API/Infrastructure/Repositories/GlobeRepository.cs`

#### 3) Updated Discovery SQL contract naming and procedure source
Renamed procedure source file and switched backend call target to Discovery naming.

- SQL script file renamed:
  - `sp_GetGlobeSummary.sql` -> `sp_GetDiscoverPageInfo.sql`
- Backend repository now calls:
  - `sp_GetDiscoverPageInfo`

#### 4) Discovery UI completion and interaction polish
Completed filter modal behavior and multiple content/UX refinements.

- Discovery filters popup:
  - smaller header
  - real styled `Close` button with hover/click states
  - wrapped chip-style option buttons
  - functional options wired to both list + globe:
    - A--Z / Z--A
    - Most Hidden Gems -> Least
    - Least Hidden Gems -> Most
    - Only Show Countries with Hidden Gems
    - Show Countries Without Hidden Gems (opposite behavior)
    - Continent multi-select + All Continents reset
- Default filter state now starts with:
  - `Only Show Countries with Hidden Gems` enabled
- Hovering a globe country now jumps to corresponding list item instantly (no visible long smooth scroll).

#### 5) Discovery copy and content updates
- Discovery blurb text replaced with project-specific copy.
- Welcome popup updates:
  - hidden songs button text changed to `Hidden Gems`
  - clicking outside popup closes it
- List card and globe tooltip content formatting updates:
  - labels and spacing normalized
  - bullet formatting in list details

#### 6) Data-state UI messaging updates
- If hidden gems are absent for country/year:
  - `Hidden Gems: No Hidden Gems for {year}`
- If no song data row exists for country/year:
  - `Most popular album: No song data for {year}`

These messages are display-only and are based on actual returned data state.

#### 7) UI adjustments
- Changed 'Hidden Songs' button on Welcome Screen to 'Hidden Gems'
- Added functionality to enable user to click anywhere besides the Welcome Pop-Up, to close the Welcome Pop-Up
- Adjusted spacing in country listings in List View
- Added bullet points in country listings in List View

#### Verification After Fix:

- `dotnet build backend/Capstone.API/Capstone.API.csproj` -> success
- `npx tsc --noEmit` (frontend app) -> success
- Discovery UI behavior verified manually for:
  - shared globe/list filtering
  - filter toggle/deselect behavior
  - continent multi-select
  - modal close interactions
  - hover -> list jump behavior

#### Files Changed:

- `Documents/mp3li implementation timeline document.txt`
- `backend/Capstone.API/Controllers/DiscoveryController.cs`
- `backend/Capstone.API/Infrastructure/Repositories/GlobeRepository.cs`
- `backend/Capstone.API/Models/Globe/CountryGlobeSummary.cs`
- `backend/Capstone.API/SQL Scripts/read/sp_GetDiscoverPageInfo.sql`
- `hidden-gem-music-app/App.tsx`
- `hidden-gem-music-app/src/components/CountryCard.tsx`
- `hidden-gem-music-app/src/components/DiscoveryBlurb.tsx`
- `hidden-gem-music-app/src/components/DiscoverySidebarPanels.tsx`
- `hidden-gem-music-app/src/components/globe/GlobePanel.tsx`
- `hidden-gem-music-app/src/components/globe/GlobeView.native.tsx`
- `hidden-gem-music-app/src/components/globe/GlobeView.tsx`
- `hidden-gem-music-app/src/components/globe/GlobeView.web.tsx`
- `hidden-gem-music-app/src/data/apiMappers.ts`
- `hidden-gem-music-app/src/data/discoveryApi.ts`
- `hidden-gem-music-app/src/screens/DiscoveryScreen.web.tsx`
- `hidden-gem-music-app/src/screens/WelcomeScreen.web.tsx`
- `hidden-gem-music-app/src/types/api.ts`

#### Note for Leena:

Procedure to apply/update:
- `sp_GetDiscoverPageInfo`

Use the current SQL from:
- `backend/Capstone.API/SQL Scripts/read/sp_GetDiscoverPageInfo.sql`

Current expected behavior of this proc in Discovery context:
- hidden gem count comes from `HiddenGems` by country/year
- top album/artist comes from most frequent charted song in country/year (`ChartEntry` path)
- strict ISO country filtering excludes pseudo/global rows

Validation query:

```sql
USE HiddenGemMusic;
GO
EXEC sp_GetDiscoverPageInfo @Year = 2021;
GO
```

Post-apply runtime check:
- restart backend host
- confirm endpoint response:
  - `GET /api/discovery/countries?year=2021`

#### Remaining Gap / Discussion Needed (Pre-Selected Filters):

The only intentionally non-functional area for this screen is **Pre-Selected Filters logic**.

Current state:
- UI shell exists for pre-selected filters.
- They are not yet mapped to finalized backend semantics.

Needs team decision:
- exact definition for each pre-selected filter (e.g., “Your Region vs. The World”, “Biggest Crossover Years”)
- whether those should:
  - map to existing endpoint params,
  - or require new endpoint(s)/fields,
  - or require dedicated pre-computed DB outputs.

I can implement whichever direction the team prefers:
- If backend contract is provided, I will wire directly.
- If new endpoints are needed, I can implement those as next step once definitions are agreed.
