### PR TITLE
Completed Issue 100 - Country Comparison Mode Page Web Screen Data Implementation

### DIFF
--- a/Documents/mp3li implementation timeline document.txt
+++ b/Documents/mp3li implementation timeline document.txt
@@ -2,6 +2,58 @@ mp3li implementation timeline document
 
 Updated: April 29, 2026
 
+Comparison Endpoint Verification + Hardening + SP Contract Cross-Check (April 29, 2026)
+- Goal for this task:
+  - Validate the Country Comparison endpoint behavior, add robust error handling, cross-check backend mapper contracts against comparison SP outputs, confirm whether additional SPs are needed, and document implementation details for team handoff.
+- Endpoint status and initial validation context:
+  - Existing comparison route implementation is present and wired:
+    - `GET /api/comparison?countryA={code}&countryB={code}&year={year}`
+    - `GET /api/comparison/hidden-gems?countryA={code}&countryB={code}&year={year}`
+  - User-reported browser validation confirms the main comparison endpoint returns payload data for:
+    - `http://localhost:5140/api/comparison?countryA=US&countryB=GB&year=2021`
+- SP and mapper cross-check findings:
+  - Comparison repository calls:
+    - `sp_GetCountryComparison`
+    - `sp_GetComparisonHiddenGems`
+  - SQL script outputs currently include aliases such as:
+    - `iso_code`, `full_name`, `song_title`, `countries_charting`
+  - Existing repository mappers were still expecting older alias names in several properties:
+    - `country_code`, `country_name`, `song_name`, `countries_charting_count`
+  - Impact:
+    - Endpoint could still return `200 OK`, but selected DTO fields could be null/default when alias keys do not match.
+- Backend hardening added in this task:
+  - `ComparisonController` now validates:
+    - `countryA` is exactly 2 letters
+    - `countryB` is exactly 2 letters
+    - `countryA` and `countryB` are not the same code
+    - year must be between `1975..2021`
+    - year excludes unavailable gap years `2007..2010`
+  - `ComparisonController` now applies structured exception handling on both comparison endpoints:
+    - `503` for `SqlException` with logging
+    - `500` for unexpected exceptions with logging
+    - `400` for invalid input
+    - `404` retained for no comparison result row set on primary compare endpoint
+- Mapper compatibility fixes completed:
+  - Comparison repository mapping now supports both legacy and current SP aliases:
+    - country code: `country_code` or `iso_code`
+    - country name: `country_name` or `full_name`
+    - song name: `song_name` or `song_title`
+    - countries charting count: `countries_charting_count` or `countries_charting`
+  - This ensures DTO population remains stable while DB/SP aliases evolve.
+- Additional SP requirement outcome:
+  - No additional stored procedures were required for this task.
+  - Existing procedures already cover required comparison data paths once mapper alias compatibility is enforced.
+- Runtime verification completion (final pass):
+  - Initial 500 failures were traced to environment config, not endpoint logic:
+    - API was running in `Production`, while `DefaultConnection` existed only in `appsettings.Development.json`.
+    - Added `ConnectionStrings:DefaultConnection` to `appsettings.json` so default run path resolves the DB connection consistently.
+  - Final endpoint checks after restart:
+    - `GET /api/comparison?countryA=US&countryB=GB&year=2021` -> returns large populated JSON payload (`countryA`, `countryB`, `sharedSongs`, `uniqueToA`, `uniqueToB`).
+    - `GET /api/comparison/hidden-gems?countryA=US&countryB=GB&year=2021` -> `200` with populated `songName`, `artistName`, `trendScore`, and non-zero `countriesChartingCount`.
+    - `GET /api/comparison?countryA=U1&countryB=GB&year=2021` -> `400` with ISO-format validation message.
+    - `GET /api/comparison?countryA=US&countryB=US&year=2021` -> `400` with same-country validation message.
+    - `GET /api/comparison?countryA=US&countryB=GB&year=1900` -> `400` with supported-year-range validation message.
+
 Country + Preview Endpoint Verification, Failure Analysis, SQL Fix, and Repro Handoff (April 29, 2026)
 - Goal for this task:
   - Verify both Country endpoints against my restored local DB, harden backend behavior, and document exactly what failed and how it was fixed so Leena can apply the same DB-side correction before future backup zips.

--- a/Documents/mp3li implementation timeline document.txt
+++ b/Documents/mp3li implementation timeline document.txt
@@ -2,6 +2,60 @@ mp3li implementation timeline document
 
 Updated: April 29, 2026
 
+Country + Preview Endpoint Verification, Failure Analysis, SQL Fix, and Repro Handoff (April 29, 2026)
+- Goal for this task:
+  - Verify both Country endpoints against my restored local DB, harden backend behavior, and document exactly what failed and how it was fixed so Leena can apply the same DB-side correction before future backup zips.
+- Environment/setup context:
+  - SQL Server running via Docker on macOS.
+  - DB restored and queried through SSMS in Windows 11 via Parallels.
+  - API run locally with `dotnet run --project backend/Capstone.API` on `http://localhost:5140`.
+- Browser endpoint tests run (initial pass) and outputs:
+  - `GET /api/country/US?year=2021` returned populated JSON (`countryCode`, `countryName`, chart stats, song lists).
+  - `GET /api/country/ZZ?year=2021` returned `404 Not Found`.
+  - `GET /api/country/US?year=1900` returned `404 Not Found` (this was later flagged for stricter validation behavior because year selectors are dataset-bounded).
+  - `GET /api/country/US/hidden-gems/preview?year=2021` returned `500` message: `An unexpected error occurred while retrieving hidden gems preview data.`
+  - `GET /api/country/ZZ/hidden-gems/preview?year=2021` returned same `500` message.
+- Failure encountered:
+  - Hidden-gems preview endpoint failed (`500`) for both valid and invalid country code inputs.
+- SSMS diagnostic queries run and exact error:
+  - Ran:
+    - `EXEC sp_GetCountryHiddenGemsPreview @CountryCode='US', @Year=2021;`
+    - `EXEC sp_GetCountryHiddenGemsPreview @CountryCode='ZZ', @Year=2021;`
+  - SQL Server error:
+    - `Msg 208, Level 16, State 1, Procedure sp_GetCountryHiddenGemsPreview, Line 8`
+    - `Invalid object name 'Song'.`
+- Root cause:
+  - Restored DB had an outdated procedure version of `sp_GetCountryHiddenGemsPreview` still referencing legacy table `Song` instead of current star schema tables.
+- Exact remediation SQL executed in SSMS:
+  - Applied `CREATE OR ALTER PROCEDURE dbo.sp_GetCountryHiddenGemsPreview` using:
+    - `HiddenGems` + `Country` core join
+    - `DIM_Song`
+    - `Bridge_SongArtist` with `artist_order = 1`
+    - `DIM_Artist`
+    - `TOP 5 ... ORDER BY hg.trend_score DESC`
+- Validation after fix:
+  - SSMS proc re-test returned rows for `US, 2021` (no SQL errors).
+  - Browser re-test:
+    - `GET /api/country/US/hidden-gems/preview?year=2021` returned expected JSON list of 5 hidden gems.
+    - `GET /api/country/ZZ/hidden-gems/preview?year=2021` returned empty behavior (no server error).
+- Backend hardening completed after verification:
+  - `CountryController` now validates:
+    - country code must be exactly 2 letters
+    - year must be in supported dataset window (`1975..2021`) and excludes unavailable gap years (`2007..2010`)
+  - Country endpoint response behavior now explicitly differentiates:
+    - `400` invalid code/year input
+    - `404` no profile row for valid profile lookup
+    - `503` SQL/database failures
+    - `500` unexpected failures
+- SP contract and mapper cross-check outcome:
+  - Confirmed Country repository bindings to:
+    - `sp_GetCountryProfile`
+    - `sp_GetCountryHiddenGemsPreview`
+  - Confirmed no additional SP was required for this task once preview proc was corrected in DB.
+- Repro/handoff note for Leena:
+  - Apply the same `CREATE OR ALTER PROCEDURE dbo.sp_GetCountryHiddenGemsPreview` star-schema version in source DB before producing future backup zips.
+  - Without this, restored environments can reproduce the same `Invalid object name 'Song'` failure on preview endpoint.
+
 Backend Database Connection + Endpoint Validation + Mapper Alignment (April 29, 2026)
 - Local SQL Server database restore was validated through SSMS in Windows 11 on Parallels, and API local hosting was confirmed in macOS Docker setup context.
 - API startup was confirmed working on local dev host:

--- a/Documents/mp3li implementation timeline document.txt
+++ b/Documents/mp3li implementation timeline document.txt
@@ -1,6 +1,250 @@
 mp3li implementation timeline document
 
-Updated: April 29, 2026
+Updated: April 30, 2026
+
+Country Comparison Mode Page Web Screen Data Implementation (Issue 100) (May 1, 2026)
+- Completed the Country Comparison Mode web-screen data implementation scope and interaction polish for this issue.
+
+Implemented data behavior:
+- Country list behavior now requires song availability in app data for the currently selected year (not just hidden-gem availability).
+- Comparison Mode country source wiring was updated to use the broader discovery-backed country source in app state for selection/list availability.
+- Selected comparison-country mapping and available-country handoff were aligned with that same source so selection and result screens stay consistent.
+
+Implemented UI/interaction updates:
+- Select Year dropdown now uses strict available years from metadata API (`loadAvailableYears`) instead of static mock year options.
+- Select Year dropdown now closes when clicking outside of the dropdown.
+- Comparison blurb copy was updated to final issue-aligned usage guidance text.
+- Region filter options were corrected to include the intended continent set while removing non-user-facing placeholders:
+  - removed `Continent info coming soon.`
+  - removed `Other`
+- Language and Genre filter chips were preserved visually and functionally while broader genre/language dataset details remain deferred.
+- Unknown values were removed from Language and Genre filter option lists.
+- Filter changes now auto-clear current selected countries to avoid stale invalid selections under new filter states.
+- Added a `Clear Selections` control next to the selected-count summary in the Select Countries header:
+  - uses matching filter-chip style language
+  - semitransparent treatment in default/hover/press states
+  - only visible when the Select Countries panel is expanded
+- Country-selection helper text remains concise (`x out of 2 countries selected`) after follow-up cleanup.
+
+Filter behavior updates:
+- Region, Language, Genre, and Popularity filters all affect visible country results.
+- Popularity filters (`Biggest Hits`, `Fast Rising Songs`, `All Songs`) now apply concrete list behavior in the comparison-mode country list.
+
+Navigation/task integrity:
+- Existing comparison-mode route flow and button wiring were preserved while implementing these data/filter changes.
+
+Files updated in this issue implementation:
+- `hidden-gem-music-app/src/screens/ComparisonSelectScreen.web.tsx`
+- `hidden-gem-music-app/App.tsx`
+
+Verification:
+- `cd hidden-gem-music-app && npx tsc --noEmit` passed after the final set of issue-100 changes.
+
+Country Comparison View Page Web Screen Data Implementation (Issue 98) (April 30, 2026)
+- Comparison View was upgraded from mock-data behavior into API-backed country-detail parity on both panes.
+- Each pane now independently loads backend-backed country data using the same implementation pattern used on Country Page:
+  - `GET /api/metadata/years` for year options
+  - `GET /api/country/{code}?year={year}` for country profile stats
+  - `GET /api/country/{code}/hidden-gems/preview?year={year}&limit=13` for hidden-gems carousel preview
+  - `GET /api/country/{code}/songs?year={year}&listType=unique&page={page}&pageSize=50`
+  - `GET /api/country/{code}/songs?year={year}&listType=shared&page={page}&pageSize=50`
+- API mapper parity was added for comparison-pane data transformation:
+  - `mapApiCountryProfile`
+  - `mapApiHiddenGem`
+  - `mapApiSong`
+- Pane-level request lifecycle logic now mirrors Country Page behavior:
+  - reset lists / paging state on country or year change
+  - initial loading states for profile, preview, unique list, shared list
+  - guarded stale-request handling per pane via request id tracking
+  - graceful fallback to existing generated profile values when profile API data is unavailable
+- Both pane song columns now support paged load-more behavior tied to scroll position:
+  - unique list (`Most Loved in This Country`)
+  - shared list (`Loved Here and Elsewhere`)
+- Comparison-pane summary generation now follows the same implementation style used on Country Page:
+  - dynamic general-description text using loaded artists and songs when available
+  - loading-safe fallback copy while data is still resolving
+- Favorite Artists section on Comparison View was aligned to current implementation expectations:
+  - artist cards are sourced from API-derived top unique/shared songs
+  - cards now include artist name plus associated song title
+  - long artist / song text is clamped to 3 lines with ellipsis
+  - horizontal scrolling was enabled with persistent visible horizontal scrollbar treatment
+  - this behavior was implemented for Comparison View only (not Country Page)
+- Comparison-pane year dropdown behavior was corrected to be pane-local:
+  - changing year on left pane affects only left pane
+  - changing year on right pane affects only right pane
+  - shared-year coupling was removed for the comparison results screen
+- Stored procedure and SQL contract note:
+  - no new stored procedure edits were required in this round
+  - existing Country Page SP work was reused (`sp_GetAvailableYears`, `sp_GetCountryHiddenGemsPreview`, `sp_GetCountrySongsPaged`) through current API endpoints
+- Main implementation file updated:
+  - `hidden-gem-music-app/src/screens/ComparisonResultsScreen.web.tsx`
+- Verification completed:
+  - `npx tsc --noEmit` passed after changes
+
+Country Detail Web Screen Data Implementation + Discovery Timeline Year Real-Data Alignment (May 1, 2026)
+- Goal for this task:
+  - Replace Country Detail placeholder wiring with live API data (except intentional genre/language deferrals), add list pagination/infinite loading for large song lists, align dropdown/year behavior with real dataset years, and complete Discovery timeline slider year-gap behavior using real years only.
+
+- Scope completed:
+  - Country Detail Web Screen:
+    - Header/dropdown/stat/list/hidden-gems preview/data-loading behavior and endpoint wiring.
+  - Discovery Globe screen:
+    - Timeline slider year source + gap rendering/drag behavior aligned to real available years.
+  - Deferred-by-design areas retained:
+    - Genre + Language data content sections (data not yet available).
+
+- Backend/API implementation completed:
+  - New metadata years API:
+    - Added `GET /api/metadata/years`
+    - Files:
+      - `backend/Capstone.API/Controllers/MetadataController.cs`
+      - `backend/Capstone.API/Infrastructure/Interfaces/IMetadataRepository.cs`
+      - `backend/Capstone.API/Infrastructure/Repositories/MetadataRepository.cs`
+      - `backend/Capstone.API/Program.cs` (DI registration)
+  - Country hidden gems preview endpoint extended:
+    - Existing route now supports `limit` query parameter:
+      - `GET /api/country/{code}/hidden-gems/preview?year={year}&limit={n}`
+    - Files:
+      - `backend/Capstone.API/Controllers/CountryController.cs`
+      - `backend/Capstone.API/Infrastructure/Interfaces/ICountryRepository.cs`
+      - `backend/Capstone.API/Infrastructure/Repositories/CountryRepository.cs`
+      - `backend/Capstone.API/SQL Scripts/read/sp_GetCountryHiddenGemsPreview.sql`
+  - Country year validation contract updated:
+    - Country endpoints now validate `year` against actual DB years from `sp_GetAvailableYears` (instead of legacy hardcoded year window).
+    - File:
+      - `backend/Capstone.API/Controllers/CountryController.cs`
+  - New paged songs endpoint for Country list panels:
+    - Added `GET /api/country/{code}/songs?year={year}&listType={shared|unique}&page={n}&pageSize={n}`
+    - Supports infinite-scroll style front-end loading.
+    - Files:
+      - `backend/Capstone.API/Models/Country/CountrySongsPage.cs`
+      - `backend/Capstone.API/Controllers/CountryController.cs`
+      - `backend/Capstone.API/Infrastructure/Interfaces/ICountryRepository.cs`
+      - `backend/Capstone.API/Infrastructure/Repositories/CountryRepository.cs`
+      - `backend/Capstone.API/SQL Scripts/read/sp_GetCountrySongsPaged.sql`
+
+- SQL procedures added/changed:
+  - Added:
+    - `backend/Capstone.API/SQL Scripts/read/sp_GetAvailableYears.sql`
+    - `backend/Capstone.API/SQL Scripts/read/sp_GetCountrySongsPaged.sql`
+  - Updated:
+    - `backend/Capstone.API/SQL Scripts/read/sp_GetCountryHiddenGemsPreview.sql`
+      - Added `@Limit INT = 5`
+      - `TOP 5` -> `TOP (@Limit)`
+
+- Exact DB-side commands run/validated in this workflow:
+  - `EXEC sp_GetAvailableYears;`
+    - Returned (current restored dataset): `2017, 2018, 2019, 2020, 2021, 2023, 2024, 2025`
+    - Confirms gap year `2022` missing.
+  - `EXEC sp_GetCountryHiddenGemsPreview @CountryCode='US', @Year=2021, @Limit=13;`
+    - Returned 13 rows sorted by trend score.
+  - `EXEC sp_GetCountrySongsPaged @CountryCode='US', @Year=2023, @ListType='unique', @Offset=0, @PageSize=50;`
+  - `EXEC sp_GetCountrySongsPaged @CountryCode='US', @Year=2023, @ListType='shared', @Offset=0, @PageSize=50;`
+
+- Browser/API checks used during verification:
+  - `GET /api/metadata/years`
+  - `GET /api/country/US?year=2023`
+  - `GET /api/country/US/hidden-gems/preview?year=2023&limit=13`
+  - `GET /api/country/US/songs?year=2023&listType=unique&page=1&pageSize=50`
+  - `GET /api/country/US/songs?year=2023&listType=shared&page=1&pageSize=50`
+
+- Frontend implementation completed (Country Detail):
+  - New Country API client:
+    - `hidden-gem-music-app/src/data/countryApi.ts`
+      - loads country profile, hidden-gems preview, metadata years, and paged country songs.
+  - Country screen moved from placeholder-only behavior to live data for implemented sections:
+    - `hidden-gem-music-app/src/screens/CountryScreen.web.tsx`
+  - Country dropdown:
+    - Uses full country data source aligned with Discovery country set.
+    - Click-outside closes dropdown.
+    - Loading popup behavior when changing country.
+  - Year dropdown (Country screen):
+    - Uses only real API years from `/api/metadata/years`.
+    - Click-outside closes dropdown.
+  - Stat square mappings:
+    - Songs in This View -> `totalCharted`
+    - Loved in This Country -> `uniqueCount`
+    - Loved Here and Elsewhere (count) -> `sharedCount`
+    - Loved Here and Elsewhere (%) -> `overlapPct`
+  - Favorite Artists section:
+    - Uses unique-songs artists first; backfills from shared-songs artists if needed.
+    - During initial load, shows animated `Loading...` states instead of placeholder names.
+  - Hidden Gems preview section:
+    - Uses top 13 from country preview endpoint.
+    - During load, displays animated `Loading...` song/artist text instead of placeholder values.
+  - Country list panels:
+    - `Most Loved in This Country` and `Loved Here and Elsewhere` now use paged API endpoint and auto-fetch next pages on near-bottom scroll.
+    - Initial and incremental loading states added.
+  - Language section title updated:
+    - `Country Name's Language(s) in Music`
+  - General Description sentence rewired to requested template style:
+    - Uses current genres + loaded artists/songs.
+    - Uses animated `Loading...` slots while required data is still loading.
+  - Removed placeholder fallbacks for implemented (non-deferred) sections:
+    - Replaced with explicit loading-state behavior to avoid fake content during fetch.
+
+- Frontend implementation completed (Discovery timeline):
+  - Files:
+    - `hidden-gem-music-app/src/components/YearSlider.tsx`
+    - `hidden-gem-music-app/src/screens/DiscoveryScreen.web.tsx`
+    - `hidden-gem-music-app/App.tsx`
+  - Timeline slider now:
+    - Uses API-provided available years.
+    - Computes real missing-year gap from the dataset year list.
+    - Renders gap as one discrete year-slot width.
+    - Prevents thumb from landing in gap; dragging jumps to either valid side.
+
+- Issues encountered and fixes applied:
+  - Hidden Gems page endpoint had mapper key mismatches (`song_title` vs `song_name`, `countries_charting` vs `countries_charting_count`):
+    - Confirmed this affected `/api/hidden-gems/{code}` and not country preview endpoint.
+    - Country-detail preview path remained correct.
+  - Country endpoints originally rejected valid newer years due to old hardcoded validator:
+    - Fixed by year validation against `sp_GetAvailableYears`.
+  - Country list panels still showed placeholder rows after initial integration:
+    - Root cause: combined failure path and fallback generation.
+    - Fixed by independent data fetch handling + no placeholder fallback for those sections.
+  - Discovery country label switched to backend full name (e.g., `United States`) when seed label expected (`USA`):
+    - Fixed merge behavior to preserve existing seed display name when available.
+
+- UI polish changes completed during final pass:
+  - Dropdown click-outside close behavior for Country and Year selectors.
+  - `%` symbol reduced in size for overlap stat square.
+  - Number vertical alignment adjusted in first two stat squares.
+  - Stat square loading text reduced in size while loading.
+
+- Files added in this delivery:
+  - `backend/Capstone.API/Controllers/MetadataController.cs`
+  - `backend/Capstone.API/Infrastructure/Interfaces/IMetadataRepository.cs`
+  - `backend/Capstone.API/Infrastructure/Repositories/MetadataRepository.cs`
+  - `backend/Capstone.API/Models/Country/CountrySongsPage.cs`
+  - `backend/Capstone.API/SQL Scripts/read/sp_GetAvailableYears.sql`
+  - `backend/Capstone.API/SQL Scripts/read/sp_GetCountrySongsPaged.sql`
+  - `hidden-gem-music-app/src/data/countryApi.ts`
+
+- Existing files updated in this delivery:
+  - `backend/Capstone.API/Controllers/CountryController.cs`
+  - `backend/Capstone.API/Infrastructure/Interfaces/ICountryRepository.cs`
+  - `backend/Capstone.API/Infrastructure/Repositories/CountryRepository.cs`
+  - `backend/Capstone.API/Program.cs`
+  - `backend/Capstone.API/SQL Scripts/read/sp_GetCountryHiddenGemsPreview.sql`
+  - `hidden-gem-music-app/App.tsx`
+  - `hidden-gem-music-app/src/components/YearSlider.tsx`
+  - `hidden-gem-music-app/src/screens/DiscoveryScreen.web.tsx`
+  - `hidden-gem-music-app/src/screens/CountryScreen.web.tsx`
+  - `hidden-gem-music-app/src/data/discoveryApi.ts`
+  - `hidden-gem-music-app/src/types/api.ts`
+
+- Build/typecheck verification run:
+  - `dotnet build backend/Capstone.API/Capstone.API.csproj` -> success
+  - `cd hidden-gem-music-app && npx tsc --noEmit` -> success
+- SP contract and mapper cross-check outcome:
+  - Confirmed Country repository bindings to:
+    - `sp_GetCountryProfile`
+    - `sp_GetCountryHiddenGemsPreview`
+  - Confirmed no additional SP was required for this task once preview proc was corrected in DB.
+- Repro/handoff note for Leena:
+  - Apply the same `CREATE OR ALTER PROCEDURE dbo.sp_GetCountryHiddenGemsPreview` star-schema version in source DB before producing future backup zips.
+  - Without this, restored environments can reproduce the same `Invalid object name 'Song'` failure on preview endpoint.
 
 Discovery Globe Data Integration + Discovery Filters Completion + DB Repro Runbook (April 30, 2026)
 - Goal for this task:
@@ -258,171 +502,6 @@ Country + Preview Endpoint Verification, Failure Analysis, SQL Fix, and Repro Ha
     - `404` no profile row for valid profile lookup
     - `503` SQL/database failures
     - `500` unexpected failures
-
-Country Detail Web Screen Data Implementation + Discovery Timeline Year Real-Data Alignment (May 1, 2026)
-- Goal for this task:
-  - Replace Country Detail placeholder wiring with live API data (except intentional genre/language deferrals), add list pagination/infinite loading for large song lists, align dropdown/year behavior with real dataset years, and complete Discovery timeline slider year-gap behavior using real years only.
-
-- Scope completed:
-  - Country Detail Web Screen:
-    - Header/dropdown/stat/list/hidden-gems preview/data-loading behavior and endpoint wiring.
-  - Discovery Globe screen:
-    - Timeline slider year source + gap rendering/drag behavior aligned to real available years.
-  - Deferred-by-design areas retained:
-    - Genre + Language data content sections (data not yet available).
-
-- Backend/API implementation completed:
-  - New metadata years API:
-    - Added `GET /api/metadata/years`
-    - Files:
-      - `backend/Capstone.API/Controllers/MetadataController.cs`
-      - `backend/Capstone.API/Infrastructure/Interfaces/IMetadataRepository.cs`
-      - `backend/Capstone.API/Infrastructure/Repositories/MetadataRepository.cs`
-      - `backend/Capstone.API/Program.cs` (DI registration)
-  - Country hidden gems preview endpoint extended:
-    - Existing route now supports `limit` query parameter:
-      - `GET /api/country/{code}/hidden-gems/preview?year={year}&limit={n}`
-    - Files:
-      - `backend/Capstone.API/Controllers/CountryController.cs`
-      - `backend/Capstone.API/Infrastructure/Interfaces/ICountryRepository.cs`
-      - `backend/Capstone.API/Infrastructure/Repositories/CountryRepository.cs`
-      - `backend/Capstone.API/SQL Scripts/read/sp_GetCountryHiddenGemsPreview.sql`
-  - Country year validation contract updated:
-    - Country endpoints now validate `year` against actual DB years from `sp_GetAvailableYears` (instead of legacy hardcoded year window).
-    - File:
-      - `backend/Capstone.API/Controllers/CountryController.cs`
-  - New paged songs endpoint for Country list panels:
-    - Added `GET /api/country/{code}/songs?year={year}&listType={shared|unique}&page={n}&pageSize={n}`
-    - Supports infinite-scroll style front-end loading.
-    - Files:
-      - `backend/Capstone.API/Models/Country/CountrySongsPage.cs`
-      - `backend/Capstone.API/Controllers/CountryController.cs`
-      - `backend/Capstone.API/Infrastructure/Interfaces/ICountryRepository.cs`
-      - `backend/Capstone.API/Infrastructure/Repositories/CountryRepository.cs`
-      - `backend/Capstone.API/SQL Scripts/read/sp_GetCountrySongsPaged.sql`
-
-- SQL procedures added/changed:
-  - Added:
-    - `backend/Capstone.API/SQL Scripts/read/sp_GetAvailableYears.sql`
-    - `backend/Capstone.API/SQL Scripts/read/sp_GetCountrySongsPaged.sql`
-  - Updated:
-    - `backend/Capstone.API/SQL Scripts/read/sp_GetCountryHiddenGemsPreview.sql`
-      - Added `@Limit INT = 5`
-      - `TOP 5` -> `TOP (@Limit)`
-
-- Exact DB-side commands run/validated in this workflow:
-  - `EXEC sp_GetAvailableYears;`
-    - Returned (current restored dataset): `2017, 2018, 2019, 2020, 2021, 2023, 2024, 2025`
-    - Confirms gap year `2022` missing.
-  - `EXEC sp_GetCountryHiddenGemsPreview @CountryCode='US', @Year=2021, @Limit=13;`
-    - Returned 13 rows sorted by trend score.
-  - `EXEC sp_GetCountrySongsPaged @CountryCode='US', @Year=2023, @ListType='unique', @Offset=0, @PageSize=50;`
-  - `EXEC sp_GetCountrySongsPaged @CountryCode='US', @Year=2023, @ListType='shared', @Offset=0, @PageSize=50;`
-
-- Browser/API checks used during verification:
-  - `GET /api/metadata/years`
-  - `GET /api/country/US?year=2023`
-  - `GET /api/country/US/hidden-gems/preview?year=2023&limit=13`
-  - `GET /api/country/US/songs?year=2023&listType=unique&page=1&pageSize=50`
-  - `GET /api/country/US/songs?year=2023&listType=shared&page=1&pageSize=50`
-
-- Frontend implementation completed (Country Detail):
-  - New Country API client:
-    - `hidden-gem-music-app/src/data/countryApi.ts`
-      - loads country profile, hidden-gems preview, metadata years, and paged country songs.
-  - Country screen moved from placeholder-only behavior to live data for implemented sections:
-    - `hidden-gem-music-app/src/screens/CountryScreen.web.tsx`
-  - Country dropdown:
-    - Uses full country data source aligned with Discovery country set.
-    - Click-outside closes dropdown.
-    - Loading popup behavior when changing country.
-  - Year dropdown (Country screen):
-    - Uses only real API years from `/api/metadata/years`.
-    - Click-outside closes dropdown.
-  - Stat square mappings:
-    - Songs in This View -> `totalCharted`
-    - Loved in This Country -> `uniqueCount`
-    - Loved Here and Elsewhere (count) -> `sharedCount`
-    - Loved Here and Elsewhere (%) -> `overlapPct`
-  - Favorite Artists section:
-    - Uses unique-songs artists first; backfills from shared-songs artists if needed.
-    - During initial load, shows animated `Loading...` states instead of placeholder names.
-  - Hidden Gems preview section:
-    - Uses top 13 from country preview endpoint.
-    - During load, displays animated `Loading...` song/artist text instead of placeholder values.
-  - Country list panels:
-    - `Most Loved in This Country` and `Loved Here and Elsewhere` now use paged API endpoint and auto-fetch next pages on near-bottom scroll.
-    - Initial and incremental loading states added.
-  - Language section title updated:
-    - `Country Name's Language(s) in Music`
-  - General Description sentence rewired to requested template style:
-    - Uses current genres + loaded artists/songs.
-    - Uses animated `Loading...` slots while required data is still loading.
-  - Removed placeholder fallbacks for implemented (non-deferred) sections:
-    - Replaced with explicit loading-state behavior to avoid fake content during fetch.
-
-- Frontend implementation completed (Discovery timeline):
-  - Files:
-    - `hidden-gem-music-app/src/components/YearSlider.tsx`
-    - `hidden-gem-music-app/src/screens/DiscoveryScreen.web.tsx`
-    - `hidden-gem-music-app/App.tsx`
-  - Timeline slider now:
-    - Uses API-provided available years.
-    - Computes real missing-year gap from the dataset year list.
-    - Renders gap as one discrete year-slot width.
-    - Prevents thumb from landing in gap; dragging jumps to either valid side.
-
-- Issues encountered and fixes applied:
-  - Hidden Gems page endpoint had mapper key mismatches (`song_title` vs `song_name`, `countries_charting` vs `countries_charting_count`):
-    - Confirmed this affected `/api/hidden-gems/{code}` and not country preview endpoint.
-    - Country-detail preview path remained correct.
-  - Country endpoints originally rejected valid newer years due to old hardcoded validator:
-    - Fixed by year validation against `sp_GetAvailableYears`.
-  - Country list panels still showed placeholder rows after initial integration:
-    - Root cause: combined failure path and fallback generation.
-    - Fixed by independent data fetch handling + no placeholder fallback for those sections.
-  - Discovery country label switched to backend full name (e.g., `United States`) when seed label expected (`USA`):
-    - Fixed merge behavior to preserve existing seed display name when available.
-
-- UI polish changes completed during final pass:
-  - Dropdown click-outside close behavior for Country and Year selectors.
-  - `%` symbol reduced in size for overlap stat square.
-  - Number vertical alignment adjusted in first two stat squares.
-  - Stat square loading text reduced in size while loading.
-
-- Files added in this delivery:
-  - `backend/Capstone.API/Controllers/MetadataController.cs`
-  - `backend/Capstone.API/Infrastructure/Interfaces/IMetadataRepository.cs`
-  - `backend/Capstone.API/Infrastructure/Repositories/MetadataRepository.cs`
-  - `backend/Capstone.API/Models/Country/CountrySongsPage.cs`
-  - `backend/Capstone.API/SQL Scripts/read/sp_GetAvailableYears.sql`
-  - `backend/Capstone.API/SQL Scripts/read/sp_GetCountrySongsPaged.sql`
-  - `hidden-gem-music-app/src/data/countryApi.ts`
-
-- Existing files updated in this delivery:
-  - `backend/Capstone.API/Controllers/CountryController.cs`
-  - `backend/Capstone.API/Infrastructure/Interfaces/ICountryRepository.cs`
-  - `backend/Capstone.API/Infrastructure/Repositories/CountryRepository.cs`
-  - `backend/Capstone.API/Program.cs`
-  - `backend/Capstone.API/SQL Scripts/read/sp_GetCountryHiddenGemsPreview.sql`
-  - `hidden-gem-music-app/App.tsx`
-  - `hidden-gem-music-app/src/components/YearSlider.tsx`
-  - `hidden-gem-music-app/src/screens/DiscoveryScreen.web.tsx`
-  - `hidden-gem-music-app/src/screens/CountryScreen.web.tsx`
-  - `hidden-gem-music-app/src/data/discoveryApi.ts`
-  - `hidden-gem-music-app/src/types/api.ts`
-
-- Build/typecheck verification run:
-  - `dotnet build backend/Capstone.API/Capstone.API.csproj` -> success
-  - `cd hidden-gem-music-app && npx tsc --noEmit` -> success
-- SP contract and mapper cross-check outcome:
-  - Confirmed Country repository bindings to:
-    - `sp_GetCountryProfile`
-    - `sp_GetCountryHiddenGemsPreview`
-  - Confirmed no additional SP was required for this task once preview proc was corrected in DB.
-- Repro/handoff note for Leena:
-  - Apply the same `CREATE OR ALTER PROCEDURE dbo.sp_GetCountryHiddenGemsPreview` star-schema version in source DB before producing future backup zips.
-  - Without this, restored environments can reproduce the same `Invalid object name 'Song'` failure on preview endpoint.
 
 Backend Database Connection + Endpoint Validation + Mapper Alignment (April 29, 2026)
 - Local SQL Server database restore was validated through SSMS in Windows 11 on Parallels, and API local hosting was confirmed in macOS Docker setup context.
@@ -713,46 +792,6 @@ Architecture Documentation and Repo Tracking Cleanup (April 21, 2026)
   - The tracked generated files were removed from Git tracking so the ignore rules can work as intended going forward
 - This cleanup is being treated as an additional repo-maintenance improvement attached to the same general setup work, since it removes machine-specific generated files from future frontend/backend collaboration noise.
 
-Project Foundation and Screen Architecture (April 17, 2026)
-- React Native project structure was created in `hidden-gem-music-app`.
-- Shared theme primitives were established:
-  - Color tokens
-  - Typography setup
-  - Shared spacing
-  - Reusable panel / button styling
-- Uploaded Nyght Serif and Tanklager font files were wired into the app.
-- Initial route structure was built for:
-  - Welcome
-  - Discovery Globe
-  - Country
-  - Hidden Songs / Hidden Gems
-  - Comparison Select
-  - Comparison Results
-  - Dashboard
-  - Credits
-- Mock data and yearly data helpers were set up so major screens could respond to selected-year changes.
-- A loading overlay pattern was added for year-switching interactions.
-
-Core Discovery Flow and Shared UI Systems (April 18, 2026)
-- The discovery experience was split into globe and list-view panels so the app background remains visually stable while secondary content scrolls independently.
-- Search was moved into the main navigation flow instead of remaining the primary planned standalone screen.
-- Shared screen scaffolding and gradient background treatments were added to support a more polished mockup-driven layout direction.
-- The placeholder globe was separated behind platform-specific components so the app can transition to real Mapbox integration later without rewriting the higher-level discovery layout.
-- Country and comparison data views were connected to the existing year-aware mock-data structure.
-
-Visual Theme Revision and Navigation Restyling (April 19, 2026)
-- The full app palette was reworked to match the mockup art more accurately:
-  - Header gradient and nav colors
-  - Main vertical background gradient
-  - Secondary panel surfaces for globe and list views
-  - Timeline colors
-  - Scrollbar colors
-  - Globe-card top / bottom color split
-- Dark text usage was standardized away from pure black, and light text usage was standardized away from pure white.
-- Country listing outlines, list-view cards, button fills, and globe-card surfaces were updated to match the new palette.
-- The display-face usage was updated so the project now uses `NyghtSerif-MediumItalic` for the intended serif styling.
-- The top navigation was restyled with wider desktop spacing and a more responsive condensed behavior for narrower web widths.
-
 Responsive Header, Routing, and Interaction Polish (April 20, 2026)
 - The header wordmark was customized so the `i` in `Hidden` uses the gem asset as its dot, with the glyph itself adjusted to support that styling.
 - `Hidden Songs` was added to the main navigation between `Comparison Mode` and `Dashboard`.
@@ -816,81 +855,42 @@ Current Follow-up Work
 - Continue screen-by-screen visual alignment against the finalized mockups, especially for secondary screens.
 - Recheck narrow-width web behavior after the remaining feature screens fully adopt the updated header and filter-row patterns.
 
-Country Comparison View Page Web Screen Data Implementation (Issue 98) (April 30, 2026)
-- Comparison View was upgraded from mock-data behavior into API-backed country-detail parity on both panes.
-- Each pane now independently loads backend-backed country data using the same implementation pattern used on Country Page:
-  - `GET /api/metadata/years` for year options
-  - `GET /api/country/{code}?year={year}` for country profile stats
-  - `GET /api/country/{code}/hidden-gems/preview?year={year}&limit=13` for hidden-gems carousel preview
-  - `GET /api/country/{code}/songs?year={year}&listType=unique&page={page}&pageSize=50`
-  - `GET /api/country/{code}/songs?year={year}&listType=shared&page={page}&pageSize=50`
-- API mapper parity was added for comparison-pane data transformation:
-  - `mapApiCountryProfile`
-  - `mapApiHiddenGem`
-  - `mapApiSong`
-- Pane-level request lifecycle logic now mirrors Country Page behavior:
-  - reset lists / paging state on country or year change
-  - initial loading states for profile, preview, unique list, shared list
-  - guarded stale-request handling per pane via request id tracking
-  - graceful fallback to existing generated profile values when profile API data is unavailable
-- Both pane song columns now support paged load-more behavior tied to scroll position:
-  - unique list (`Most Loved in This Country`)
-  - shared list (`Loved Here and Elsewhere`)
-- Comparison-pane summary generation now follows the same implementation style used on Country Page:
-  - dynamic general-description text using loaded artists and songs when available
-  - loading-safe fallback copy while data is still resolving
-- Favorite Artists section on Comparison View was aligned to current implementation expectations:
-  - artist cards are sourced from API-derived top unique/shared songs
-  - cards now include artist name plus associated song title
-  - long artist / song text is clamped to 3 lines with ellipsis
-  - horizontal scrolling was enabled with persistent visible horizontal scrollbar treatment
-  - this behavior was implemented for Comparison View only (not Country Page)
-- Comparison-pane year dropdown behavior was corrected to be pane-local:
-  - changing year on left pane affects only left pane
-  - changing year on right pane affects only right pane
-  - shared-year coupling was removed for the comparison results screen
-- Stored procedure and SQL contract note:
-  - no new stored procedure edits were required in this round
-  - existing Country Page SP work was reused (`sp_GetAvailableYears`, `sp_GetCountryHiddenGemsPreview`, `sp_GetCountrySongsPaged`) through current API endpoints
-- Main implementation file updated:
-  - `hidden-gem-music-app/src/screens/ComparisonResultsScreen.web.tsx`
-- Verification completed:
-  - `npx tsc --noEmit` passed after changes
+Visual Theme Revision and Navigation Restyling (April 19, 2026)
+- The full app palette was reworked to match the mockup art more accurately:
+  - Header gradient and nav colors
+  - Main vertical background gradient
+  - Secondary panel surfaces for globe and list views
+  - Timeline colors
+  - Scrollbar colors
+  - Globe-card top / bottom color split
+- Dark text usage was standardized away from pure black, and light text usage was standardized away from pure white.
+- Country listing outlines, list-view cards, button fills, and globe-card surfaces were updated to match the new palette.
+- The display-face usage was updated so the project now uses `NyghtSerif-MediumItalic` for the intended serif styling.
+- The top navigation was restyled with wider desktop spacing and a more responsive condensed behavior for narrower web widths.
 
-Country Comparison Mode Page Web Screen Data Implementation (Issue 100) (May 1, 2026)
-- Completed the Country Comparison Mode web-screen data implementation scope and interaction polish for this issue.
+Core Discovery Flow and Shared UI Systems (April 18, 2026)
+- The discovery experience was split into globe and list-view panels so the app background remains visually stable while secondary content scrolls independently.
+- Search was moved into the main navigation flow instead of remaining the primary planned standalone screen.
+- Shared screen scaffolding and gradient background treatments were added to support a more polished mockup-driven layout direction.
+- The placeholder globe was separated behind platform-specific components so the app can transition to real Mapbox integration later without rewriting the higher-level discovery layout.
+- Country and comparison data views were connected to the existing year-aware mock-data structure.
 
-Implemented data behavior:
-- Country list behavior now requires song availability in app data for the currently selected year (not just hidden-gem availability).
-- Comparison Mode country source wiring was updated to use the broader discovery-backed country source in app state for selection/list availability.
-- Selected comparison-country mapping and available-country handoff were aligned with that same source so selection and result screens stay consistent.
-
-Implemented UI/interaction updates:
-- Select Year dropdown now uses strict available years from metadata API (`loadAvailableYears`) instead of static mock year options.
-- Select Year dropdown now closes when clicking outside of the dropdown.
-- Comparison blurb copy was updated to final issue-aligned usage guidance text.
-- Region filter options were corrected to include the intended continent set while removing non-user-facing placeholders:
-  - removed `Continent info coming soon.`
-  - removed `Other`
-- Language and Genre filter chips were preserved visually and functionally while broader genre/language dataset details remain deferred.
-- Unknown values were removed from Language and Genre filter option lists.
-- Filter changes now auto-clear current selected countries to avoid stale invalid selections under new filter states.
-- Added a `Clear Selections` control next to the selected-count summary in the Select Countries header:
-  - uses matching filter-chip style language
-  - semitransparent treatment in default/hover/press states
-  - only visible when the Select Countries panel is expanded
-- Country-selection helper text remains concise (`x out of 2 countries selected`) after follow-up cleanup.
-
-Filter behavior updates:
-- Region, Language, Genre, and Popularity filters all affect visible country results.
-- Popularity filters (`Biggest Hits`, `Fast Rising Songs`, `All Songs`) now apply concrete list behavior in the comparison-mode country list.
-
-Navigation/task integrity:
-- Existing comparison-mode route flow and button wiring were preserved while implementing these data/filter changes.
-
-Files updated in this issue implementation:
-- `hidden-gem-music-app/src/screens/ComparisonSelectScreen.web.tsx`
-- `hidden-gem-music-app/App.tsx`
-
-Verification:
-- `cd hidden-gem-music-app && npx tsc --noEmit` passed after the final set of issue-100 changes.
+Project Foundation and Screen Architecture (April 17, 2026)
+- React Native project structure was created in `hidden-gem-music-app`.
+- Shared theme primitives were established:
+  - Color tokens
+  - Typography setup
+  - Shared spacing
+  - Reusable panel / button styling
+- Uploaded Nyght Serif and Tanklager font files were wired into the app.
+- Initial route structure was built for:
+  - Welcome
+  - Discovery Globe
+  - Country
+  - Hidden Songs / Hidden Gems
+  - Comparison Select
+  - Comparison Results
+  - Dashboard
+  - Credits
+- Mock data and yearly data helpers were set up so major screens could respond to selected-year changes.
+- A loading overlay pattern was added for year-switching interactions.

--- a/Documents/mp3li implementation timeline document.txt
+++ b/Documents/mp3li implementation timeline document.txt
@@ -258,6 +258,163 @@ Country + Preview Endpoint Verification, Failure Analysis, SQL Fix, and Repro Ha
     - `404` no profile row for valid profile lookup
     - `503` SQL/database failures
     - `500` unexpected failures
+
+Country Detail Web Screen Data Implementation + Discovery Timeline Year Real-Data Alignment (May 1, 2026)
+- Goal for this task:
+  - Replace Country Detail placeholder wiring with live API data (except intentional genre/language deferrals), add list pagination/infinite loading for large song lists, align dropdown/year behavior with real dataset years, and complete Discovery timeline slider year-gap behavior using real years only.
+
+- Scope completed:
+  - Country Detail Web Screen:
+    - Header/dropdown/stat/list/hidden-gems preview/data-loading behavior and endpoint wiring.
+  - Discovery Globe screen:
+    - Timeline slider year source + gap rendering/drag behavior aligned to real available years.
+  - Deferred-by-design areas retained:
+    - Genre + Language data content sections (data not yet available).
+
+- Backend/API implementation completed:
+  - New metadata years API:
+    - Added `GET /api/metadata/years`
+    - Files:
+      - `backend/Capstone.API/Controllers/MetadataController.cs`
+      - `backend/Capstone.API/Infrastructure/Interfaces/IMetadataRepository.cs`
+      - `backend/Capstone.API/Infrastructure/Repositories/MetadataRepository.cs`
+      - `backend/Capstone.API/Program.cs` (DI registration)
+  - Country hidden gems preview endpoint extended:
+    - Existing route now supports `limit` query parameter:
+      - `GET /api/country/{code}/hidden-gems/preview?year={year}&limit={n}`
+    - Files:
+      - `backend/Capstone.API/Controllers/CountryController.cs`
+      - `backend/Capstone.API/Infrastructure/Interfaces/ICountryRepository.cs`
+      - `backend/Capstone.API/Infrastructure/Repositories/CountryRepository.cs`
+      - `backend/Capstone.API/SQL Scripts/read/sp_GetCountryHiddenGemsPreview.sql`
+  - Country year validation contract updated:
+    - Country endpoints now validate `year` against actual DB years from `sp_GetAvailableYears` (instead of legacy hardcoded year window).
+    - File:
+      - `backend/Capstone.API/Controllers/CountryController.cs`
+  - New paged songs endpoint for Country list panels:
+    - Added `GET /api/country/{code}/songs?year={year}&listType={shared|unique}&page={n}&pageSize={n}`
+    - Supports infinite-scroll style front-end loading.
+    - Files:
+      - `backend/Capstone.API/Models/Country/CountrySongsPage.cs`
+      - `backend/Capstone.API/Controllers/CountryController.cs`
+      - `backend/Capstone.API/Infrastructure/Interfaces/ICountryRepository.cs`
+      - `backend/Capstone.API/Infrastructure/Repositories/CountryRepository.cs`
+      - `backend/Capstone.API/SQL Scripts/read/sp_GetCountrySongsPaged.sql`
+
+- SQL procedures added/changed:
+  - Added:
+    - `backend/Capstone.API/SQL Scripts/read/sp_GetAvailableYears.sql`
+    - `backend/Capstone.API/SQL Scripts/read/sp_GetCountrySongsPaged.sql`
+  - Updated:
+    - `backend/Capstone.API/SQL Scripts/read/sp_GetCountryHiddenGemsPreview.sql`
+      - Added `@Limit INT = 5`
+      - `TOP 5` -> `TOP (@Limit)`
+
+- Exact DB-side commands run/validated in this workflow:
+  - `EXEC sp_GetAvailableYears;`
+    - Returned (current restored dataset): `2017, 2018, 2019, 2020, 2021, 2023, 2024, 2025`
+    - Confirms gap year `2022` missing.
+  - `EXEC sp_GetCountryHiddenGemsPreview @CountryCode='US', @Year=2021, @Limit=13;`
+    - Returned 13 rows sorted by trend score.
+  - `EXEC sp_GetCountrySongsPaged @CountryCode='US', @Year=2023, @ListType='unique', @Offset=0, @PageSize=50;`
+  - `EXEC sp_GetCountrySongsPaged @CountryCode='US', @Year=2023, @ListType='shared', @Offset=0, @PageSize=50;`
+
+- Browser/API checks used during verification:
+  - `GET /api/metadata/years`
+  - `GET /api/country/US?year=2023`
+  - `GET /api/country/US/hidden-gems/preview?year=2023&limit=13`
+  - `GET /api/country/US/songs?year=2023&listType=unique&page=1&pageSize=50`
+  - `GET /api/country/US/songs?year=2023&listType=shared&page=1&pageSize=50`
+
+- Frontend implementation completed (Country Detail):
+  - New Country API client:
+    - `hidden-gem-music-app/src/data/countryApi.ts`
+      - loads country profile, hidden-gems preview, metadata years, and paged country songs.
+  - Country screen moved from placeholder-only behavior to live data for implemented sections:
+    - `hidden-gem-music-app/src/screens/CountryScreen.web.tsx`
+  - Country dropdown:
+    - Uses full country data source aligned with Discovery country set.
+    - Click-outside closes dropdown.
+    - Loading popup behavior when changing country.
+  - Year dropdown (Country screen):
+    - Uses only real API years from `/api/metadata/years`.
+    - Click-outside closes dropdown.
+  - Stat square mappings:
+    - Songs in This View -> `totalCharted`
+    - Loved in This Country -> `uniqueCount`
+    - Loved Here and Elsewhere (count) -> `sharedCount`
+    - Loved Here and Elsewhere (%) -> `overlapPct`
+  - Favorite Artists section:
+    - Uses unique-songs artists first; backfills from shared-songs artists if needed.
+    - During initial load, shows animated `Loading...` states instead of placeholder names.
+  - Hidden Gems preview section:
+    - Uses top 13 from country preview endpoint.
+    - During load, displays animated `Loading...` song/artist text instead of placeholder values.
+  - Country list panels:
+    - `Most Loved in This Country` and `Loved Here and Elsewhere` now use paged API endpoint and auto-fetch next pages on near-bottom scroll.
+    - Initial and incremental loading states added.
+  - Language section title updated:
+    - `Country Name's Language(s) in Music`
+  - General Description sentence rewired to requested template style:
+    - Uses current genres + loaded artists/songs.
+    - Uses animated `Loading...` slots while required data is still loading.
+  - Removed placeholder fallbacks for implemented (non-deferred) sections:
+    - Replaced with explicit loading-state behavior to avoid fake content during fetch.
+
+- Frontend implementation completed (Discovery timeline):
+  - Files:
+    - `hidden-gem-music-app/src/components/YearSlider.tsx`
+    - `hidden-gem-music-app/src/screens/DiscoveryScreen.web.tsx`
+    - `hidden-gem-music-app/App.tsx`
+  - Timeline slider now:
+    - Uses API-provided available years.
+    - Computes real missing-year gap from the dataset year list.
+    - Renders gap as one discrete year-slot width.
+    - Prevents thumb from landing in gap; dragging jumps to either valid side.
+
+- Issues encountered and fixes applied:
+  - Hidden Gems page endpoint had mapper key mismatches (`song_title` vs `song_name`, `countries_charting` vs `countries_charting_count`):
+    - Confirmed this affected `/api/hidden-gems/{code}` and not country preview endpoint.
+    - Country-detail preview path remained correct.
+  - Country endpoints originally rejected valid newer years due to old hardcoded validator:
+    - Fixed by year validation against `sp_GetAvailableYears`.
+  - Country list panels still showed placeholder rows after initial integration:
+    - Root cause: combined failure path and fallback generation.
+    - Fixed by independent data fetch handling + no placeholder fallback for those sections.
+  - Discovery country label switched to backend full name (e.g., `United States`) when seed label expected (`USA`):
+    - Fixed merge behavior to preserve existing seed display name when available.
+
+- UI polish changes completed during final pass:
+  - Dropdown click-outside close behavior for Country and Year selectors.
+  - `%` symbol reduced in size for overlap stat square.
+  - Number vertical alignment adjusted in first two stat squares.
+  - Stat square loading text reduced in size while loading.
+
+- Files added in this delivery:
+  - `backend/Capstone.API/Controllers/MetadataController.cs`
+  - `backend/Capstone.API/Infrastructure/Interfaces/IMetadataRepository.cs`
+  - `backend/Capstone.API/Infrastructure/Repositories/MetadataRepository.cs`
+  - `backend/Capstone.API/Models/Country/CountrySongsPage.cs`
+  - `backend/Capstone.API/SQL Scripts/read/sp_GetAvailableYears.sql`
+  - `backend/Capstone.API/SQL Scripts/read/sp_GetCountrySongsPaged.sql`
+  - `hidden-gem-music-app/src/data/countryApi.ts`
+
+- Existing files updated in this delivery:
+  - `backend/Capstone.API/Controllers/CountryController.cs`
+  - `backend/Capstone.API/Infrastructure/Interfaces/ICountryRepository.cs`
+  - `backend/Capstone.API/Infrastructure/Repositories/CountryRepository.cs`
+  - `backend/Capstone.API/Program.cs`
+  - `backend/Capstone.API/SQL Scripts/read/sp_GetCountryHiddenGemsPreview.sql`
+  - `hidden-gem-music-app/App.tsx`
+  - `hidden-gem-music-app/src/components/YearSlider.tsx`
+  - `hidden-gem-music-app/src/screens/DiscoveryScreen.web.tsx`
+  - `hidden-gem-music-app/src/screens/CountryScreen.web.tsx`
+  - `hidden-gem-music-app/src/data/discoveryApi.ts`
+  - `hidden-gem-music-app/src/types/api.ts`
+
+- Build/typecheck verification run:
+  - `dotnet build backend/Capstone.API/Capstone.API.csproj` -> success
+  - `cd hidden-gem-music-app && npx tsc --noEmit` -> success
 - SP contract and mapper cross-check outcome:
   - Confirmed Country repository bindings to:
     - `sp_GetCountryProfile`

--- a/Documents/mp3li implementation timeline document.txt
+++ b/Documents/mp3li implementation timeline document.txt
@@ -1,6 +1,30 @@
-mp3li's Feature Implementation Timeline for Hidden Gem Music
+mp3li implementation timeline document
 
-Updated: April 26, 2026
+Updated: April 29, 2026
+
+Backend Database Connection + Endpoint Validation + Mapper Alignment (April 29, 2026)
+- Local SQL Server database restore was validated through SSMS in Windows 11 on Parallels, and API local hosting was confirmed in macOS Docker setup context.
+- API startup was confirmed working on local dev host:
+  - `dotnet run --project backend/Capstone.API`
+  - `Now listening on: http://localhost:5140`
+- Branch sync work was completed so current feature branch included latest `origin/main` updates:
+  - Local main was updated from origin
+  - `testing-endpoints` was merged forward with latest main
+  - Local uncommitted backend changes were preserved through stash/restore flow
+- Connection string in backend development settings was updated to active working SQL host credentials:
+  - `Server=192.168.111.9,1433;Database=HiddenGemMusic;User Id=sa;Password=Capstone123!;TrustServerCertificate=True;`
+- Endpoint validation exposed a schema-alias mismatch between stored procedure outputs and backend mapping keys:
+  - Stored procedures currently return fields such as `iso_code`, `full_name`, and `song_title`
+  - Existing mapper expected `country_code`, `country_name`, and `song_name`
+- Country repository mapping was updated to support both naming patterns for compatibility with current stored procedure outputs:
+  - Country fields now resolve across old/new alias variants
+  - Song name fields now resolve across `song_name` and `song_title`
+  - Hidden gems country count mapping now supports both `countries_charting_count` and `countries_charting`
+- Build verification succeeded after mapper updates:
+  - `dotnet build backend/Capstone.API` completed with 0 errors
+- Endpoint re-test confirmed successful populated response for country profile:
+  - `http://localhost:5140/api/country/US?year=2021`
+  - `countryCode`, `countryName`, and `songName` now return populated values instead of null
 
 All Web Screens Completed with Placeholder Data (April 26, 2026)
 - All planned web UI screens are now completed in a styled and functional placeholder-data state:

--- a/Documents/mp3li implementation timeline document.txt
+++ b/Documents/mp3li implementation timeline document.txt
@@ -2,6 +2,165 @@ mp3li implementation timeline document
 
 Updated: April 29, 2026
 
+Discovery Globe Data Integration + Discovery Filters Completion + DB Repro Runbook (April 30, 2026)
+- Goal for this task:
+  - Replace Discovery Globe/List mock-country wiring with backend data, complete the Discovery filters popup, and document exact DB-side stored procedure updates required so Leena can recreate the same behavior in SQL Server.
+
+- Branch and scope:
+  - Branch used: `implementing-data-discovery-globe-screen`
+  - Scope intentionally focused on Discovery + Welcome interactions and backend Discovery data contract only.
+
+- Frontend implementation completed:
+  - Discovery country source moved to API-backed loading in app flow:
+    - Added `hidden-gem-music-app/src/data/discoveryApi.ts`
+    - `App.tsx` now loads Discovery countries by year via API and passes that set into `DiscoveryScreen`
+  - Added API normalization/mapping support for Discovery payload:
+    - `hidden-gem-music-app/src/types/api.ts`
+    - `hidden-gem-music-app/src/data/apiMappers.ts`
+  - Discovery list/globe content behavior updates:
+    - Country cards now use consistent stacked layout and bullet details.
+    - Detail copy now uses explicit labels and spacing, including:
+      - `Hidden Gems:  {count}`
+      - `Genre(s):  ...`
+      - `Language(s):  ...`
+    - If a country has no hidden gems in selected year:
+      - `Hidden Gems:  No Hidden Gems for {year}`
+    - If a country has no song data row for that year:
+      - `Most popular album:  No song data for {year}`
+  - Discovery blurb text updated to project-specific copy.
+  - Welcome overlay updates:
+    - Button text updated to `Hidden Gems`
+    - Clicking outside popup closes popup
+  - Discovery filters popup completed and wired functionally:
+    - Smaller header, actual styled Close button with hover/press state
+    - Sort options:
+      - `A--Z`, `Z--A`
+      - Most hidden gems -> least
+      - Least hidden gems -> most
+    - Toggle options:
+      - `Only Show Countries with Hidden Gems`
+      - `Show Countries Without Hidden Gems` (mutually exclusive with above)
+    - Continent filter:
+      - Multi-select
+      - `All Continents` reset option
+      - Region label changed to `Continent`
+      - Display normalization for noisy values:
+        - `Continent info coming soon.` -> `Unknown / Missing`
+        - `Other` -> `Other / Territories`
+    - Filters now apply to BOTH list view and globe from one shared filtered set.
+    - Default state now starts with `Only Show Countries with Hidden Gems` enabled.
+  - Globe-to-list hover interaction refinement:
+    - Auto-scroll now jumps instantly (no visible smooth scrolling) when hover selection changes.
+
+- Backend implementation completed:
+  - Added discovery-specific API route:
+    - `backend/Capstone.API/Controllers/DiscoveryController.cs`
+    - Route: `GET /api/discovery/countries?year={year}`
+  - Discovery backend data model/repository contract expanded:
+    - `backend/Capstone.API/Models/Globe/CountryGlobeSummary.cs`
+      - includes `Region`
+      - includes `TopArtistName`
+    - `backend/Capstone.API/Infrastructure/Repositories/GlobeRepository.cs`
+      - now calls `sp_GetDiscoverPageInfo`
+      - key mapping hardened for multiple alias/casing patterns
+      - maps region, lat/long, hidden gem count, top album, top artist
+  - SQL script rename and contract update:
+    - Removed: `backend/Capstone.API/SQL Scripts/read/sp_GetGlobeSummary.sql`
+    - Added: `backend/Capstone.API/SQL Scripts/read/sp_GetDiscoverPageInfo.sql`
+
+- Critical DB-side reality discovered during verification:
+  - Many countries had `0` chart-entry rows for selected year in `ChartEntry`, so they cannot produce a top song/album/artist for that year.
+  - Non-zero hidden-gem counts and song metadata were present for only part of countries depending on dataset coverage.
+  - `DIM_Song.album_name` is often null; fallback logic is needed if “album” must always show meaningful text.
+  - A pseudo-country row like `-- / Global` can appear in source data and must be filtered out by strict ISO-code constraints.
+
+- Final SQL logic direction for Discovery page info:
+  - Hidden gem count remains sourced from `HiddenGems` by country/year.
+  - Top album/artist is sourced from MOST FREQUENT charted song in country/year from `ChartEntry` (not hidden-gem-only ranking).
+  - This matches “most popular in that country/year” intent.
+
+- DB handoff for Leena:
+  - Apply/refresh procedure: `sp_GetDiscoverPageInfo`
+  - Use the following SQL definition:
+
+```sql
+USE HiddenGemMusic;
+GO
+
+CREATE OR ALTER PROCEDURE sp_GetDiscoverPageInfo
+    @Year INT
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    SELECT
+        c.iso_code AS country_code,
+        c.full_name AS country_name,
+        c.latitude,
+        c.longitude,
+        c.region,
+        ISNULL(hg_agg.hidden_gem_count, 0) AS hidden_gem_count,
+        top_song.top_album_name AS top_album_name,
+        top_song.top_artist_name AS top_artist_name
+    FROM Country c
+    LEFT JOIN (
+        SELECT
+            country_id,
+            COUNT(*) AS hidden_gem_count
+        FROM HiddenGems
+        WHERE chart_year = @Year
+        GROUP BY country_id
+    ) hg_agg ON hg_agg.country_id = c.country_id
+    LEFT JOIN (
+        SELECT
+            ce.country_id,
+            COALESCE(NULLIF(s_inner.album_name, ''), s_inner.title, 'Unknown Song') AS top_album_name,
+            COALESCE(NULLIF(a_inner.artist_name, ''), 'Unknown Artist') AS top_artist_name,
+            ROW_NUMBER() OVER (
+                PARTITION BY ce.country_id
+                ORDER BY COUNT(*) DESC, ce.song_id ASC
+            ) AS rn
+        FROM ChartEntry ce
+        JOIN DIM_Song s_inner ON s_inner.song_id = ce.song_id
+        LEFT JOIN Bridge_SongArtist bsa_inner
+            ON bsa_inner.song_id = s_inner.song_id
+           AND bsa_inner.artist_order = 1
+        LEFT JOIN DIM_Artist a_inner ON a_inner.artist_id = bsa_inner.artist_id
+        WHERE ce.country_id IS NOT NULL
+          AND YEAR(ce.snapshot_date) = @Year
+        GROUP BY ce.country_id, ce.song_id, s_inner.album_name, s_inner.title, a_inner.artist_name
+    ) top_song ON top_song.country_id = c.country_id AND top_song.rn = 1
+    WHERE c.latitude IS NOT NULL
+      AND c.longitude IS NOT NULL
+      AND c.iso_code IS NOT NULL
+      AND LEN(c.iso_code) = 2
+      AND c.iso_code NOT LIKE '%[^A-Z]%'
+    ORDER BY c.full_name;
+END;
+GO
+```
+
+  - Validation query:
+
+```sql
+USE HiddenGemMusic;
+GO
+EXEC sp_GetDiscoverPageInfo @Year = 2021;
+GO
+```
+
+  - Post-apply runtime check points:
+    - Restart backend API host
+    - Re-test endpoint: `http://localhost:5140/api/discovery/countries?year=2021`
+
+- Validation checklist used after implementation:
+  - API returned region/lat/long for countries.
+  - Non-zero hidden-gem countries showed numeric counts.
+  - Countries with no hidden gems showed year-specific “No Hidden Gems” copy.
+  - Countries lacking chart rows showed year-specific “No song data” copy.
+  - Discovery filters changed both list and globe result sets consistently.
+  - Discovery popup controls retained hover/press style parity with existing UI language.
+
 Comparison Endpoint Verification + Hardening + SP Contract Cross-Check (April 29, 2026)
 - Goal for this task:
   - Validate the Country Comparison endpoint behavior, add robust error handling, cross-check backend mapper contracts against comparison SP outputs, confirm whether additional SPs are needed, and document implementation details for team handoff.

--- a/Documents/mp3li implementation timeline document.txt
+++ b/Documents/mp3li implementation timeline document.txt
@@ -815,3 +815,44 @@ Current Follow-up Work
 - Replace the placeholder welcome-screen summary copy with final project language.
 - Continue screen-by-screen visual alignment against the finalized mockups, especially for secondary screens.
 - Recheck narrow-width web behavior after the remaining feature screens fully adopt the updated header and filter-row patterns.
+
+Country Comparison View Page Web Screen Data Implementation (Issue 98) (April 30, 2026)
+- Comparison View was upgraded from mock-data behavior into API-backed country-detail parity on both panes.
+- Each pane now independently loads backend-backed country data using the same implementation pattern used on Country Page:
+  - `GET /api/metadata/years` for year options
+  - `GET /api/country/{code}?year={year}` for country profile stats
+  - `GET /api/country/{code}/hidden-gems/preview?year={year}&limit=13` for hidden-gems carousel preview
+  - `GET /api/country/{code}/songs?year={year}&listType=unique&page={page}&pageSize=50`
+  - `GET /api/country/{code}/songs?year={year}&listType=shared&page={page}&pageSize=50`
+- API mapper parity was added for comparison-pane data transformation:
+  - `mapApiCountryProfile`
+  - `mapApiHiddenGem`
+  - `mapApiSong`
+- Pane-level request lifecycle logic now mirrors Country Page behavior:
+  - reset lists / paging state on country or year change
+  - initial loading states for profile, preview, unique list, shared list
+  - guarded stale-request handling per pane via request id tracking
+  - graceful fallback to existing generated profile values when profile API data is unavailable
+- Both pane song columns now support paged load-more behavior tied to scroll position:
+  - unique list (`Most Loved in This Country`)
+  - shared list (`Loved Here and Elsewhere`)
+- Comparison-pane summary generation now follows the same implementation style used on Country Page:
+  - dynamic general-description text using loaded artists and songs when available
+  - loading-safe fallback copy while data is still resolving
+- Favorite Artists section on Comparison View was aligned to current implementation expectations:
+  - artist cards are sourced from API-derived top unique/shared songs
+  - cards now include artist name plus associated song title
+  - long artist / song text is clamped to 3 lines with ellipsis
+  - horizontal scrolling was enabled with persistent visible horizontal scrollbar treatment
+  - this behavior was implemented for Comparison View only (not Country Page)
+- Comparison-pane year dropdown behavior was corrected to be pane-local:
+  - changing year on left pane affects only left pane
+  - changing year on right pane affects only right pane
+  - shared-year coupling was removed for the comparison results screen
+- Stored procedure and SQL contract note:
+  - no new stored procedure edits were required in this round
+  - existing Country Page SP work was reused (`sp_GetAvailableYears`, `sp_GetCountryHiddenGemsPreview`, `sp_GetCountrySongsPaged`) through current API endpoints
+- Main implementation file updated:
+  - `hidden-gem-music-app/src/screens/ComparisonResultsScreen.web.tsx`
+- Verification completed:
+  - `npx tsc --noEmit` passed after changes

--- a/Documents/mp3li implementation timeline document.txt
+++ b/Documents/mp3li implementation timeline document.txt
@@ -856,3 +856,41 @@ Country Comparison View Page Web Screen Data Implementation (Issue 98) (April 30
   - `hidden-gem-music-app/src/screens/ComparisonResultsScreen.web.tsx`
 - Verification completed:
   - `npx tsc --noEmit` passed after changes
+
+Country Comparison Mode Page Web Screen Data Implementation (Issue 100) (May 1, 2026)
+- Completed the Country Comparison Mode web-screen data implementation scope and interaction polish for this issue.
+
+Implemented data behavior:
+- Country list behavior now requires song availability in app data for the currently selected year (not just hidden-gem availability).
+- Comparison Mode country source wiring was updated to use the broader discovery-backed country source in app state for selection/list availability.
+- Selected comparison-country mapping and available-country handoff were aligned with that same source so selection and result screens stay consistent.
+
+Implemented UI/interaction updates:
+- Select Year dropdown now uses strict available years from metadata API (`loadAvailableYears`) instead of static mock year options.
+- Select Year dropdown now closes when clicking outside of the dropdown.
+- Comparison blurb copy was updated to final issue-aligned usage guidance text.
+- Region filter options were corrected to include the intended continent set while removing non-user-facing placeholders:
+  - removed `Continent info coming soon.`
+  - removed `Other`
+- Language and Genre filter chips were preserved visually and functionally while broader genre/language dataset details remain deferred.
+- Unknown values were removed from Language and Genre filter option lists.
+- Filter changes now auto-clear current selected countries to avoid stale invalid selections under new filter states.
+- Added a `Clear Selections` control next to the selected-count summary in the Select Countries header:
+  - uses matching filter-chip style language
+  - semitransparent treatment in default/hover/press states
+  - only visible when the Select Countries panel is expanded
+- Country-selection helper text remains concise (`x out of 2 countries selected`) after follow-up cleanup.
+
+Filter behavior updates:
+- Region, Language, Genre, and Popularity filters all affect visible country results.
+- Popularity filters (`Biggest Hits`, `Fast Rising Songs`, `All Songs`) now apply concrete list behavior in the comparison-mode country list.
+
+Navigation/task integrity:
+- Existing comparison-mode route flow and button wiring were preserved while implementing these data/filter changes.
+
+Files updated in this issue implementation:
+- `hidden-gem-music-app/src/screens/ComparisonSelectScreen.web.tsx`
+- `hidden-gem-music-app/App.tsx`
+
+Verification:
+- `cd hidden-gem-music-app && npx tsc --noEmit` passed after the final set of issue-100 changes.

--- a/backend/Capstone.API/Controllers/ComparisonController.cs
+++ b/backend/Capstone.API/Controllers/ComparisonController.cs
@@ -1,5 +1,7 @@
 using Capstone.API.Infrastructure.Interfaces;
+using Microsoft.Data.SqlClient;
 using Microsoft.AspNetCore.Mvc;
+using System.Text.RegularExpressions;
 
 namespace Capstone.API.Controllers
 {
@@ -10,14 +12,22 @@ namespace Capstone.API.Controllers
     [Route("api/comparison")]
     public class ComparisonController : ControllerBase
     {
+        private static readonly Regex CountryCodeRegex = new("^[A-Za-z]{2}$", RegexOptions.Compiled);
+        private const int MinSupportedYear = 1975;
+        private const int MaxSupportedYear = 2021;
+        private const int UnavailableGapStartYear = 2007;
+        private const int UnavailableGapEndYear = 2010;
+
         private readonly IComparisonRepository _repo;
+        private readonly ILogger<ComparisonController> _logger;
 
         /// <summary>
         /// Initializes a new instance of ComparisonController.
         /// </summary>
-        public ComparisonController(IComparisonRepository repo)
+        public ComparisonController(IComparisonRepository repo, ILogger<ComparisonController> logger)
         {
             _repo = repo;
+            _logger = logger;
         }
 
         /// <summary>
@@ -33,11 +43,41 @@ namespace Capstone.API.Controllers
             [FromQuery] string countryB,
             [FromQuery] int year = 2021)
         {
-            var result = await _repo.GetCountryComparisonAsync(countryA.ToUpper(), countryB.ToUpper(), year);
-            if (result == null)
-                return NotFound();
+            if (!TryValidateInputs(countryA, countryB, year, out var validationError))
+                return BadRequest(new { message = validationError });
 
-            return Ok(result);
+            try
+            {
+                var result = await _repo.GetCountryComparisonAsync(
+                    countryA.ToUpperInvariant(),
+                    countryB.ToUpperInvariant(),
+                    year);
+
+                if (result == null)
+                    return NotFound();
+
+                return Ok(result);
+            }
+            catch (SqlException ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "SQL error getting country comparison for {CountryA} vs {CountryB} year {Year}",
+                    countryA,
+                    countryB,
+                    year);
+                return StatusCode(503, new { message = "Database temporarily unavailable while retrieving country comparison data." });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "Error getting country comparison for {CountryA} vs {CountryB} year {Year}",
+                    countryA,
+                    countryB,
+                    year);
+                return StatusCode(500, new { message = "An unexpected error occurred while retrieving country comparison data." });
+            }
         }
 
         /// <summary>
@@ -53,8 +93,73 @@ namespace Capstone.API.Controllers
             [FromQuery] string countryB,
             [FromQuery] int year = 2021)
         {
-            var result = await _repo.GetComparisonHiddenGemsAsync(countryA.ToUpper(), countryB.ToUpper(), year);
-            return Ok(result);
+            if (!TryValidateInputs(countryA, countryB, year, out var validationError))
+                return BadRequest(new { message = validationError });
+
+            try
+            {
+                var result = await _repo.GetComparisonHiddenGemsAsync(
+                    countryA.ToUpperInvariant(),
+                    countryB.ToUpperInvariant(),
+                    year);
+                return Ok(result);
+            }
+            catch (SqlException ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "SQL error getting comparison hidden gems for {CountryA} vs {CountryB} year {Year}",
+                    countryA,
+                    countryB,
+                    year);
+                return StatusCode(503, new { message = "Database temporarily unavailable while retrieving comparison hidden gems data." });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "Error getting comparison hidden gems for {CountryA} vs {CountryB} year {Year}",
+                    countryA,
+                    countryB,
+                    year);
+                return StatusCode(500, new { message = "An unexpected error occurred while retrieving comparison hidden gems data." });
+            }
+        }
+
+        private static bool TryValidateInputs(string countryA, string countryB, int year, out string validationError)
+        {
+            if (string.IsNullOrWhiteSpace(countryA) || !CountryCodeRegex.IsMatch(countryA))
+            {
+                validationError = "countryA must be exactly 2 letters (ISO format, e.g. 'US').";
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(countryB) || !CountryCodeRegex.IsMatch(countryB))
+            {
+                validationError = "countryB must be exactly 2 letters (ISO format, e.g. 'GB').";
+                return false;
+            }
+
+            if (countryA.Equals(countryB, StringComparison.OrdinalIgnoreCase))
+            {
+                validationError = "countryA and countryB must be different countries.";
+                return false;
+            }
+
+            if (year < MinSupportedYear || year > MaxSupportedYear)
+            {
+                validationError = $"Year must be between {MinSupportedYear} and {MaxSupportedYear}.";
+                return false;
+            }
+
+            if (year >= UnavailableGapStartYear && year <= UnavailableGapEndYear)
+            {
+                validationError = $"Year {year} is unavailable in this dataset window.";
+                return false;
+            }
+
+            validationError = string.Empty;
+            return true;
         }
     }
 }

--- a/backend/Capstone.API/Controllers/CountryController.cs
+++ b/backend/Capstone.API/Controllers/CountryController.cs
@@ -1,5 +1,7 @@
 using Capstone.API.Infrastructure.Interfaces;
+using Microsoft.Data.SqlClient;
 using Microsoft.AspNetCore.Mvc;
+using System.Text.RegularExpressions;
 
 namespace Capstone.API.Controllers
 {
@@ -8,19 +10,27 @@ namespace Capstone.API.Controllers
     /// </summary>
     [ApiController]
     [Route("api/country")]
-public class CountryController : ControllerBase
-{
-    private readonly ICountryRepository _repo;
-    private readonly ILogger<CountryController> _logger;
+    public class CountryController : ControllerBase
+    {
+        private static readonly Regex CountryCodeRegex = new("^[A-Za-z]{2}$", RegexOptions.Compiled);
+
+        // Keep backend year validation aligned with frontend selectable years.
+        private const int MinSupportedYear = 1975;
+        private const int MaxSupportedYear = 2021;
+        private const int UnavailableGapStartYear = 2007;
+        private const int UnavailableGapEndYear = 2010;
+
+        private readonly ICountryRepository _repo;
+        private readonly ILogger<CountryController> _logger;
 
         /// <summary>
         /// Initializes a new instance of CountryController.
         /// </summary>
-    public CountryController(ICountryRepository repo, ILogger<CountryController> logger)
-    {
-        _repo = repo;
-        _logger = logger;
-    }
+        public CountryController(ICountryRepository repo, ILogger<CountryController> logger)
+        {
+            _repo = repo;
+            _logger = logger;
+        }
 
         /// <summary>
         /// Returns full chart statistics and top song lists for a single country and year.
@@ -28,23 +38,32 @@ public class CountryController : ControllerBase
         /// </summary>
         /// <param name="code">2-letter ISO country code (e.g. "US", "JP").</param>
         /// <param name="year">The chart year to display. Defaults to 2021.</param>
-    [HttpGet("{code}")]
-    public async Task<IActionResult> GetCountryProfile(string code, [FromQuery] int year = 2021)
-    {
-        try
+        [HttpGet("{code}")]
+        public async Task<IActionResult> GetCountryProfile(string code, [FromQuery] int year = 2021)
         {
-            var result = await _repo.GetCountryProfileAsync(code.ToUpper(), year);
-            if (result == null)
-                return NotFound();
+            if (!TryValidateInputs(code, year, out var validationError))
+                return BadRequest(new { message = validationError });
 
-            return Ok(result);
+            try
+            {
+                var normalizedCode = code.ToUpperInvariant();
+                var result = await _repo.GetCountryProfileAsync(normalizedCode, year);
+                if (result == null)
+                    return NotFound();
+
+                return Ok(result);
+            }
+            catch (SqlException ex)
+            {
+                _logger.LogError(ex, "SQL error getting country profile for {CountryCode} year {Year}", code, year);
+                return StatusCode(503, new { message = "Database temporarily unavailable while retrieving country profile data." });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error getting country profile for {CountryCode} year {Year}", code, year);
+                return StatusCode(500, new { message = "An unexpected error occurred while retrieving country profile data." });
+            }
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error getting country profile for {CountryCode} year {Year}", code, year);
-            return StatusCode(500, new { message = "An unexpected error occurred while retrieving country profile data." });
-        }
-    }
 
         /// <summary>
         /// Returns the top 5 hidden gems for the teaser widget on the country profile page.
@@ -52,19 +71,52 @@ public class CountryController : ControllerBase
         /// </summary>
         /// <param name="code">2-letter ISO country code.</param>
         /// <param name="year">The chart year to display. Defaults to 2021.</param>
-    [HttpGet("{code}/hidden-gems/preview")]
-    public async Task<IActionResult> GetHiddenGemsPreview(string code, [FromQuery] int year = 2021)
-    {
-        try
+        [HttpGet("{code}/hidden-gems/preview")]
+        public async Task<IActionResult> GetHiddenGemsPreview(string code, [FromQuery] int year = 2021)
         {
-            var result = await _repo.GetHiddenGemsPreviewAsync(code.ToUpper(), year);
-            return Ok(result);
+            if (!TryValidateInputs(code, year, out var validationError))
+                return BadRequest(new { message = validationError });
+
+            try
+            {
+                var normalizedCode = code.ToUpperInvariant();
+                var result = await _repo.GetHiddenGemsPreviewAsync(normalizedCode, year);
+                return Ok(result);
+            }
+            catch (SqlException ex)
+            {
+                _logger.LogError(ex, "SQL error getting hidden gems preview for {CountryCode} year {Year}", code, year);
+                return StatusCode(503, new { message = "Database temporarily unavailable while retrieving hidden gems preview data." });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error getting hidden gems preview for {CountryCode} year {Year}", code, year);
+                return StatusCode(500, new { message = "An unexpected error occurred while retrieving hidden gems preview data." });
+            }
         }
-        catch (Exception ex)
+
+        private static bool TryValidateInputs(string code, int year, out string validationError)
         {
-            _logger.LogError(ex, "Error getting hidden gems preview for {CountryCode} year {Year}", code, year);
-            return StatusCode(500, new { message = "An unexpected error occurred while retrieving hidden gems preview data." });
+            if (string.IsNullOrWhiteSpace(code) || !CountryCodeRegex.IsMatch(code))
+            {
+                validationError = "Country code must be exactly 2 letters (ISO format, e.g. 'US').";
+                return false;
+            }
+
+            if (year < MinSupportedYear || year > MaxSupportedYear)
+            {
+                validationError = $"Year must be between {MinSupportedYear} and {MaxSupportedYear}.";
+                return false;
+            }
+
+            if (year >= UnavailableGapStartYear && year <= UnavailableGapEndYear)
+            {
+                validationError = $"Year {year} is unavailable in this dataset window.";
+                return false;
+            }
+
+            validationError = string.Empty;
+            return true;
         }
     }
-}
 }

--- a/backend/Capstone.API/Controllers/CountryController.cs
+++ b/backend/Capstone.API/Controllers/CountryController.cs
@@ -8,17 +8,19 @@ namespace Capstone.API.Controllers
     /// </summary>
     [ApiController]
     [Route("api/country")]
-    public class CountryController : ControllerBase
-    {
-        private readonly ICountryRepository _repo;
+public class CountryController : ControllerBase
+{
+    private readonly ICountryRepository _repo;
+    private readonly ILogger<CountryController> _logger;
 
         /// <summary>
         /// Initializes a new instance of CountryController.
         /// </summary>
-        public CountryController(ICountryRepository repo)
-        {
-            _repo = repo;
-        }
+    public CountryController(ICountryRepository repo, ILogger<CountryController> logger)
+    {
+        _repo = repo;
+        _logger = logger;
+    }
 
         /// <summary>
         /// Returns full chart statistics and top song lists for a single country and year.
@@ -26,8 +28,10 @@ namespace Capstone.API.Controllers
         /// </summary>
         /// <param name="code">2-letter ISO country code (e.g. "US", "JP").</param>
         /// <param name="year">The chart year to display. Defaults to 2021.</param>
-        [HttpGet("{code}")]
-        public async Task<IActionResult> GetCountryProfile(string code, [FromQuery] int year = 2021)
+    [HttpGet("{code}")]
+    public async Task<IActionResult> GetCountryProfile(string code, [FromQuery] int year = 2021)
+    {
+        try
         {
             var result = await _repo.GetCountryProfileAsync(code.ToUpper(), year);
             if (result == null)
@@ -35,6 +39,12 @@ namespace Capstone.API.Controllers
 
             return Ok(result);
         }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error getting country profile for {CountryCode} year {Year}", code, year);
+            return StatusCode(500, new { message = "An unexpected error occurred while retrieving country profile data." });
+        }
+    }
 
         /// <summary>
         /// Returns the top 5 hidden gems for the teaser widget on the country profile page.
@@ -42,11 +52,19 @@ namespace Capstone.API.Controllers
         /// </summary>
         /// <param name="code">2-letter ISO country code.</param>
         /// <param name="year">The chart year to display. Defaults to 2021.</param>
-        [HttpGet("{code}/hidden-gems/preview")]
-        public async Task<IActionResult> GetHiddenGemsPreview(string code, [FromQuery] int year = 2021)
+    [HttpGet("{code}/hidden-gems/preview")]
+    public async Task<IActionResult> GetHiddenGemsPreview(string code, [FromQuery] int year = 2021)
+    {
+        try
         {
             var result = await _repo.GetHiddenGemsPreviewAsync(code.ToUpper(), year);
             return Ok(result);
         }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error getting hidden gems preview for {CountryCode} year {Year}", code, year);
+            return StatusCode(500, new { message = "An unexpected error occurred while retrieving hidden gems preview data." });
+        }
     }
+}
 }

--- a/backend/Capstone.API/Controllers/CountryController.cs
+++ b/backend/Capstone.API/Controllers/CountryController.cs
@@ -14,21 +14,26 @@ namespace Capstone.API.Controllers
     {
         private static readonly Regex CountryCodeRegex = new("^[A-Za-z]{2}$", RegexOptions.Compiled);
 
-        // Keep backend year validation aligned with frontend selectable years.
-        private const int MinSupportedYear = 1975;
-        private const int MaxSupportedYear = 2021;
-        private const int UnavailableGapStartYear = 2007;
-        private const int UnavailableGapEndYear = 2010;
+        private const int DefaultPreviewLimit = 5;
+        private const int MaxPreviewLimit = 25;
+        private const int DefaultSongsPage = 1;
+        private const int DefaultSongsPageSize = 50;
+        private const int MaxSongsPageSize = 200;
 
         private readonly ICountryRepository _repo;
+        private readonly IMetadataRepository _metadataRepo;
         private readonly ILogger<CountryController> _logger;
 
         /// <summary>
         /// Initializes a new instance of CountryController.
         /// </summary>
-        public CountryController(ICountryRepository repo, ILogger<CountryController> logger)
+        public CountryController(
+            ICountryRepository repo,
+            IMetadataRepository metadataRepo,
+            ILogger<CountryController> logger)
         {
             _repo = repo;
+            _metadataRepo = metadataRepo;
             _logger = logger;
         }
 
@@ -41,7 +46,8 @@ namespace Capstone.API.Controllers
         [HttpGet("{code}")]
         public async Task<IActionResult> GetCountryProfile(string code, [FromQuery] int year = 2021)
         {
-            if (!TryValidateInputs(code, year, out var validationError))
+            var validationError = await ValidateInputsAsync(code, year);
+            if (validationError != null)
                 return BadRequest(new { message = validationError });
 
             try
@@ -72,15 +78,18 @@ namespace Capstone.API.Controllers
         /// <param name="code">2-letter ISO country code.</param>
         /// <param name="year">The chart year to display. Defaults to 2021.</param>
         [HttpGet("{code}/hidden-gems/preview")]
-        public async Task<IActionResult> GetHiddenGemsPreview(string code, [FromQuery] int year = 2021)
+        public async Task<IActionResult> GetHiddenGemsPreview(string code, [FromQuery] int year = 2021, [FromQuery] int limit = DefaultPreviewLimit)
         {
-            if (!TryValidateInputs(code, year, out var validationError))
+            var validationError = await ValidateInputsAsync(code, year);
+            if (validationError != null)
                 return BadRequest(new { message = validationError });
+
+            var normalizedLimit = Math.Clamp(limit, 1, MaxPreviewLimit);
 
             try
             {
                 var normalizedCode = code.ToUpperInvariant();
-                var result = await _repo.GetHiddenGemsPreviewAsync(normalizedCode, year);
+                var result = await _repo.GetHiddenGemsPreviewAsync(normalizedCode, year, normalizedLimit);
                 return Ok(result);
             }
             catch (SqlException ex)
@@ -95,28 +104,71 @@ namespace Capstone.API.Controllers
             }
         }
 
-        private static bool TryValidateInputs(string code, int year, out string validationError)
+        /// <summary>
+        /// Returns paginated shared or unique songs for the country page list panels.
+        /// GET /api/country/{code}/songs?year={year}&amp;listType={shared|unique}&amp;page={page}&amp;pageSize={pageSize}
+        /// </summary>
+        /// <param name="code">2-letter ISO country code.</param>
+        /// <param name="year">The chart year to display.</param>
+        /// <param name="listType">Either "shared" or "unique".</param>
+        /// <param name="page">1-based page number.</param>
+        /// <param name="pageSize">Results per page.</param>
+        [HttpGet("{code}/songs")]
+        public async Task<IActionResult> GetCountrySongs(
+            string code,
+            [FromQuery] int year = 2021,
+            [FromQuery] string listType = "shared",
+            [FromQuery] int page = DefaultSongsPage,
+            [FromQuery] int pageSize = DefaultSongsPageSize)
+        {
+            var validationError = await ValidateInputsAsync(code, year);
+            if (validationError != null)
+                return BadRequest(new { message = validationError });
+
+            var normalizedListType = listType.Trim().ToLowerInvariant();
+            if (normalizedListType != "shared" && normalizedListType != "unique")
+                return BadRequest(new { message = "listType must be either 'shared' or 'unique'." });
+
+            var normalizedPage = Math.Max(page, 1);
+            var normalizedPageSize = Math.Clamp(pageSize, 1, MaxSongsPageSize);
+
+            try
+            {
+                var normalizedCode = code.ToUpperInvariant();
+                var result = await _repo.GetCountrySongsPageAsync(
+                    normalizedCode,
+                    year,
+                    normalizedListType,
+                    normalizedPage,
+                    normalizedPageSize);
+                return Ok(result);
+            }
+            catch (SqlException ex)
+            {
+                _logger.LogError(ex, "SQL error getting country songs for {CountryCode} year {Year} listType {ListType}", code, year, listType);
+                return StatusCode(503, new { message = "Database temporarily unavailable while retrieving country songs data." });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error getting country songs for {CountryCode} year {Year} listType {ListType}", code, year, listType);
+                return StatusCode(500, new { message = "An unexpected error occurred while retrieving country songs data." });
+            }
+        }
+
+        private async Task<string?> ValidateInputsAsync(string code, int year)
         {
             if (string.IsNullOrWhiteSpace(code) || !CountryCodeRegex.IsMatch(code))
             {
-                validationError = "Country code must be exactly 2 letters (ISO format, e.g. 'US').";
-                return false;
+                return "Country code must be exactly 2 letters (ISO format, e.g. 'US').";
             }
 
-            if (year < MinSupportedYear || year > MaxSupportedYear)
+            var availableYears = (await _metadataRepo.GetAvailableYearsAsync()).ToHashSet();
+            if (!availableYears.Contains(year))
             {
-                validationError = $"Year must be between {MinSupportedYear} and {MaxSupportedYear}.";
-                return false;
+                return $"Year {year} is unavailable in this dataset.";
             }
 
-            if (year >= UnavailableGapStartYear && year <= UnavailableGapEndYear)
-            {
-                validationError = $"Year {year} is unavailable in this dataset window.";
-                return false;
-            }
-
-            validationError = string.Empty;
-            return true;
+            return null;
         }
     }
 }

--- a/backend/Capstone.API/Controllers/DiscoveryController.cs
+++ b/backend/Capstone.API/Controllers/DiscoveryController.cs
@@ -1,0 +1,32 @@
+using Capstone.API.Infrastructure.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Capstone.API.Controllers
+{
+    /// <summary>
+    /// Serves shared country summary data for the Discovery experience.
+    /// The globe and list consume this same payload and render it differently.
+    /// </summary>
+    [ApiController]
+    [Route("api/discovery")]
+    public class DiscoveryController : ControllerBase
+    {
+        private readonly IGlobeRepository _repo;
+
+        public DiscoveryController(IGlobeRepository repo)
+        {
+            _repo = repo;
+        }
+
+        /// <summary>
+        /// Returns one summary row per country for Discovery list + globe.
+        /// GET /api/discovery/countries?year={year}
+        /// </summary>
+        [HttpGet("countries")]
+        public async Task<IActionResult> GetDiscoveryCountries([FromQuery] int year = 2021)
+        {
+            var result = await _repo.GetGlobeSummaryAsync(year);
+            return Ok(result);
+        }
+    }
+}

--- a/backend/Capstone.API/Controllers/MetadataController.cs
+++ b/backend/Capstone.API/Controllers/MetadataController.cs
@@ -1,0 +1,34 @@
+using Capstone.API.Infrastructure.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Capstone.API.Controllers
+{
+    /// <summary>
+    /// Serves shared metadata used by frontend controls.
+    /// </summary>
+    [ApiController]
+    [Route("api/metadata")]
+    public class MetadataController : ControllerBase
+    {
+        private readonly IMetadataRepository _repo;
+
+        /// <summary>
+        /// Initializes a new instance of MetadataController.
+        /// </summary>
+        public MetadataController(IMetadataRepository repo)
+        {
+            _repo = repo;
+        }
+
+        /// <summary>
+        /// Returns available chart years that have data.
+        /// GET /api/metadata/years
+        /// </summary>
+        [HttpGet("years")]
+        public async Task<IActionResult> GetAvailableYears()
+        {
+            var years = await _repo.GetAvailableYearsAsync();
+            return Ok(years);
+        }
+    }
+}

--- a/backend/Capstone.API/Documentation/ADR-BACKEND-002-Routes-Controllers-DTOs.md
+++ b/backend/Capstone.API/Documentation/ADR-BACKEND-002-Routes-Controllers-DTOs.md
@@ -7,6 +7,20 @@
 
 ---
 
+## April 29, 2026 Verification Addendum (Country Endpoints)
+
+- `CountryController` input validation now enforces:
+  - `code` must be exactly 2 letters (`400` on failure)
+  - `year` must be in dataset-supported range `1975..2021`, excluding known unavailable gap years `2007..2010` (`400` on failure)
+- Error handling for Country endpoints now distinguishes:
+  - `400` invalid input
+  - `404` valid input but no profile row for `/api/country/{code}`
+  - `503` SQL/database failures
+  - `500` unexpected failures
+- `sp_GetCountryHiddenGemsPreview` was cross-checked against a restored local DB that initially had an outdated procedure version referencing legacy table `Song`.
+  - Required/current version uses star schema joins: `DIM_Song`, `Bridge_SongArtist`, `DIM_Artist`.
+  - After applying `CREATE OR ALTER PROCEDURE` with star schema joins, preview endpoint returned valid JSON.
+
 ## Context
 
 This ADR documents the concrete implementation of the API surface: every route, controller action, repository method, stored procedure call, and DTO field mapping. It was written after the code compiled and built successfully, and reflects the actual state of the files — not the planning document.
@@ -83,7 +97,9 @@ All country codes are normalized to uppercase (`.ToUpper()`) at the controller b
 
 **Route params:** `code` (2-letter ISO, normalized to uppercase)
 **Query params:** `year` (int)
+**Input validation:** `code` must be 2 letters; `year` must be `1975..2021` excluding `2007..2010` (`400` on validation failure).
 **Returns 404** if `GetCountryProfileAsync` returns null (country/year combination not found).
+**Returns 503** for SQL/database failures; **500** for unexpected failures.
 
 ---
 
@@ -161,21 +177,21 @@ For each SP: the name as hard-coded in the repository, the parameter names as pa
 | 1 | Top shared songs | `CountryProfile.TopSharedSongs` |
 | 2 | Top unique songs | `CountryProfile.TopUniqueSongs` |
 
-**Set 0 expected columns:**
+**Set 0 expected columns (verified aliases):**
 | Column | C# property | Type |
 |--------|------------|------|
-| `country_code` | `CountryProfile.CountryCode` | string? |
-| `country_name` | `CountryProfile.CountryName` | string? |
+| `country_code` or `iso_code` | `CountryProfile.CountryCode` | string? |
+| `country_name` or `full_name` | `CountryProfile.CountryName` | string? |
 | `chart_year` | `CountryProfile.Year` | int |
 | `total_charted` | `CountryProfile.TotalCharted` | int |
 | `shared_count` | `CountryProfile.SharedCount` | int |
 | `unique_count` | `CountryProfile.UniqueCount` | int |
 | `overlap_pct` | `CountryProfile.OverlapPct` | decimal |
 
-**Sets 1 and 2 expected columns (Song):**
+**Sets 1 and 2 expected columns (Song, verified aliases):**
 | Column | C# property | Type |
 |--------|------------|------|
-| `song_name` | `Song.SongName` | string? |
+| `song_name` or `song_title` | `Song.SongName` | string? |
 | `artist_name` | `Song.ArtistName` | string? |
 | `album_name` | `Song.AlbumName` | string? |
 
@@ -184,7 +200,15 @@ For each SP: the name as hard-coded in the repository, the parameter names as pa
 ### 3.3 `sp_GetCountryHiddenGemsPreview`
 **Repository:** `CountryRepository.GetHiddenGemsPreviewAsync`
 **Params:** `@CountryCode CHAR(2)`, `@Year INT`
-**Expected output columns:** Same as Section 3.5 (HiddenGem shape).
+**Expected output columns (verified aliases):**
+- `song_name` or `song_title` → `HiddenGem.SongName`
+- `album_name` → `HiddenGem.AlbumName`
+- `artist_name` → `HiddenGem.ArtistName`
+- `trend_score` → `HiddenGem.TrendScore`
+- `countries_charting_count` or `countries_charting` → `HiddenGem.CountriesChartingCount`
+
+**Required stored procedure version note:**
+- Procedure must reference star-schema tables (`DIM_Song`, `Bridge_SongArtist`, `DIM_Artist`), not legacy `Song`.
 
 ---
 

--- a/backend/Capstone.API/Infrastructure/Interfaces/ICountryRepository.cs
+++ b/backend/Capstone.API/Infrastructure/Interfaces/ICountryRepository.cs
@@ -17,11 +17,23 @@ namespace Capstone.API.Infrastructure.Interfaces
         Task<CountryProfile?> GetCountryProfileAsync(string countryCode, int year);
 
         /// <summary>
-        /// Returns the top 5 hidden gems for the teaser widget on the country page.
+        /// Returns hidden gems for the teaser widget on the country page.
         /// Calls sp_GetCountryHiddenGemsPreview.
         /// </summary>
         /// <param name="countryCode">2-letter ISO country code.</param>
         /// <param name="year">The chart year to filter by.</param>
-        Task<IEnumerable<HiddenGem>> GetHiddenGemsPreviewAsync(string countryCode, int year);
+        /// <param name="limit">Maximum number of rows to return.</param>
+        Task<IEnumerable<HiddenGem>> GetHiddenGemsPreviewAsync(string countryCode, int year, int limit);
+
+        /// <summary>
+        /// Returns a paginated list of shared or unique songs for a country-year view.
+        /// Calls sp_GetCountrySongsPaged.
+        /// </summary>
+        /// <param name="countryCode">2-letter ISO country code.</param>
+        /// <param name="year">The chart year to filter by.</param>
+        /// <param name="listType">Either "shared" or "unique".</param>
+        /// <param name="page">1-based page number.</param>
+        /// <param name="pageSize">Results per page.</param>
+        Task<CountrySongsPage> GetCountrySongsPageAsync(string countryCode, int year, string listType, int page, int pageSize);
     }
 }

--- a/backend/Capstone.API/Infrastructure/Interfaces/IMetadataRepository.cs
+++ b/backend/Capstone.API/Infrastructure/Interfaces/IMetadataRepository.cs
@@ -1,0 +1,14 @@
+namespace Capstone.API.Infrastructure.Interfaces
+{
+    /// <summary>
+    /// Defines data access for shared metadata endpoints.
+    /// </summary>
+    public interface IMetadataRepository
+    {
+        /// <summary>
+        /// Returns the list of available chart years present in the dataset.
+        /// Calls sp_GetAvailableYears.
+        /// </summary>
+        Task<IEnumerable<int>> GetAvailableYearsAsync();
+    }
+}

--- a/backend/Capstone.API/Infrastructure/Repositories/ComparisonRepository.cs
+++ b/backend/Capstone.API/Infrastructure/Repositories/ComparisonRepository.cs
@@ -71,8 +71,8 @@ namespace Capstone.API.Infrastructure.Repositories
         {
             return new CountryComparisonSide
             {
-                CountryCode = AsString(row, "country_code"),
-                CountryName = AsString(row, "country_name"),
+                CountryCode = AsString(row, "country_code", "iso_code"),
+                CountryName = AsString(row, "country_name", "full_name"),
                 TotalCharted = AsInt(row, "total_charted"),
                 SharedCount = AsInt(row, "shared_count"),
                 UniqueCount = AsInt(row, "unique_count"),
@@ -84,7 +84,7 @@ namespace Capstone.API.Infrastructure.Repositories
         {
             return new SharedSong
             {
-                SongName = AsString(row, "song_name"),
+                SongName = AsString(row, "song_name", "song_title", "title"),
                 ArtistName = AsString(row, "artist_name"),
                 AlbumName = AsString(row, "album_name"),
                 RankInCountryA = AsInt(row, "rank_in_country_a"),
@@ -96,7 +96,7 @@ namespace Capstone.API.Infrastructure.Repositories
         {
             return new Song
             {
-                SongName = AsString(row, "song_name"),
+                SongName = AsString(row, "song_name", "song_title", "title"),
                 ArtistName = AsString(row, "artist_name"),
                 AlbumName = AsString(row, "album_name")
             };
@@ -106,21 +106,45 @@ namespace Capstone.API.Infrastructure.Repositories
         {
             return new ComparisonHiddenGem
             {
-                SongName = AsString(row, "song_name"),
+                SongName = AsString(row, "song_name", "song_title", "title"),
                 AlbumName = AsString(row, "album_name"),
                 ArtistName = AsString(row, "artist_name"),
                 TrendScore = AsDecimal(row, "trend_score"),
-                CountriesChartingCount = AsInt(row, "countries_charting_count")
+                CountriesChartingCount = AsInt(row, "countries_charting_count", "countries_charting", "country_count")
             };
         }
 
-        private static string? AsString(IDictionary<string, object?> row, string key)
-            => row.TryGetValue(key, out var v) ? v?.ToString() : null;
+        private static string? AsString(IDictionary<string, object?> row, params string[] keys)
+        {
+            foreach (var key in keys)
+            {
+                if (row.TryGetValue(key, out var value) && value != null)
+                    return value.ToString();
+            }
 
-        private static int AsInt(IDictionary<string, object?> row, string key)
-            => row.TryGetValue(key, out var v) && v != null ? Convert.ToInt32(v) : 0;
+            return null;
+        }
 
-        private static decimal AsDecimal(IDictionary<string, object?> row, string key)
-            => row.TryGetValue(key, out var v) && v != null ? Convert.ToDecimal(v) : 0m;
+        private static int AsInt(IDictionary<string, object?> row, params string[] keys)
+        {
+            foreach (var key in keys)
+            {
+                if (row.TryGetValue(key, out var value) && value != null)
+                    return Convert.ToInt32(value);
+            }
+
+            return 0;
+        }
+
+        private static decimal AsDecimal(IDictionary<string, object?> row, params string[] keys)
+        {
+            foreach (var key in keys)
+            {
+                if (row.TryGetValue(key, out var value) && value != null)
+                    return Convert.ToDecimal(value);
+            }
+
+            return 0m;
+        }
     }
 }

--- a/backend/Capstone.API/Infrastructure/Repositories/CountryRepository.cs
+++ b/backend/Capstone.API/Infrastructure/Repositories/CountryRepository.cs
@@ -38,13 +38,13 @@ namespace Capstone.API.Infrastructure.Repositories
 
             var profile = new CountryProfile
             {
-                CountryCode = AsString(stats, "country_code"),
-                CountryName = AsString(stats, "country_name"),
-                Year = AsInt(stats, "chart_year"),
-                TotalCharted = AsInt(stats, "total_charted"),
-                SharedCount = AsInt(stats, "shared_count"),
-                UniqueCount = AsInt(stats, "unique_count"),
-                OverlapPct = AsDecimal(stats, "overlap_pct")
+                CountryCode = AsStringAny(stats, "country_code", "iso_code"),
+                CountryName = AsStringAny(stats, "country_name", "full_name"),
+                Year = AsIntAny(stats, "chart_year", "year"),
+                TotalCharted = AsIntAny(stats, "total_charted"),
+                SharedCount = AsIntAny(stats, "shared_count"),
+                UniqueCount = AsIntAny(stats, "unique_count"),
+                OverlapPct = AsDecimalAny(stats, "overlap_pct")
             };
 
             if (sets.Count > 1)
@@ -72,9 +72,9 @@ namespace Capstone.API.Infrastructure.Repositories
         {
             return new Song
             {
-                SongName = AsString(row, "song_name"),
-                ArtistName = AsString(row, "artist_name"),
-                AlbumName = AsString(row, "album_name")
+                SongName = AsStringAny(row, "song_name", "song_title", "title"),
+                ArtistName = AsStringAny(row, "artist_name"),
+                AlbumName = AsStringAny(row, "album_name")
             };
         }
 
@@ -82,23 +82,47 @@ namespace Capstone.API.Infrastructure.Repositories
         {
             return new HiddenGem
             {
-                SongName = AsString(row, "song_name"),
-                AlbumName = AsString(row, "album_name"),
-                ArtistName = AsString(row, "artist_name"),
-                Genre = AsString(row, "genre"),
-                PreviewUrl = AsString(row, "preview_url"),
-                TrendScore = AsDecimal(row, "trend_score"),
-                CountriesChartingCount = AsInt(row, "countries_charting_count")
+                SongName = AsStringAny(row, "song_name", "song_title", "title"),
+                AlbumName = AsStringAny(row, "album_name"),
+                ArtistName = AsStringAny(row, "artist_name"),
+                Genre = AsStringAny(row, "genre"),
+                PreviewUrl = AsStringAny(row, "preview_url"),
+                TrendScore = AsDecimalAny(row, "trend_score"),
+                CountriesChartingCount = AsIntAny(row, "countries_charting_count", "countries_charting")
             };
         }
 
-        private static string? AsString(IDictionary<string, object?> row, string key)
-            => row.TryGetValue(key, out var v) ? v?.ToString() : null;
+        private static string? AsStringAny(IDictionary<string, object?> row, params string[] keys)
+        {
+            foreach (var key in keys)
+            {
+                if (row.TryGetValue(key, out var v) && v != null)
+                    return v.ToString();
+            }
 
-        private static int AsInt(IDictionary<string, object?> row, string key)
-            => row.TryGetValue(key, out var v) && v != null ? Convert.ToInt32(v) : 0;
+            return null;
+        }
 
-        private static decimal AsDecimal(IDictionary<string, object?> row, string key)
-            => row.TryGetValue(key, out var v) && v != null ? Convert.ToDecimal(v) : 0m;
+        private static int AsIntAny(IDictionary<string, object?> row, params string[] keys)
+        {
+            foreach (var key in keys)
+            {
+                if (row.TryGetValue(key, out var v) && v != null)
+                    return Convert.ToInt32(v);
+            }
+
+            return 0;
+        }
+
+        private static decimal AsDecimalAny(IDictionary<string, object?> row, params string[] keys)
+        {
+            foreach (var key in keys)
+            {
+                if (row.TryGetValue(key, out var v) && v != null)
+                    return Convert.ToDecimal(v);
+            }
+
+            return 0m;
+        }
     }
 }

--- a/backend/Capstone.API/Infrastructure/Repositories/CountryRepository.cs
+++ b/backend/Capstone.API/Infrastructure/Repositories/CountryRepository.cs
@@ -57,15 +57,46 @@ namespace Capstone.API.Infrastructure.Repositories
         }
 
         /// <inheritdoc/>
-        public async Task<IEnumerable<HiddenGem>> GetHiddenGemsPreviewAsync(string countryCode, int year)
+        public async Task<IEnumerable<HiddenGem>> GetHiddenGemsPreviewAsync(string countryCode, int year, int limit)
         {
             var rows = await _db.GetDataAsync("sp_GetCountryHiddenGemsPreview", new Dictionary<string, object?>
             {
                 { "@CountryCode", countryCode },
-                { "@Year", year }
+                { "@Year", year },
+                { "@Limit", limit }
             });
 
             return rows.Select(MapHiddenGem);
+        }
+
+        /// <inheritdoc/>
+        public async Task<CountrySongsPage> GetCountrySongsPageAsync(string countryCode, int year, string listType, int page, int pageSize)
+        {
+            var safePage = Math.Max(page, 1);
+            var safePageSize = Math.Clamp(pageSize, 1, 100);
+            var offset = (safePage - 1) * safePageSize;
+
+            var rows = (await _db.GetDataAsync("sp_GetCountrySongsPaged", new Dictionary<string, object?>
+            {
+                { "@CountryCode", countryCode },
+                { "@Year", year },
+                { "@ListType", listType },
+                { "@Offset", offset },
+                { "@PageSize", safePageSize }
+            })).ToList();
+
+            var totalCount = rows.Count > 0 ? AsIntAny(rows[0], "total_count", "TotalCount") : 0;
+            var items = rows.Select(MapSong).ToList();
+            var loadedItemCount = offset + items.Count;
+
+            return new CountrySongsPage
+            {
+                Items = items,
+                Page = safePage,
+                PageSize = safePageSize,
+                TotalCount = totalCount,
+                HasMore = loadedItemCount < totalCount
+            };
         }
 
         private static Song MapSong(IDictionary<string, object?> row)

--- a/backend/Capstone.API/Infrastructure/Repositories/GlobeRepository.cs
+++ b/backend/Capstone.API/Infrastructure/Repositories/GlobeRepository.cs
@@ -4,7 +4,7 @@ using Capstone.API.Models.Globe;
 namespace Capstone.API.Infrastructure.Repositories
 {
     /// <summary>
-    /// Retrieves globe summary data by calling sp_GetGlobeSummary on the pre-computed summary tables.
+    /// Retrieves discovery country data by calling sp_GetDiscoverPageInfo on the pre-computed summary tables.
     /// Never touches ChartEntry directly.
     /// </summary>
     public class GlobeRepository : IGlobeRepository
@@ -22,7 +22,7 @@ namespace Capstone.API.Infrastructure.Repositories
         /// <inheritdoc/>
         public async Task<IEnumerable<CountryGlobeSummary>> GetGlobeSummaryAsync(int year)
         {
-            var rows = await _db.GetDataAsync("sp_GetGlobeSummary", new Dictionary<string, object?>
+            var rows = await _db.GetDataAsync("sp_GetDiscoverPageInfo", new Dictionary<string, object?>
             {
                 { "@Year", year }
             });
@@ -34,22 +34,48 @@ namespace Capstone.API.Infrastructure.Repositories
         {
             return new CountryGlobeSummary
             {
-                CountryCode = AsString(row, "country_code"),
-                CountryName = AsString(row, "country_name"),
-                Lat = AsDouble(row, "lat"),
-                Long = AsDouble(row, "long"),
-                HiddenGemCount = AsInt(row, "hidden_gem_count"),
-                TopAlbumName = AsString(row, "top_album_name")
+                CountryCode = AsStringAny(row, "country_code", "countryCode", "CountryCode", "iso_code"),
+                CountryName = AsStringAny(row, "country_name", "countryName", "CountryName", "full_name"),
+                Region = AsStringAny(row, "region", "Region"),
+                Lat = AsDoubleAny(row, "latitude", "lat", "Latitude", "Lat"),
+                Long = AsDoubleAny(row, "longitude", "long", "Longitude", "Long"),
+                HiddenGemCount = AsIntAny(row, "hidden_gem_count", "hiddenGemCount", "HiddenGemCount"),
+                TopAlbumName = AsStringAny(row, "top_album_name", "topAlbumName", "TopAlbumName"),
+                TopArtistName = AsStringAny(row, "top_artist_name", "topArtistName", "TopArtistName")
             };
         }
 
-        private static string? AsString(IDictionary<string, object?> row, string key)
-            => row.TryGetValue(key, out var v) ? v?.ToString() : null;
+        private static string? AsStringAny(IDictionary<string, object?> row, params string[] keys)
+        {
+            foreach (var key in keys)
+            {
+                if (row.TryGetValue(key, out var v) && v != null)
+                    return v.ToString();
+            }
 
-        private static int AsInt(IDictionary<string, object?> row, string key)
-            => row.TryGetValue(key, out var v) && v != null ? Convert.ToInt32(v) : 0;
+            return null;
+        }
 
-        private static double AsDouble(IDictionary<string, object?> row, string key)
-            => row.TryGetValue(key, out var v) && v != null ? Convert.ToDouble(v) : 0.0;
+        private static int AsIntAny(IDictionary<string, object?> row, params string[] keys)
+        {
+            foreach (var key in keys)
+            {
+                if (row.TryGetValue(key, out var v) && v != null)
+                    return Convert.ToInt32(v);
+            }
+
+            return 0;
+        }
+
+        private static double AsDoubleAny(IDictionary<string, object?> row, params string[] keys)
+        {
+            foreach (var key in keys)
+            {
+                if (row.TryGetValue(key, out var v) && v != null)
+                    return Convert.ToDouble(v);
+            }
+
+            return 0.0;
+        }
     }
 }

--- a/backend/Capstone.API/Infrastructure/Repositories/MetadataRepository.cs
+++ b/backend/Capstone.API/Infrastructure/Repositories/MetadataRepository.cs
@@ -1,0 +1,42 @@
+using Capstone.API.Infrastructure.Interfaces;
+
+namespace Capstone.API.Infrastructure.Repositories
+{
+    /// <summary>
+    /// Retrieves shared metadata used by multiple frontend controls.
+    /// </summary>
+    public class MetadataRepository : IMetadataRepository
+    {
+        private readonly IDataRepository _db;
+
+        /// <summary>
+        /// Initializes a new instance of MetadataRepository using the default connection.
+        /// </summary>
+        public MetadataRepository(IDataRepositoryFactory factory)
+        {
+            _db = factory.Create("DefaultConnection");
+        }
+
+        /// <inheritdoc/>
+        public async Task<IEnumerable<int>> GetAvailableYearsAsync()
+        {
+            var rows = await _db.GetDataAsync("sp_GetAvailableYears");
+
+            return rows
+                .Select((row) =>
+                {
+                    if (row.TryGetValue("chart_year", out var chartYear) && chartYear != null)
+                        return Convert.ToInt32(chartYear);
+
+                    if (row.TryGetValue("year", out var year) && year != null)
+                        return Convert.ToInt32(year);
+
+                    return 0;
+                })
+                .Where((year) => year > 0)
+                .Distinct()
+                .OrderBy((year) => year)
+                .ToList();
+        }
+    }
+}

--- a/backend/Capstone.API/Models/Country/CountrySongsPage.cs
+++ b/backend/Capstone.API/Models/Country/CountrySongsPage.cs
@@ -1,0 +1,35 @@
+using Capstone.API.Models.Shared;
+
+namespace Capstone.API.Models.Country
+{
+    /// <summary>
+    /// Represents a paginated songs response for country shared/unique song lists.
+    /// </summary>
+    public class CountrySongsPage
+    {
+        /// <summary>
+        /// Gets or sets the returned page items.
+        /// </summary>
+        public List<Song> Items { get; set; } = new();
+
+        /// <summary>
+        /// Gets or sets the current 1-based page number.
+        /// </summary>
+        public int Page { get; set; }
+
+        /// <summary>
+        /// Gets or sets the page size used for this response.
+        /// </summary>
+        public int PageSize { get; set; }
+
+        /// <summary>
+        /// Gets or sets total items available for this list type.
+        /// </summary>
+        public int TotalCount { get; set; }
+
+        /// <summary>
+        /// Gets whether there are additional pages available.
+        /// </summary>
+        public bool HasMore { get; set; }
+    }
+}

--- a/backend/Capstone.API/Models/Globe/CountryGlobeSummary.cs
+++ b/backend/Capstone.API/Models/Globe/CountryGlobeSummary.cs
@@ -17,6 +17,11 @@ namespace Capstone.API.Models.Globe
         public string? CountryName { get; set; }
 
         /// <summary>
+        /// Gets or sets the geographic region/continent label for this country.
+        /// </summary>
+        public string? Region { get; set; }
+
+        /// <summary>
         /// Gets or sets the latitude for Mapbox dot placement.
         /// </summary>
         public double Lat { get; set; }
@@ -36,5 +41,11 @@ namespace Capstone.API.Models.Globe
         /// Nullable — may not be available for all countries.
         /// </summary>
         public string? TopAlbumName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the primary artist associated with the top discovery item.
+        /// Nullable — may not be available for all countries.
+        /// </summary>
+        public string? TopArtistName { get; set; }
     }
 }

--- a/backend/Capstone.API/Program.cs
+++ b/backend/Capstone.API/Program.cs
@@ -26,6 +26,7 @@ builder.Services.AddScoped<ICountryRepository, CountryRepository>();
 builder.Services.AddScoped<IHiddenGemsRepository, HiddenGemsRepository>();
 builder.Services.AddScoped<IComparisonRepository, ComparisonRepository>();
 builder.Services.AddScoped<IDashboardRepository, DashboardRepository>();
+builder.Services.AddScoped<IMetadataRepository, MetadataRepository>();
 
 var app = builder.Build();
 

--- a/backend/Capstone.API/SQL Scripts/read/sp_GetAvailableYears.sql
+++ b/backend/Capstone.API/SQL Scripts/read/sp_GetAvailableYears.sql
@@ -1,0 +1,22 @@
+-- =============================================
+-- Author:      Hidden Gem Music Team
+-- Create date: 04/30/2026
+-- Description: Returns sorted list of chart years with available data.
+-- EXEC sp_GetAvailableYears;
+-- =============================================
+
+USE HiddenGemMusic;
+GO
+
+CREATE OR ALTER PROCEDURE sp_GetAvailableYears
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    SELECT DISTINCT
+        YEAR(snapshot_date) AS chart_year
+    FROM ChartEntry
+    WHERE snapshot_date IS NOT NULL
+    ORDER BY chart_year ASC;
+END;
+GO

--- a/backend/Capstone.API/SQL Scripts/read/sp_GetCountryHiddenGemsPreview.sql
+++ b/backend/Capstone.API/SQL Scripts/read/sp_GetCountryHiddenGemsPreview.sql
@@ -14,12 +14,13 @@ GO
 
 CREATE OR ALTER PROCEDURE sp_GetCountryHiddenGemsPreview
     @CountryCode CHAR(2),
-    @Year        INT
+    @Year        INT,
+    @Limit       INT = 5
 AS
 BEGIN
     SET NOCOUNT ON;
 
-    SELECT TOP 5
+    SELECT TOP (@Limit)
         s.song_id,
         s.title         AS song_title,
         a.artist_name,

--- a/backend/Capstone.API/SQL Scripts/read/sp_GetCountrySongsPaged.sql
+++ b/backend/Capstone.API/SQL Scripts/read/sp_GetCountrySongsPaged.sql
@@ -1,0 +1,76 @@
+-- =============================================
+-- Author:      Hidden Gem Music Team
+-- Create date: 05/01/2026
+-- Description: Returns paginated shared/unique songs for a country-year view.
+-- EXEC sp_GetCountrySongsPaged @CountryCode='US', @Year=2023, @ListType='shared', @Offset=0, @PageSize=50;
+-- =============================================
+
+USE HiddenGemMusic;
+GO
+
+CREATE OR ALTER PROCEDURE sp_GetCountrySongsPaged
+    @CountryCode CHAR(2),
+    @Year        INT,
+    @ListType    NVARCHAR(16),
+    @Offset      INT = 0,
+    @PageSize    INT = 50
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    DECLARE @CountryId INT = (
+        SELECT country_id
+        FROM Country
+        WHERE iso_code = @CountryCode
+    );
+
+    ;WITH Filtered AS (
+        SELECT
+            s.song_id,
+            s.title AS song_title,
+            a.artist_name,
+            s.album_name,
+            scp.country_count
+        FROM SongCountryPresence scp
+        JOIN DIM_Song s
+            ON s.song_id = scp.song_id
+        LEFT JOIN Bridge_SongArtist bsa
+            ON bsa.song_id = s.song_id
+           AND bsa.artist_order = 1
+        LEFT JOIN DIM_Artist a
+            ON a.artist_id = bsa.artist_id
+        WHERE scp.chart_year = @Year
+          AND (
+                (@ListType = 'shared'
+                 AND scp.country_count > 1
+                 AND NOT EXISTS (
+                    SELECT 1
+                    FROM HiddenGems hg
+                    WHERE hg.country_id = @CountryId
+                      AND hg.song_id = scp.song_id
+                      AND hg.chart_year = @Year
+                 ))
+                OR
+                (@ListType = 'unique'
+                 AND scp.country_count = 1
+                 AND NOT EXISTS (
+                    SELECT 1
+                    FROM HiddenGems hg
+                    WHERE hg.song_id = scp.song_id
+                      AND hg.chart_year = @Year
+                 ))
+              )
+    )
+    SELECT
+        song_title,
+        artist_name,
+        album_name,
+        COUNT(1) OVER() AS total_count
+    FROM Filtered
+    ORDER BY
+        CASE WHEN @ListType = 'shared' THEN country_count END DESC,
+        song_title ASC
+    OFFSET @Offset ROWS
+    FETCH NEXT @PageSize ROWS ONLY;
+END;
+GO

--- a/backend/Capstone.API/SQL Scripts/read/sp_GetDiscoverPageInfo.sql
+++ b/backend/Capstone.API/SQL Scripts/read/sp_GetDiscoverPageInfo.sql
@@ -7,13 +7,13 @@
 --              on DIM_Song, no album_id FK needed.
 -- Description: One lightweight row per country for globe dots and country list sidebar.
 -- Also feeds Mapbox tileset export. Reads only pre-computed tables.
--- EXEC sp_GetGlobeSummary @Year = 2021;
+-- EXEC sp_GetDiscoverPageInfo @Year = 2021;
 -- =============================================
 
 USE HiddenGemMusic;
 GO
 
-CREATE OR ALTER PROCEDURE sp_GetGlobeSummary
+CREATE OR ALTER PROCEDURE sp_GetDiscoverPageInfo
     @Year INT
 AS
 BEGIN
@@ -26,7 +26,8 @@ BEGIN
         c.longitude,
         c.region,
         ISNULL(hg_agg.hidden_gem_count, 0)  AS hidden_gem_count,
-        top_alb.album_name                  AS top_album_name
+        top_song.album_name                 AS top_album_name,
+        top_song.artist_name                AS top_artist_name
     FROM Country c
     -- hidden gem count per country
     LEFT JOIN (
@@ -37,22 +38,27 @@ BEGIN
         WHERE chart_year = @Year
         GROUP BY country_id
     ) hg_agg ON hg_agg.country_id = c.country_id
-    -- top album: album_name appearing most in this country's hidden gems this year
-    -- simplified from original — album_name is now a plain string on DIM_Song
+    -- top song detail: most frequent charted song in each country/year
+    -- this is independent from hidden gems and reflects overall country popularity
     LEFT JOIN (
         SELECT
-            hg_src.country_id,
+            ce.country_id,
             s_inner.album_name,
+            a_inner.artist_name,
             ROW_NUMBER() OVER (
-                PARTITION BY hg_src.country_id
-                ORDER BY COUNT(*) DESC
+                PARTITION BY ce.country_id
+                ORDER BY COUNT(*) DESC, ce.song_id ASC
             ) AS rn
-        FROM HiddenGems hg_src
-        JOIN DIM_Song s_inner ON s_inner.song_id = hg_src.song_id
-        WHERE hg_src.chart_year    = @Year
-          AND s_inner.album_name   IS NOT NULL
-        GROUP BY hg_src.country_id, s_inner.album_name
-    ) top_alb ON top_alb.country_id = c.country_id AND top_alb.rn = 1
+        FROM ChartEntry ce
+        JOIN DIM_Song s_inner ON s_inner.song_id = ce.song_id
+        LEFT JOIN Bridge_SongArtist bsa_inner
+            ON bsa_inner.song_id = s_inner.song_id
+           AND bsa_inner.artist_order = 1
+        LEFT JOIN DIM_Artist a_inner ON a_inner.artist_id = bsa_inner.artist_id
+        WHERE ce.country_id IS NOT NULL
+          AND YEAR(ce.snapshot_date) = @Year
+        GROUP BY ce.country_id, ce.song_id, s_inner.album_name, a_inner.artist_name
+    ) top_song ON top_song.country_id = c.country_id AND top_song.rn = 1
     WHERE c.latitude  IS NOT NULL
       AND c.longitude IS NOT NULL
     ORDER BY c.full_name;

--- a/backend/Capstone.API/appsettings.Development.json
+++ b/backend/Capstone.API/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=192.168.111.9,1433;Database=HiddenGemMusic;User Id=sa;Password=Capstone123!;TrustServerCertificate=True;"
   }
 }

--- a/backend/Capstone.API/appsettings.json
+++ b/backend/Capstone.API/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=192.168.111.9,1433;Database=HiddenGemMusic;User Id=sa;Password=Capstone123!;TrustServerCertificate=True;"
+  },
   "AllowedHosts": "*"
 }

--- a/hidden-gem-music-app/App.tsx
+++ b/hidden-gem-music-app/App.tsx
@@ -175,9 +175,9 @@ export default function App() {
   const selectedComparisonCountries = useMemo(
     () =>
       comparisonIds
-        .map((countryId) => countries.find((country) => country.id === countryId))
+        .map((countryId) => discoveryCountries.find((country) => country.id === countryId))
         .filter((country): country is Country => Boolean(country)),
-    [comparisonIds, countries]
+    [comparisonIds, discoveryCountries]
   );
 
   const dashboardMetrics = useMemo(() => getDashboardMetrics(selectedYear, countries), [countries, selectedYear]);
@@ -409,8 +409,8 @@ export default function App() {
   }, [countries, currentRoute, featuredCountry.id, selectedCountryId]);
 
   useEffect(() => {
-    setComparisonIds((current) => current.filter((id) => countries.some((country) => country.id === id)).slice(0, 2));
-  }, [countries]);
+    setComparisonIds((current) => current.filter((id) => discoveryCountries.some((country) => country.id === id)).slice(0, 2));
+  }, [discoveryCountries]);
 
   useEffect(() => {
     return () => {
@@ -735,7 +735,7 @@ export default function App() {
               <Stack.Screen name="comparisonSelect" options={{ title: "Comparison Mode" }}>
                 {() => (
                   <ComparisonSelectScreen
-                    countries={countries}
+                    countries={discoveryCountries}
                     selectedCountryIds={comparisonIds}
                     onToggleCountry={(countryId) => {
                       setComparisonIds((current) => {
@@ -748,6 +748,7 @@ export default function App() {
                         return [...current, countryId];
                       });
                     }}
+                    onClearSelections={() => setComparisonIds([])}
                     onDone={() => navigateToRoute("comparisonResults")}
                     selectedYear={selectedYear}
                     onChangeYear={(year) => handleYearChange(year, "Comparison Mode")}
@@ -759,7 +760,7 @@ export default function App() {
                 {() => (
                   <ComparisonResultsScreen
                     countries={selectedComparisonCountries}
-                    availableCountries={countries}
+                    availableCountries={discoveryCountries}
                     selectedYear={selectedYear}
                     onBack={() => navigateToRoute("comparisonSelect")}
                     onChangeYear={(year) => handleYearChange(year, "Comparison View")}

--- a/hidden-gem-music-app/App.tsx
+++ b/hidden-gem-music-app/App.tsx
@@ -15,6 +15,7 @@ import { DashboardScreen } from "./src/screens/DashboardScreen";
 import { DiscoveryScreen } from "./src/screens/DiscoveryScreen";
 import { HiddenGemsScreen } from "./src/screens/HiddenGemsScreen";
 import { WelcomeScreen } from "./src/screens/WelcomeScreen";
+import { loadDiscoveryCountries } from "./src/data/discoveryApi";
 import {
   availableYears,
   getCountriesForYear,
@@ -155,6 +156,7 @@ export default function App() {
   const [searchOpen, setSearchOpen] = useState(false);
 
   const countries = useMemo(() => getCountriesForYear(selectedYear), [selectedYear]);
+  const [discoveryCountries, setDiscoveryCountries] = useState<Country[]>(countries);
   const featuredCountry = useMemo(() => getFeaturedCountry(selectedYear), [selectedYear]);
   const songs = useMemo(() => getSongsForCountryYear(selectedCountryId, selectedYear), [selectedCountryId, selectedYear]);
 
@@ -326,6 +328,15 @@ export default function App() {
     });
   };
 
+  const openCountryFromDiscovery = (countryId: string) => {
+    if (countries.some((country) => country.id === countryId)) {
+      openCountry(countryId);
+      return;
+    }
+
+    setSelectedCountryId(countryId);
+  };
+
   const openHiddenGemsForCountry = (countryId: string, selection?: { songTitle?: string; artist?: string }) => {
     const countrySongs = getSongsForCountryYear(countryId, selectedYear);
     const normalize = (value?: string) => value?.trim().toLowerCase() ?? "";
@@ -364,10 +375,14 @@ export default function App() {
   }, [songs, selectedSongId]);
 
   useEffect(() => {
+    if (currentRoute === "discovery") {
+      return;
+    }
+
     if (!countries.some((country) => country.id === selectedCountryId)) {
       setSelectedCountryId(featuredCountry.id);
     }
-  }, [countries, featuredCountry.id, selectedCountryId]);
+  }, [countries, currentRoute, featuredCountry.id, selectedCountryId]);
 
   useEffect(() => {
     setComparisonIds((current) => current.filter((id) => countries.some((country) => country.id === id)).slice(0, 2));
@@ -399,6 +414,29 @@ export default function App() {
       navigationRef.dispatch(CommonActions.setParams(nextParams));
     }
   }, [currentRoute, navigationReady, navigationRef, selectedCountryId, selectedYear]);
+
+  useEffect(() => {
+    let isCancelled = false;
+    setDiscoveryCountries(countries);
+
+    loadDiscoveryCountries(selectedYear, countries)
+      .then((apiCountries) => {
+        if (isCancelled || apiCountries.length === 0) {
+          return;
+        }
+
+        setDiscoveryCountries(apiCountries);
+      })
+      .catch((error) => {
+        if (!isCancelled) {
+          console.warn("Failed to load discovery countries from API; using local mock countries.", error);
+        }
+      });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [countries, selectedYear]);
 
   useEffect(() => {
     if (typeof document === "undefined") {
@@ -609,10 +647,10 @@ export default function App() {
               <Stack.Screen name="discovery" options={{ title: "Discovery Globe" }}>
                 {() => (
                   <DiscoveryScreen
-                    countries={countries}
+                    countries={discoveryCountries}
                     selectedCountryId={selectedCountryId}
                     onSelectCountry={(countryId) => setSelectedCountryId(countryId)}
-                    onOpenCountry={openCountry}
+                    onOpenCountry={openCountryFromDiscovery}
                     selectedYear={selectedYear}
                     onChangeYear={(year) => handleYearChange(year, "Discovery Globe")}
                   />

--- a/hidden-gem-music-app/App.tsx
+++ b/hidden-gem-music-app/App.tsx
@@ -16,6 +16,7 @@ import { DiscoveryScreen } from "./src/screens/DiscoveryScreen";
 import { HiddenGemsScreen } from "./src/screens/HiddenGemsScreen";
 import { WelcomeScreen } from "./src/screens/WelcomeScreen";
 import { loadDiscoveryCountries } from "./src/data/discoveryApi";
+import { loadAvailableYears } from "./src/data/countryApi";
 import {
   availableYears,
   getCountriesForYear,
@@ -154,6 +155,7 @@ export default function App() {
   );
   const [loadingMessage, setLoadingMessage] = useState<string | null>(null);
   const [searchOpen, setSearchOpen] = useState(false);
+  const [apiAvailableYears, setApiAvailableYears] = useState<number[]>([]);
 
   const countries = useMemo(() => getCountriesForYear(selectedYear), [selectedYear]);
   const [discoveryCountries, setDiscoveryCountries] = useState<Country[]>(countries);
@@ -161,8 +163,8 @@ export default function App() {
   const songs = useMemo(() => getSongsForCountryYear(selectedCountryId, selectedYear), [selectedCountryId, selectedYear]);
 
   const selectedCountry = useMemo(
-    () => getCountryByYear(selectedCountryId, selectedYear) ?? featuredCountry,
-    [selectedCountryId, selectedYear, featuredCountry]
+    () => discoveryCountries.find((country) => country.id === selectedCountryId) ?? getCountryByYear(selectedCountryId, selectedYear) ?? featuredCountry,
+    [discoveryCountries, selectedCountryId, selectedYear, featuredCountry]
   );
 
   const selectedSong = useMemo(
@@ -316,16 +318,38 @@ export default function App() {
   };
 
   const openCountry = (countryId: string) => {
-    setSelectedCountryId(countryId);
+    const countryLabel = discoveryCountries.find((country) => country.id === countryId)?.name ?? countries.find((country) => country.id === countryId)?.name ?? countryId;
 
-    if (!navigationRef.isReady()) {
+    if (countryId === selectedCountryId) {
+      if (navigationRef.isReady()) {
+        navigationRef.navigate("country", {
+          country: countryId,
+          year: selectedYear,
+        });
+      }
       return;
     }
 
-    navigationRef.navigate("country", {
-      country: countryId,
-      year: selectedYear,
-    });
+    setLoadingMessage(`Loading ${countryLabel} for ${selectedYear}...`);
+    if (loadingTimerRef.current) {
+      clearTimeout(loadingTimerRef.current);
+    }
+
+    loadingTimerRef.current = setTimeout(() => {
+      setSelectedCountryId(countryId);
+      setLoadingMessage(null);
+
+      if (!navigationRef.isReady()) {
+        return;
+      }
+
+      navigationRef.navigate("country", {
+        country: countryId,
+        year: selectedYear,
+      });
+    }, 500);
+
+    return;
   };
 
   const openCountryFromDiscovery = (countryId: string) => {
@@ -437,6 +461,26 @@ export default function App() {
       isCancelled = true;
     };
   }, [countries, selectedYear]);
+
+  useEffect(() => {
+    let isCancelled = false;
+
+    loadAvailableYears()
+      .then((years) => {
+        if (!isCancelled && years.length > 0) {
+          setApiAvailableYears(years);
+        }
+      })
+      .catch((error) => {
+        if (!isCancelled) {
+          console.warn("Failed to load API available years; Discovery timeline will use default years.", error);
+        }
+      });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     if (typeof document === "undefined") {
@@ -653,6 +697,7 @@ export default function App() {
                     onOpenCountry={openCountryFromDiscovery}
                     selectedYear={selectedYear}
                     onChangeYear={(year) => handleYearChange(year, "Discovery Globe")}
+                    availableYears={apiAvailableYears}
                   />
                 )}
               </Stack.Screen>
@@ -661,7 +706,7 @@ export default function App() {
                 {() => (
                   <CountryScreen
                     country={selectedCountry}
-                    countries={countries}
+                    countries={discoveryCountries}
                     onSelectCountry={openCountry}
                     onOpenHiddenGems={openHiddenGems}
                     onOpenComparisonMode={() => navigateToRoute("comparisonSelect")}

--- a/hidden-gem-music-app/src/components/CountryCard.tsx
+++ b/hidden-gem-music-app/src/components/CountryCard.tsx
@@ -9,14 +9,19 @@ import { Panel } from "./Panel";
 
 type Props = {
   country: Country;
+  selectedYear?: number;
   selected?: boolean;
   onPress: () => void;
   onTitlePress?: () => void;
   onHover?: () => void;
 };
 
-export function CountryCard({ country, selected, onPress, onTitlePress, onHover }: Props) {
+export function CountryCard({ country, selectedYear, selected, onPress, onTitlePress, onHover }: Props) {
   const [hovered, setHovered] = useState(false);
+  const hasHiddenGems = country.hiddenSongs > 0;
+  const noHiddenGemsCopy = selectedYear ? `No Hidden Gems for ${selectedYear}` : "No Hidden Gems for this year";
+  const hasNoSongData = country.album === "Unknown Album" && country.albumArtist === "Unknown Artist";
+  const noSongDataCopy = selectedYear ? `No song data for ${selectedYear}` : "No song data for this year";
 
   return (
     <Pressable
@@ -46,11 +51,18 @@ export function CountryCard({ country, selected, onPress, onTitlePress, onHover 
               <Text style={styles.region}>{country.region}</Text>
             </View>
             <View style={styles.right}>
-              <Text style={styles.detail}>Hidden Songs: {country.hiddenSongs}</Text>
-              <Text style={styles.detail}>Most popular genres: {country.genres.join(", ")}</Text>
               <Text style={styles.detail}>
-                Most popular album: {country.album} by {country.albumArtist}
+                • Hidden Gems:  {hasHiddenGems ? `${country.hiddenSongs}` : noHiddenGemsCopy}
               </Text>
+              <Text style={styles.detail}>• Genre(s):  Genre info coming soon.</Text>
+              <Text style={styles.detail}>• Language(s):  Language info coming soon.</Text>
+              {hasNoSongData ? (
+                <Text style={styles.detail}>• Most popular album:  {noSongDataCopy}</Text>
+              ) : (
+                <Text style={styles.detail}>
+                  • Most popular album:  {country.album} by {country.albumArtist}
+                </Text>
+              )}
             </View>
           </View>
         </LinearGradient>
@@ -88,18 +100,15 @@ const styles = StyleSheet.create({
     borderRadius: 20,
   },
   row: {
-    flexDirection: "row",
-    gap: 18,
-    flexWrap: "wrap",
+    flexDirection: "column",
+    gap: 12,
   },
   left: {
-    minWidth: 170,
     gap: 10,
   },
   right: {
-    flex: 1,
     gap: 10,
-    minWidth: 240,
+    width: "100%",
   },
   countryName: {
     color: colors.textStrong,

--- a/hidden-gem-music-app/src/components/DiscoveryBlurb.tsx
+++ b/hidden-gem-music-app/src/components/DiscoveryBlurb.tsx
@@ -12,8 +12,8 @@ type Props = {
 };
 
 export function DiscoveryBlurb({
-  heading = "This is the Blurb",
-  body = "this is the text inside the blurb that will say things about the page you're on and will guide users through the experience. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+  heading = "Discovery Globe",
+  body = "Welcome to Hidden Gem Music's Discovery Globe. The purpose of this app is to find and display the 'discovery gap' -- What music is most loved in what country, and how far did that country's most loved music spread to be shared and loved by other countries? You can apply either Pre-Selected filters like Your Region vs. The World or The Biggest Crossover Years, or more in All Filters like sorting by region, A-Z or Z-A, and more. Navigate countries using the globe or list. Click a country to view it's detail page and to preview it's hidden songs. Also check out comparison mode to compare two countries, in the navigation above or also at the bottom of each country page.",
 }: Props) {
   return (
     <Panel style={styles.panel}>

--- a/hidden-gem-music-app/src/components/DiscoverySidebarPanels.tsx
+++ b/hidden-gem-music-app/src/components/DiscoverySidebarPanels.tsx
@@ -17,6 +17,7 @@ type Props = {
   onSelectCountry: (countryId: string) => void;
   onOpenCountry: (countryId: string) => void;
   autoScrollSignal?: number;
+  selectedYear?: number;
 };
 
 type ExpandedPanel = "filters" | "list";
@@ -24,7 +25,7 @@ type ExpandedPanel = "filters" | "list";
 const hoverGradient = ["rgba(117,82,107,0.52)", "rgba(108,119,142,0.44)", "rgba(108,119,142,0.36)"] as const;
 const activeGradient = [colors.navGradient, colors.backgroundRaised, colors.backgroundRaised] as const;
 
-export function DiscoverySidebarPanels({ countries, selectedCountryId, onSelectCountry, onOpenCountry, autoScrollSignal }: Props) {
+export function DiscoverySidebarPanels({ countries, selectedCountryId, onSelectCountry, onOpenCountry, autoScrollSignal, selectedYear }: Props) {
   const [expandedPanel, setExpandedPanel] = useState<ExpandedPanel>("filters");
   const [activeFilter, setActiveFilter] = useState<string | null>(null);
   const [hoveredFilter, setHoveredFilter] = useState<string | null>(null);
@@ -183,7 +184,7 @@ export function DiscoverySidebarPanels({ countries, selectedCountryId, onSelectC
 
     const y = positionsRef.current[selectedCountryId];
     if (typeof y === "number") {
-      listScrollRef.current?.scrollTo({ y: Math.max(y - 18, 0), animated: true });
+      listScrollRef.current?.scrollTo({ y: Math.max(y - 18, 0), animated: false });
     }
   }, [autoScrollSignal, expandedPanel]);
 
@@ -231,7 +232,9 @@ export function DiscoverySidebarPanels({ countries, selectedCountryId, onSelectC
         <Pressable style={styles.sectionHeader} onPress={() => handleSectionPress("filters")}>
           <View style={styles.sectionHeaderCopy}>
             <Text style={styles.sectionTitle}>Pre-Selected Filters</Text>
-            <Text style={styles.sectionHelper}>Lorem ipsum dolor{"\n"}sit amet elit magna nunc vel</Text>
+            <Text style={styles.sectionHelper}>
+              Select optional pre-selected filters here and use 'All Filters' button on the globe for more filters.
+            </Text>
           </View>
           <Text style={styles.sectionToggle}>{expandedPanel === "filters" ? "−" : "+"}</Text>
         </Pressable>
@@ -282,7 +285,9 @@ export function DiscoverySidebarPanels({ countries, selectedCountryId, onSelectC
         <Pressable style={styles.sectionHeader} onPress={() => handleSectionPress("list")}>
           <View style={styles.sectionHeaderCopy}>
             <Text style={styles.sectionTitle}>List View</Text>
-            <Text style={styles.sectionHelper}>Lorem ipsum dolor{"\n"}sit amet elit magna nunc vel</Text>
+            <Text style={styles.sectionHelper}>
+              Click a country to view its detail page and hear previews of hidden gem songs.
+            </Text>
           </View>
           <Text style={styles.sectionToggle}>{expandedPanel === "list" ? "−" : "+"}</Text>
         </Pressable>
@@ -308,6 +313,7 @@ export function DiscoverySidebarPanels({ countries, selectedCountryId, onSelectC
                 >
                   <CountryCard
                     country={country}
+                    selectedYear={selectedYear}
                     selected={country.id === selectedCountryId}
                     onHover={() => onSelectCountry(country.id)}
                     onTitlePress={() => onOpenCountry(country.id)}
@@ -392,7 +398,7 @@ const styles = StyleSheet.create({
     fontSize: 14,
     lineHeight: 16,
     textAlign: "right",
-    maxWidth: 176,
+    maxWidth: 220,
   },
   sectionToggle: {
     color: colors.textStrong,

--- a/hidden-gem-music-app/src/components/YearSlider.tsx
+++ b/hidden-gem-music-app/src/components/YearSlider.tsx
@@ -8,22 +8,60 @@ import { typefaces } from "../theme/typography";
 type Props = {
   year: number;
   onChangeYear: (year: number) => void;
+  years?: number[];
 };
 
-const gapStartYear = 2007;
-const gapEndYear = 2010;
-
-export function YearSlider({ year, onChangeYear }: Props) {
-  const minYear = availableYears[0];
-  const maxYear = availableYears[availableYears.length - 1];
+export function YearSlider({ year, onChangeYear, years = availableYears }: Props) {
+  const sliderYears = years.length > 0 ? years : availableYears;
+  const minYear = sliderYears[0];
+  const maxYear = sliderYears[sliderYears.length - 1];
+  const largestGap = sliderYears.reduce(
+    (currentGap, currentYear, index) => {
+      if (index === 0) {
+        return currentGap;
+      }
+      const previousYear = sliderYears[index - 1];
+      const gapSize = currentYear - previousYear;
+      if (gapSize > currentGap.gapSize) {
+        return {
+          gapSize,
+          start: previousYear + 1,
+          end: currentYear - 1,
+        };
+      }
+      return currentGap;
+    },
+    { gapSize: 0, start: -1, end: -1 }
+  );
+  const hasGap = largestGap.gapSize > 1;
+  const gapStartYear = hasGap ? largestGap.start : minYear;
+  const gapEndYear = hasGap ? largestGap.end : minYear;
   const gapMidpoint = (gapStartYear + gapEndYear) / 2;
   const [dragYear, setDragYear] = useState(year);
   const [isDragging, setIsDragging] = useState(false);
   const dragYearRef = useRef(year);
-  const progress = ((dragYear - minYear) / (maxYear - minYear)) * 100;
+  const yearBeforeGap = hasGap ? gapStartYear - 1 : minYear;
+  const yearAfterGap = hasGap ? gapEndYear + 1 : maxYear;
+  const yearBeforeGapIndex = sliderYears.indexOf(yearBeforeGap);
+  const yearAfterGapIndex = sliderYears.indexOf(yearAfterGap);
+  const gapSlotIndex = hasGap ? yearAfterGapIndex : -1;
+  const totalSlots = sliderYears.length + (hasGap ? 1 : 0);
+  const maxSlotIndex = Math.max(totalSlots - 1, 1);
+  const getSlotFromYear = (value: number) => {
+    const yearIndex = sliderYears.indexOf(value);
+    if (yearIndex < 0) {
+      return 0;
+    }
+    if (!hasGap) {
+      return yearIndex;
+    }
+    return yearIndex >= yearAfterGapIndex ? yearIndex + 1 : yearIndex;
+  };
+  const dragSlotIndex = getSlotFromYear(dragYear);
+  const progress = (dragSlotIndex / maxSlotIndex) * 100;
   const clampedProgress = Math.min(Math.max(progress, 0), 100);
-  const gapStartProgress = ((gapStartYear - minYear) / (maxYear - minYear)) * 100;
-  const gapEndProgress = ((gapEndYear - minYear) / (maxYear - minYear)) * 100;
+  const gapStartProgress = hasGap ? ((gapSlotIndex - 0.5) / maxSlotIndex) * 100 : 0;
+  const gapEndProgress = hasGap ? ((gapSlotIndex + 0.5) / maxSlotIndex) * 100 : 0;
   const [trackWidth, setTrackWidth] = useState(1);
 
   const getSelectableYear = (candidateYear: number) => {
@@ -35,17 +73,17 @@ export function YearSlider({ year, onChangeYear }: Props) {
   };
 
   const getAdjacentSelectableYear = (currentYear: number, direction: -1 | 1) => {
-    const currentIndex = availableYears.indexOf(currentYear);
+    const currentIndex = sliderYears.indexOf(currentYear);
     if (currentIndex === -1) {
       return getSelectableYear(currentYear);
     }
 
     for (
       let index = currentIndex + direction;
-      index >= 0 && index < availableYears.length;
+      index >= 0 && index < sliderYears.length;
       index += direction
     ) {
-      const nextYear = availableYears[index];
+      const nextYear = sliderYears[index];
       if (nextYear < gapStartYear || nextYear > gapEndYear) {
         return nextYear;
       }
@@ -64,8 +102,20 @@ export function YearSlider({ year, onChangeYear }: Props) {
 
   const getYearFromLocation = (locationX: number) => {
     const ratio = Math.min(Math.max(locationX / trackWidth, 0), 1);
-    const rawYear = Math.round(minYear + ratio * (maxYear - minYear));
-    return getSelectableYear(rawYear);
+    const rawSlot = ratio * maxSlotIndex;
+    const slotIndex = Math.round(rawSlot);
+
+    if (!hasGap) {
+      return sliderYears[Math.min(Math.max(slotIndex, 0), sliderYears.length - 1)];
+    }
+
+    if (slotIndex === gapSlotIndex) {
+      return rawSlot < gapSlotIndex ? yearBeforeGap : yearAfterGap;
+    }
+
+    const yearIndex = slotIndex > gapSlotIndex ? slotIndex - 1 : slotIndex;
+    const clampedIndex = Math.min(Math.max(yearIndex, 0), sliderYears.length - 1);
+    return sliderYears[clampedIndex];
   };
 
   const updateFromLocation = (locationX: number) => {
@@ -104,22 +154,24 @@ export function YearSlider({ year, onChangeYear }: Props) {
           }}
         >
           <View style={[styles.fill, { width: `${clampedProgress}%` }]} />
-          <View
-            style={[
-              styles.gap,
-              {
-                left: `${gapStartProgress}%`,
-                width: `${Math.max(gapEndProgress - gapStartProgress, 0)}%`,
-              },
-            ]}
-          />
+          {hasGap ? (
+            <View
+              style={[
+                styles.gap,
+                {
+                  left: `${gapStartProgress}%`,
+                  width: `${Math.max(gapEndProgress - gapStartProgress, 0)}%`,
+                },
+              ]}
+            />
+          ) : null}
           <View style={[styles.thumb, { left: `${clampedProgress}%` }]} />
         </View>
         <Pressable onPress={() => onChangeYear(getAdjacentSelectableYear(year, 1))}>
           <Text style={styles.arrow}>›</Text>
         </Pressable>
       </View>
-      <Text style={styles.disclaimer}>Data gap: timeline skips unavailable years.</Text>
+      {hasGap ? <Text style={styles.disclaimer}>Data gap: timeline skips unavailable years.</Text> : null}
     </View>
   );
 }

--- a/hidden-gem-music-app/src/components/globe/GlobePanel.tsx
+++ b/hidden-gem-music-app/src/components/globe/GlobePanel.tsx
@@ -12,6 +12,7 @@ import { GlobeView } from "./GlobeView";
 type Props = {
   countries: Country[];
   activeCountryId?: string;
+  selectedYear?: number;
   onSelectCountry: (countryId: string) => void;
   onOpenCountry?: (countryId: string) => void;
   title: string;
@@ -26,6 +27,7 @@ type Props = {
 export function GlobePanel({
   countries,
   activeCountryId,
+  selectedYear,
   onSelectCountry,
   onOpenCountry,
   title,
@@ -55,6 +57,7 @@ export function GlobePanel({
         <GlobeView
           countries={countries}
           activeCountry={activeCountry}
+          selectedYear={selectedYear}
           onSelectCountry={onSelectCountry}
           onOpenCountry={onOpenCountry}
           selectOnHover={selectOnHover}

--- a/hidden-gem-music-app/src/components/globe/GlobeView.native.tsx
+++ b/hidden-gem-music-app/src/components/globe/GlobeView.native.tsx
@@ -7,12 +7,17 @@ import { typefaces } from "../../theme/typography";
 type Props = {
   countries: Country[];
   activeCountry?: Country;
+  selectedYear?: number;
   onSelectCountry: (countryId: string) => void;
   onOpenCountry?: (countryId: string) => void;
 };
 
-export function GlobeView({ countries, activeCountry, onSelectCountry, onOpenCountry }: Props) {
+export function GlobeView({ countries, activeCountry, selectedYear, onSelectCountry, onOpenCountry }: Props) {
   const currentCountry = activeCountry ?? countries[0];
+  const hasHiddenGems = (currentCountry?.hiddenSongs ?? 0) > 0;
+  const noHiddenGemsCopy = selectedYear ? `No Hidden Gems for ${selectedYear}` : "No Hidden Gems for this year";
+  const hasNoSongData = currentCountry ? currentCountry.album === "Unknown Album" && currentCountry.albumArtist === "Unknown Artist" : false;
+  const noSongDataCopy = selectedYear ? `No song data for ${selectedYear}` : "No song data for this year";
 
   return (
     <View style={styles.wrapper}>
@@ -54,8 +59,17 @@ export function GlobeView({ countries, activeCountry, onSelectCountry, onOpenCou
             </View>
             <View style={styles.tooltipDivider} />
             <View style={styles.tooltipBody}>
-              <Text style={styles.tooltipCopy}>Hidden Songs: {currentCountry.hiddenSongs}</Text>
+              <Text style={styles.tooltipCopy}>
+                Hidden Gems: {hasHiddenGems ? `${currentCountry.hiddenSongs}` : noHiddenGemsCopy}
+              </Text>
               <Text style={styles.tooltipCopy}>Genres: {currentCountry.genres.join(", ")}</Text>
+              {hasNoSongData ? (
+                <Text style={styles.tooltipCopy}>Most Popular Album: {noSongDataCopy}</Text>
+              ) : (
+                <Text style={styles.tooltipCopy}>
+                  Most Popular Album: {currentCountry.album} by {currentCountry.albumArtist}
+                </Text>
+              )}
             </View>
           </View>
         </Pressable>

--- a/hidden-gem-music-app/src/components/globe/GlobeView.tsx
+++ b/hidden-gem-music-app/src/components/globe/GlobeView.tsx
@@ -7,6 +7,7 @@ import { GlobeView as WebGlobeView } from "./GlobeView.web";
 type Props = {
   countries: Country[];
   activeCountry?: Country;
+  selectedYear?: number;
   onSelectCountry: (countryId: string) => void;
   onOpenCountry?: (countryId: string) => void;
   selectOnHover?: boolean;

--- a/hidden-gem-music-app/src/components/globe/GlobeView.web.tsx
+++ b/hidden-gem-music-app/src/components/globe/GlobeView.web.tsx
@@ -9,12 +9,13 @@ import { typefaces } from "../../theme/typography";
 type Props = {
   countries: Country[];
   activeCountry?: Country;
+  selectedYear?: number;
   onSelectCountry: (countryId: string) => void;
   onOpenCountry?: (countryId: string) => void;
   selectOnHover?: boolean;
 };
 
-export function GlobeView({ countries, activeCountry, onSelectCountry, onOpenCountry, selectOnHover = true }: Props) {
+export function GlobeView({ countries, activeCountry, selectedYear, onSelectCountry, onOpenCountry, selectOnHover = true }: Props) {
   const { width } = useWindowDimensions();
   const [hoveredCountryId, setHoveredCountryId] = useState<string | null>(null);
   const hoverTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -42,6 +43,10 @@ export function GlobeView({ countries, activeCountry, onSelectCountry, onOpenCou
   const connectorDy = tooltipAnchorY - markerY;
   const connectorLength = Math.sqrt(connectorDx * connectorDx + connectorDy * connectorDy);
   const connectorAngle = `${Math.atan2(connectorDy, connectorDx)}rad`;
+  const hasHiddenGems = (hoveredCountry?.hiddenSongs ?? 0) > 0;
+  const noHiddenGemsCopy = selectedYear ? `No Hidden Gems for ${selectedYear}` : "No Hidden Gems for this year";
+  const hasNoSongData = hoveredCountry ? hoveredCountry.album === "Unknown Album" && hoveredCountry.albumArtist === "Unknown Artist" : false;
+  const noSongDataCopy = selectedYear ? `No song data for ${selectedYear}` : "No song data for this year";
 
   return (
     <View style={styles.globeArea}>
@@ -137,11 +142,18 @@ export function GlobeView({ countries, activeCountry, onSelectCountry, onOpenCou
                   </View>
                   <View style={styles.tooltipDivider} />
                   <View style={styles.tooltipBody}>
-                    <Text style={styles.tooltipCopy}>Hidden Songs: {hoveredCountry.hiddenSongs}</Text>
-                    <Text style={styles.tooltipCopy}>Most Popular Genres: {hoveredCountry.genres.join(", ")}</Text>
                     <Text style={styles.tooltipCopy}>
-                      Most Popular Album: {hoveredCountry.album} by {hoveredCountry.albumArtist}
+                      Hidden Gems: {hasHiddenGems ? `${hoveredCountry.hiddenSongs}` : noHiddenGemsCopy}
                     </Text>
+                    <Text style={styles.tooltipCopy}>Genre(s): Genre info coming soon.</Text>
+                    <Text style={styles.tooltipCopy}>Language(s): Language info coming soon.</Text>
+                    {hasNoSongData ? (
+                      <Text style={styles.tooltipCopy}>Most Popular Album: {noSongDataCopy}</Text>
+                    ) : (
+                      <Text style={styles.tooltipCopy}>
+                        Most Popular Album: {hoveredCountry.album} by {hoveredCountry.albumArtist}
+                      </Text>
+                    )}
                   </View>
                 </View>
               </Pressable>

--- a/hidden-gem-music-app/src/data/apiMappers.ts
+++ b/hidden-gem-music-app/src/data/apiMappers.ts
@@ -65,10 +65,12 @@ export type UiHiddenGemPage = {
 export type UiCountryGlobeSummary = {
   countryCode: string;
   countryName: string;
+  region: string;
   lat: number;
   long: number;
   hiddenSongs: number;
   topAlbum: string;
+  topArtist: string;
 };
 
 const toNonEmpty = (value: string | null | undefined, fallback: string) => {
@@ -136,8 +138,10 @@ export const mapApiHiddenGemPage = (response: ApiHiddenGemResponse): UiHiddenGem
 export const mapApiCountryGlobeSummary = (item: ApiCountryGlobeSummary): UiCountryGlobeSummary => ({
   countryCode: toNonEmpty(item.countryCode, ""),
   countryName: toNonEmpty(item.countryName, "Unknown Country"),
+  region: toNonEmpty(item.region, "Continent info coming soon."),
   lat: item.lat,
   long: item.long,
   hiddenSongs: item.hiddenGemCount,
   topAlbum: toNonEmpty(item.topAlbumName, "Unknown Album"),
+  topArtist: toNonEmpty(item.topArtistName, "Unknown Artist"),
 });

--- a/hidden-gem-music-app/src/data/countryApi.ts
+++ b/hidden-gem-music-app/src/data/countryApi.ts
@@ -1,0 +1,57 @@
+import type { ApiCountryProfile, ApiCountrySongsPage, ApiHiddenGem } from "../types/api";
+
+const DEFAULT_API_BASE_URL = "http://localhost:5140";
+
+function getApiBaseUrl() {
+  const configuredBaseUrl = process.env.EXPO_PUBLIC_API_BASE_URL?.trim();
+  return configuredBaseUrl && configuredBaseUrl.length > 0 ? configuredBaseUrl : DEFAULT_API_BASE_URL;
+}
+
+async function parseJsonResponse<T>(response: Response, endpoint: string): Promise<T> {
+  if (!response.ok) {
+    throw new Error(`Request failed for ${endpoint} with status ${response.status}.`);
+  }
+
+  return (await response.json()) as T;
+}
+
+export async function loadCountryProfile(countryCode: string, year: number): Promise<ApiCountryProfile> {
+  const baseUrl = getApiBaseUrl().replace(/\/$/, "");
+  const endpoint = `${baseUrl}/api/country/${countryCode}?year=${year}`;
+  const response = await fetch(endpoint);
+  return parseJsonResponse<ApiCountryProfile>(response, endpoint);
+}
+
+export async function loadCountryHiddenGemsPreview(countryCode: string, year: number, limit = 13): Promise<ApiHiddenGem[]> {
+  const baseUrl = getApiBaseUrl().replace(/\/$/, "");
+  const endpoint = `${baseUrl}/api/country/${countryCode}/hidden-gems/preview?year=${year}&limit=${limit}`;
+  const response = await fetch(endpoint);
+  return parseJsonResponse<ApiHiddenGem[]>(response, endpoint);
+}
+
+export async function loadAvailableYears(): Promise<number[]> {
+  const baseUrl = getApiBaseUrl().replace(/\/$/, "");
+  const endpoint = `${baseUrl}/api/metadata/years`;
+  const response = await fetch(endpoint);
+  const payload = await parseJsonResponse<unknown[]>(response, endpoint);
+
+  return payload
+    .map((value) => Number(value))
+    .filter((value) => Number.isFinite(value))
+    .map((value) => Math.trunc(value))
+    .filter((value) => value > 0)
+    .sort((a, b) => a - b);
+}
+
+export async function loadCountrySongsPage(
+  countryCode: string,
+  year: number,
+  listType: "shared" | "unique",
+  page: number,
+  pageSize = 50
+): Promise<ApiCountrySongsPage> {
+  const baseUrl = getApiBaseUrl().replace(/\/$/, "");
+  const endpoint = `${baseUrl}/api/country/${countryCode}/songs?year=${year}&listType=${listType}&page=${page}&pageSize=${pageSize}`;
+  const response = await fetch(endpoint);
+  return parseJsonResponse<ApiCountrySongsPage>(response, endpoint);
+}

--- a/hidden-gem-music-app/src/data/discoveryApi.ts
+++ b/hidden-gem-music-app/src/data/discoveryApi.ts
@@ -64,7 +64,7 @@ export async function loadDiscoveryCountries(year: number, fallbackCountries: Co
     return {
       id: existing?.id ?? `iso-${normalizedCode.toLowerCase() || index}`,
       code: normalizedCode,
-      name: mapped.countryName,
+      name: existing?.name ?? mapped.countryName,
       region: mapped.region,
       hiddenSongs: mapped.hiddenSongs,
       genres: existing?.genres?.length ? existing.genres : ["Unknown"],

--- a/hidden-gem-music-app/src/data/discoveryApi.ts
+++ b/hidden-gem-music-app/src/data/discoveryApi.ts
@@ -1,0 +1,81 @@
+import type { Country } from "../types/content";
+import { mapApiCountryGlobeSummary } from "./apiMappers";
+import type { ApiCountryGlobeSummary } from "../types/api";
+
+const DEFAULT_API_BASE_URL = "http://localhost:5140";
+
+function getApiBaseUrl() {
+  const configuredBaseUrl = process.env.EXPO_PUBLIC_API_BASE_URL?.trim();
+  return configuredBaseUrl && configuredBaseUrl.length > 0 ? configuredBaseUrl : DEFAULT_API_BASE_URL;
+}
+
+export async function loadDiscoveryCountries(year: number, fallbackCountries: Country[]): Promise<Country[]> {
+  const existingByCode = new Map(fallbackCountries.map((country) => [country.code.toUpperCase(), country]));
+  const baseUrl = getApiBaseUrl().replace(/\/$/, "");
+  const endpoint = `${baseUrl}/api/discovery/countries?year=${year}`;
+  const response = await fetch(endpoint);
+
+  if (!response.ok) {
+    throw new Error(`Discovery country request failed with status ${response.status}.`);
+  }
+
+  const payload = ((await response.json()) as unknown[]).map((item) => {
+    const row = item as Record<string, unknown>;
+    const hiddenGemCountRaw =
+      row.hiddenGemCount ??
+      row.HiddenGemCount ??
+      row.hidden_gem_count ??
+      row.hiddenSongCount ??
+      row.hidden_song_count ??
+      row.hiddenSongs ??
+      0;
+    const topAlbumNameRaw =
+      row.topAlbumName ??
+      row.TopAlbumName ??
+      row.top_album_name ??
+      row.albumName ??
+      row.album_name ??
+      null;
+    const topArtistNameRaw =
+      row.topArtistName ??
+      row.TopArtistName ??
+      row.top_artist_name ??
+      row.artistName ??
+      row.artist_name ??
+      null;
+
+    return {
+      countryCode: (row.countryCode ?? row.CountryCode ?? row.country_code ?? "") as string | null,
+      countryName: (row.countryName ?? row.CountryName ?? row.country_name ?? "") as string | null,
+      region: (row.region ?? row.Region ?? null) as string | null,
+      lat: Number(row.lat ?? row.Lat ?? row.latitude ?? row.Latitude ?? 0),
+      long: Number(row.long ?? row.Long ?? row.longitude ?? row.Longitude ?? 0),
+      hiddenGemCount: Number(hiddenGemCountRaw),
+      topAlbumName: topAlbumNameRaw as string | null,
+      topArtistName: topArtistNameRaw as string | null,
+    } satisfies ApiCountryGlobeSummary;
+  });
+
+  return payload.map((item, index) => {
+    const mapped = mapApiCountryGlobeSummary(item);
+    const normalizedCode = mapped.countryCode.toUpperCase();
+    const existing = existingByCode.get(normalizedCode);
+
+    return {
+      id: existing?.id ?? `iso-${normalizedCode.toLowerCase() || index}`,
+      code: normalizedCode,
+      name: mapped.countryName,
+      region: mapped.region,
+      hiddenSongs: mapped.hiddenSongs,
+      genres: existing?.genres?.length ? existing.genres : ["Unknown"],
+      album: mapped.topAlbum,
+      albumArtist: mapped.topArtist,
+      topSong: existing?.topSong ?? "Unknown Song",
+      languages: existing?.languages?.length ? existing.languages : ["Unknown"],
+      sceneNote: existing?.sceneNote ?? "Discovery details will expand as country profile data is connected.",
+      featuredArtists: existing?.featuredArtists ?? [],
+      markerTop: existing?.markerTop ?? "-20%",
+      markerLeft: existing?.markerLeft ?? "-20%",
+    };
+  });
+}

--- a/hidden-gem-music-app/src/screens/ComparisonResultsScreen.web.tsx
+++ b/hidden-gem-music-app/src/screens/ComparisonResultsScreen.web.tsx
@@ -19,7 +19,8 @@ import { GemIcon } from "../components/GemIcon";
 import { Panel } from "../components/Panel";
 import { ScreenScaffold } from "../components/ScreenScaffold";
 import { SecondarySurfaceFill } from "../components/SecondarySurfaceFill";
-import { availableYears as allAvailableYears, getSongsForCountryYear } from "../data/mockData";
+import { loadAvailableYears, loadCountryHiddenGemsPreview, loadCountryProfile, loadCountrySongsPage } from "../data/countryApi";
+import { mapApiCountryProfile, mapApiHiddenGem, mapApiSong } from "../data/apiMappers";
 import { Country, Song } from "../types/content";
 import { colors } from "../theme/colors";
 import { typefaces } from "../theme/typography";
@@ -138,6 +139,10 @@ function createSongPreview(title: string, artist: string, detail: string, score:
     detail,
     score,
   };
+}
+
+function toSongPreview(song: { title: string; artist: string }, detail: string, score: number): SongPreview {
+  return createSongPreview(song.title, song.artist, detail, score);
 }
 
 function buildCountryProfile(country: Country, year: number): CountryProfileViewModel {
@@ -331,16 +336,18 @@ function ComparisonPaneDropdownStack({
   countryOptions,
   selectedCountryId,
   selectedYear,
+  availableYears,
   onChangeCountry,
   onChangeYear,
 }: {
   countryOptions: Country[];
   selectedCountryId: string;
   selectedYear: number;
+  availableYears: number[];
   onChangeCountry: (countryId: string) => void;
   onChangeYear: (year: number) => void;
 }) {
-  const yearOptions = useMemo(() => [...allAvailableYears], []);
+  const yearOptions = useMemo(() => [...availableYears], [availableYears]);
   const selectedCountryName =
     countryOptions.find((countryOption) => countryOption.id === selectedCountryId)?.name ?? "Select Country";
   const [isCountryDropdownOpen, setIsCountryDropdownOpen] = useState(false);
@@ -513,11 +520,19 @@ function MainComparisonArea({
   title,
   songs,
   onOpenHiddenGems,
+  isInitialLoading = false,
+  hasMore = false,
+  isLoadingMore = false,
+  onLoadMore,
   darkTheme = false,
 }: {
   title: string;
   songs: SongPreview[];
   onOpenHiddenGems: (selection?: { songTitle?: string; artist?: string }) => void;
+  isInitialLoading?: boolean;
+  hasMore?: boolean;
+  isLoadingMore?: boolean;
+  onLoadMore?: () => void;
   darkTheme?: boolean;
 }) {
   const scrollRef = useRef<ScrollView>(null);
@@ -527,6 +542,7 @@ function MainComparisonArea({
   const [contentHeight, setContentHeight] = useState(0);
   const [scrollY, setScrollY] = useState(0);
   const [isDraggingScrollbar, setIsDraggingScrollbar] = useState(false);
+  const [loadingDots, setLoadingDots] = useState(1);
   const scrollbarVisible = Platform.OS === "web" && viewportHeight > 0;
   const hasOverflow = scrollbarVisible && contentHeight > viewportHeight;
   const trackHeight = Math.max(viewportHeight - 20, 1);
@@ -538,7 +554,17 @@ function MainComparisonArea({
   const thumbTop = hasOverflow ? (scrollY / (contentHeight - viewportHeight)) * (viewportHeight - thumbHeight) : 0;
 
   const handleScroll = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
-    setScrollY(event.nativeEvent.contentOffset.y);
+    const nextScrollY = event.nativeEvent.contentOffset.y;
+    setScrollY(nextScrollY);
+
+    if (!hasMore || isLoadingMore || !onLoadMore || contentHeight <= 0 || viewportHeight <= 0) {
+      return;
+    }
+
+    const remaining = contentHeight - (nextScrollY + viewportHeight);
+    if (remaining < 220) {
+      onLoadMore();
+    }
   };
 
   const scrollToTrackLocation = (locationY: number) => {
@@ -589,6 +615,19 @@ function MainComparisonArea({
     };
   }, [isDraggingScrollbar, hasOverflow, thumbHeight, trackHeight, contentHeight, viewportHeight]);
 
+  useEffect(() => {
+    if (!isInitialLoading) {
+      setLoadingDots(1);
+      return;
+    }
+
+    const timer = setInterval(() => {
+      setLoadingDots((current) => (current >= 3 ? 1 : current + 1));
+    }, 350);
+
+    return () => clearInterval(timer);
+  }, [isInitialLoading]);
+
   return (
     <View style={styles.mainComparisonArea}>
       <Text style={[styles.panelTitle, darkTheme ? styles.panelTitleDark : null]}>{title}</Text>
@@ -604,6 +643,13 @@ function MainComparisonArea({
           onScroll={handleScroll}
           scrollEventThrottle={16}
         >
+          {songs.length === 0 && isInitialLoading ? (
+            <View style={styles.songListLoadingRow}>
+              <Text style={[styles.songListLoadingText, darkTheme ? styles.songListLoadingTextDark : null]}>
+                {`Loading${".".repeat(loadingDots)}`}
+              </Text>
+            </View>
+          ) : null}
           {songs.map((song, index) => (
             <Pressable
               key={`${title}-${song.title}-${song.artist}-${index}`}
@@ -659,6 +705,11 @@ function MainComparisonArea({
               }}
             </Pressable>
           ))}
+          {isLoadingMore ? (
+            <View style={styles.songListLoadingRow}>
+              <Text style={[styles.songListLoadingText, darkTheme ? styles.songListLoadingTextDark : null]}>Loading more...</Text>
+            </View>
+          ) : null}
         </ScrollView>
         {scrollbarVisible ? (
           <View
@@ -801,10 +852,14 @@ function LanguageSection({ title, items }: { title: string; items: BreakdownItem
 function HiddenSongsCarouselSection({
   countryName,
   songs,
+  isLoading,
+  loadingText,
   onOpenHiddenGems,
 }: {
   countryName: string;
   songs: Pick<Song, "title" | "artist">[];
+  isLoading: boolean;
+  loadingText: string;
   onOpenHiddenGems: (selection?: { songTitle?: string; artist?: string }) => void;
 }) {
   const songCount = songs.length;
@@ -832,6 +887,10 @@ function HiddenSongsCarouselSection({
   };
 
   const handleCarouselItemPress = (songIndex: number, isCenter: boolean) => {
+    if (isLoading) {
+      return;
+    }
+
     const song = songs[songIndex];
     if (!song) {
       return;
@@ -851,7 +910,7 @@ function HiddenSongsCarouselSection({
         <View style={styles.hiddenSongsCarouselHeaderLeft}>
           <Text style={styles.panelTitle}>Preview {countryName}'s Hidden Gems</Text>
           <Text style={styles.hiddenSongsCarouselHelper}>
-            Click a song to listen to a 30 second preview on the Hidden Gems page.
+            {isLoading ? loadingText : "Click a song to listen to a 30 second preview on the Hidden Gems page."}
           </Text>
         </View>
         <Pressable onPress={() => onOpenHiddenGems()} style={styles.hiddenSongsCarouselHelperAction}>
@@ -930,51 +989,49 @@ function HiddenSongsCarouselSection({
 function FavoriteArtistsSection({
   country,
   selectedYear,
+  artists,
+  isLoading,
   onOpenHiddenGems,
 }: {
   country: Country;
   selectedYear: number;
+  artists: Array<{ artist: string; songTitle: string }>;
+  isLoading: boolean;
   onOpenHiddenGems: (selection?: { songTitle?: string; artist?: string }) => void;
 }) {
-  const artists = Array.from({ length: 8 }, (_, index) => country.featuredArtists[index % country.featuredArtists.length]);
-
-  const [favoriteArtistOffset, setFavoriteArtistOffset] = useState(0);
-  const artistsPerPage = 4;
-  const favoriteArtistMaxOffset = Math.max(0, artists.length - artistsPerPage);
-  const visibleArtists = artists.slice(favoriteArtistOffset, favoriteArtistOffset + artistsPerPage);
+  const artistRows = Array.from({ length: 8 }, (_, index) => artists[index] ?? { artist: "", songTitle: "" });
 
   return (
     <CountryPageSection style={styles.snapshotPanel}>
       <Text style={styles.panelTitle}>{`${country.name}'s Favorite Artists in ${selectedYear}`}</Text>
 
-      <View style={styles.favoriteArtistsControls}>
-        <CarouselArrowButton
-          direction="left"
-          onPress={() => setFavoriteArtistOffset((current) => Math.max(0, current - 1))}
-          disabled={favoriteArtistOffset === 0}
-          compact
-        />
-
-        <View style={styles.favoriteArtistsRow}>
-          {visibleArtists.map((artist, index) => (
-            <Pressable
-              key={`${artist}-${favoriteArtistOffset + index}`}
-              onPress={() => onOpenHiddenGems({ artist })}
-              style={styles.favoriteArtistItem}
-            >
-              <CdCase size={104} artColor={carouselBackdropColors[(favoriteArtistOffset + index) % carouselBackdropColors.length]} />
-              <Text style={styles.favoriteArtistName}>{artist}</Text>
-            </Pressable>
-          ))}
-        </View>
-
-        <CarouselArrowButton
-          direction="right"
-          onPress={() => setFavoriteArtistOffset((current) => Math.min(favoriteArtistMaxOffset, current + 1))}
-          disabled={favoriteArtistOffset >= favoriteArtistMaxOffset}
-          compact
-        />
-      </View>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator
+        persistentScrollbar
+        style={styles.favoriteArtistsScroll}
+        contentContainerStyle={styles.favoriteArtistsRow}
+      >
+        {artistRows.map((artist, index) => (
+          <Pressable
+            key={`${artist.artist}-${artist.songTitle}-${index}`}
+            onPress={() => {
+              if (!isLoading && artist.artist) {
+                onOpenHiddenGems({ artist: artist.artist, songTitle: artist.songTitle || undefined });
+              }
+            }}
+            style={styles.favoriteArtistItem}
+          >
+            <CdCase size={104} artColor={carouselBackdropColors[index % carouselBackdropColors.length]} />
+            <Text style={styles.favoriteArtistName} numberOfLines={3} ellipsizeMode="tail">
+              {isLoading ? "Loading..." : artist.artist}
+            </Text>
+            <Text style={styles.favoriteArtistSongName} numberOfLines={3} ellipsizeMode="tail">
+              {isLoading ? "Loading..." : artist.songTitle}
+            </Text>
+          </Pressable>
+        ))}
+      </ScrollView>
     </CountryPageSection>
   );
 }
@@ -998,8 +1055,24 @@ function ComparisonCountryPane({
   onOpenCountry: (countryId: string) => void;
   onOpenHiddenGemsForCountry: (countryId: string, selection?: { songTitle?: string; artist?: string }) => void;
 }) {
-  const profile = useMemo(() => buildCountryProfile(country, selectedYear), [country, selectedYear]);
-  const hiddenGemSongs = useMemo(() => getSongsForCountryYear(country.id, selectedYear), [country.id, selectedYear]);
+  const fallbackProfile = useMemo(() => buildCountryProfile(country, selectedYear), [country, selectedYear]);
+  const [availableYears, setAvailableYears] = useState<number[]>([]);
+  const [apiProfile, setApiProfile] = useState<ReturnType<typeof mapApiCountryProfile> | null>(null);
+  const [previewSongs, setPreviewSongs] = useState<Array<{ title: string; artist: string }>>([]);
+  const [uniqueSongs, setUniqueSongs] = useState<SongPreview[]>([]);
+  const [sharedSongs, setSharedSongs] = useState<SongPreview[]>([]);
+  const [uniquePage, setUniquePage] = useState(1);
+  const [sharedPage, setSharedPage] = useState(1);
+  const [uniqueHasMore, setUniqueHasMore] = useState(false);
+  const [sharedHasMore, setSharedHasMore] = useState(false);
+  const [loadingMoreUnique, setLoadingMoreUnique] = useState(false);
+  const [loadingMoreShared, setLoadingMoreShared] = useState(false);
+  const [initialLoadingUnique, setInitialLoadingUnique] = useState(false);
+  const [initialLoadingShared, setInitialLoadingShared] = useState(false);
+  const [initialLoadingProfile, setInitialLoadingProfile] = useState(false);
+  const [initialLoadingPreview, setInitialLoadingPreview] = useState(false);
+  const [loadingDots, setLoadingDots] = useState(1);
+  const latestRequestRef = useRef(0);
   const countryOptions = useMemo(
     () =>
       availableCountries.filter((countryOption) =>
@@ -1009,6 +1082,266 @@ function ComparisonCountryPane({
   );
   const openForCountry = (selection?: { songTitle?: string; artist?: string }) =>
     onOpenHiddenGemsForCountry(country.id, selection);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    loadAvailableYears()
+      .then((years) => {
+        if (!cancelled && years.length > 0) {
+          setAvailableYears(years);
+        }
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          console.warn("Failed to load available years metadata for comparison pane. Falling back to current year selection.", error);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    const requestId = latestRequestRef.current + 1;
+    latestRequestRef.current = requestId;
+    setUniqueSongs([]);
+    setSharedSongs([]);
+    setUniquePage(1);
+    setSharedPage(1);
+    setUniqueHasMore(false);
+    setSharedHasMore(false);
+    setLoadingMoreUnique(false);
+    setLoadingMoreShared(false);
+    setInitialLoadingUnique(true);
+    setInitialLoadingShared(true);
+    setInitialLoadingProfile(true);
+    setInitialLoadingPreview(true);
+
+    loadCountryProfile(country.code, selectedYear)
+      .then((profilePayload) => {
+        if (latestRequestRef.current !== requestId) {
+          return;
+        }
+        setApiProfile(mapApiCountryProfile(profilePayload));
+        setInitialLoadingProfile(false);
+      })
+      .catch((error) => {
+        if (latestRequestRef.current !== requestId) {
+          return;
+        }
+        console.warn(`Failed to load country profile API data for comparison pane ${country.code} ${selectedYear}.`, error);
+        setApiProfile(null);
+        setInitialLoadingProfile(false);
+      });
+
+    loadCountryHiddenGemsPreview(country.code, selectedYear, 13)
+      .then((hiddenGemsPayload) => {
+        if (latestRequestRef.current !== requestId) {
+          return;
+        }
+        setPreviewSongs(
+          hiddenGemsPayload.map((item) => {
+            const mapped = mapApiHiddenGem(item);
+            return { title: mapped.title, artist: mapped.artist };
+          })
+        );
+        setInitialLoadingPreview(false);
+      })
+      .catch((error) => {
+        if (latestRequestRef.current !== requestId) {
+          return;
+        }
+        console.warn(`Failed to load hidden gems preview API data for comparison pane ${country.code} ${selectedYear}.`, error);
+        setPreviewSongs([]);
+        setInitialLoadingPreview(false);
+      });
+
+    loadCountrySongsPage(country.code, selectedYear, "unique", 1, 50)
+      .then((payload) => {
+        if (latestRequestRef.current !== requestId) {
+          return;
+        }
+        setUniqueSongs(
+          payload.items.map((song, index) =>
+            toSongPreview(mapApiSong(song), `Feels especially loved in ${country.name}`, clamp(95 - index * 2, 34, 95))
+          )
+        );
+        setUniqueHasMore(payload.hasMore);
+        setInitialLoadingUnique(false);
+      })
+      .catch((error) => {
+        if (latestRequestRef.current !== requestId) {
+          return;
+        }
+        console.warn(`Failed to load unique songs page for comparison pane ${country.code} ${selectedYear}.`, error);
+        setUniqueSongs([]);
+        setInitialLoadingUnique(false);
+      });
+
+    loadCountrySongsPage(country.code, selectedYear, "shared", 1, 50)
+      .then((payload) => {
+        if (latestRequestRef.current !== requestId) {
+          return;
+        }
+        setSharedSongs(
+          payload.items.map((song, index) =>
+            toSongPreview(mapApiSong(song), "Loved in this country and echoed across other countries", clamp(95 - index * 2, 34, 95))
+          )
+        );
+        setSharedHasMore(payload.hasMore);
+        setInitialLoadingShared(false);
+      })
+      .catch((error) => {
+        if (latestRequestRef.current !== requestId) {
+          return;
+        }
+        console.warn(`Failed to load shared songs page for comparison pane ${country.code} ${selectedYear}.`, error);
+        setSharedSongs([]);
+        setInitialLoadingShared(false);
+      });
+  }, [country.code, country.name, selectedYear]);
+
+  const yearOptions = useMemo(() => {
+    if (availableYears.length === 0) {
+      return [selectedYear];
+    }
+    if (availableYears.includes(selectedYear)) {
+      return availableYears;
+    }
+    return [...availableYears, selectedYear].sort((a, b) => a - b);
+  }, [availableYears, selectedYear]);
+
+  const loadMoreUniqueSongs = () => {
+    if (loadingMoreUnique || !uniqueHasMore) {
+      return;
+    }
+    const requestId = latestRequestRef.current;
+    const nextPage = uniquePage + 1;
+    setLoadingMoreUnique(true);
+    loadCountrySongsPage(country.code, selectedYear, "unique", nextPage, 50)
+      .then((payload) => {
+        if (latestRequestRef.current !== requestId) {
+          return;
+        }
+        setUniqueSongs((current) => {
+          const nextItems = payload.items.map((song, index) =>
+            toSongPreview(mapApiSong(song), `Feels especially loved in ${country.name}`, clamp(95 - (current.length + index) * 2, 34, 95))
+          );
+          return [...current, ...nextItems];
+        });
+        setUniquePage(nextPage);
+        setUniqueHasMore(payload.hasMore);
+      })
+      .catch((error) => {
+        if (latestRequestRef.current === requestId) {
+          console.warn(`Failed loading additional unique songs for comparison pane ${country.code} ${selectedYear}.`, error);
+        }
+      })
+      .finally(() => {
+        if (latestRequestRef.current === requestId) {
+          setLoadingMoreUnique(false);
+        }
+      });
+  };
+
+  const loadMoreSharedSongs = () => {
+    if (loadingMoreShared || !sharedHasMore) {
+      return;
+    }
+    const requestId = latestRequestRef.current;
+    const nextPage = sharedPage + 1;
+    setLoadingMoreShared(true);
+    loadCountrySongsPage(country.code, selectedYear, "shared", nextPage, 50)
+      .then((payload) => {
+        if (latestRequestRef.current !== requestId) {
+          return;
+        }
+        setSharedSongs((current) => {
+          const nextItems = payload.items.map((song, index) =>
+            toSongPreview(mapApiSong(song), "Loved in this country and echoed across other countries", clamp(95 - (current.length + index) * 2, 34, 95))
+          );
+          return [...current, ...nextItems];
+        });
+        setSharedPage(nextPage);
+        setSharedHasMore(payload.hasMore);
+      })
+      .catch((error) => {
+        if (latestRequestRef.current === requestId) {
+          console.warn(`Failed loading additional shared songs for comparison pane ${country.code} ${selectedYear}.`, error);
+        }
+      })
+      .finally(() => {
+        if (latestRequestRef.current === requestId) {
+          setLoadingMoreShared(false);
+        }
+      });
+  };
+
+  const favoriteArtists = useMemo(() => {
+    if (!apiProfile) {
+      return [];
+    }
+    const selectedArtists: Array<{ artist: string; songTitle: string }> = [];
+    const seen = new Set<string>();
+    const addArtist = (name: string, songTitle: string) => {
+      const normalized = name.trim().toLowerCase();
+      if (!normalized || seen.has(normalized) || selectedArtists.length >= 8) {
+        return;
+      }
+      seen.add(normalized);
+      selectedArtists.push({ artist: name, songTitle });
+    };
+    apiProfile.topUniqueSongs.forEach((song) => addArtist(song.artist, song.title));
+    if (selectedArtists.length < 8) {
+      apiProfile.topSharedSongs.forEach((song) => addArtist(song.artist, song.title));
+    }
+    return selectedArtists;
+  }, [apiProfile]);
+
+  const hiddenGemSongs = useMemo(() => previewSongs, [previewSongs]);
+  const profileStats = useMemo(
+    () => ({
+      totalCharted: apiProfile?.totalCharted ?? fallbackProfile.totalCharted,
+      uniqueCount: apiProfile?.uniqueCount ?? fallbackProfile.uniqueCount,
+      sharedCount: apiProfile?.sharedCount ?? fallbackProfile.sharedCount,
+      overlapPercent: apiProfile?.overlapPercent ?? fallbackProfile.overlapPercent,
+      uniqueSongs,
+      sharedSongs,
+      genreBreakdown: fallbackProfile.genreBreakdown,
+      languageBreakdown: fallbackProfile.languageBreakdown,
+    }),
+    [apiProfile, fallbackProfile, sharedSongs, uniqueSongs]
+  );
+
+  const isCoreLoading = initialLoadingProfile || initialLoadingUnique || initialLoadingShared;
+  const loadingText = `Loading${".".repeat(loadingDots)}`;
+
+  useEffect(() => {
+    if (!(isCoreLoading || initialLoadingPreview)) {
+      setLoadingDots(1);
+      return;
+    }
+    const timer = setInterval(() => {
+      setLoadingDots((current) => (current >= 3 ? 1 : current + 1));
+    }, 350);
+    return () => clearInterval(timer);
+  }, [initialLoadingPreview, isCoreLoading]);
+
+  const generalDescriptionText = useMemo(() => {
+    const genreA = country.genres[0] ?? "Unknown Genre";
+    const genreB = country.genres[1] ?? genreA;
+    const genreC = country.genres[2] ?? genreB;
+    const artistA = favoriteArtists[0]?.artist;
+    const artistB = favoriteArtists[1]?.artist;
+    const songA = profileStats.uniqueSongs[0] ?? profileStats.sharedSongs[0];
+    const songB = profileStats.uniqueSongs[1] ?? profileStats.sharedSongs[1] ?? profileStats.sharedSongs[0];
+    if (!artistA || !artistB || !songA || !songB) {
+      return `A mix of ${genreA}, ${genreB}, and ${genreC} are ${country.name}'s favorites in ${selectedYear}. Favorite artists include ${loadingText} and ${loadingText}, and favorite songs that year included ${loadingText} and ${loadingText}.`;
+    }
+    return `A mix of ${genreA}, ${genreB}, and ${genreC} are ${country.name}'s favorites in ${selectedYear}. Favorite artists include ${artistA} and ${artistB}, and favorite songs that year included ${songA.title} by ${songA.artist} and ${songB.title} by ${songB.artist}.`;
+  }, [country.genres, country.name, favoriteArtists, loadingText, profileStats.sharedSongs, profileStats.uniqueSongs, selectedYear]);
 
   return (
     <Panel style={styles.paneShell}>
@@ -1036,6 +1369,7 @@ function ComparisonCountryPane({
             countryOptions={countryOptions}
             selectedCountryId={country.id}
             selectedYear={selectedYear}
+            availableYears={yearOptions}
             onChangeCountry={onChangeCountry}
             onChangeYear={onChangeYear}
           />
@@ -1050,7 +1384,7 @@ function ComparisonCountryPane({
                 <Text style={[styles.countrySummarySectionDetailTitle, styles.countrySummarySectionTextDark]}>General Description</Text>
                 <View style={styles.countrySummarySectionDetailTitleUnderline} />
               </View>
-              <Text style={[styles.countrySummarySectionDetailText, styles.countrySummarySectionTextDark]}>{country.sceneNote}</Text>
+              <Text style={[styles.countrySummarySectionDetailText, styles.countrySummarySectionTextDark]}>{generalDescriptionText}</Text>
             </View>
             <View style={styles.countrySummarySectionDetailCard}>
               <View style={styles.countrySummarySectionDetailTitleWrap}>
@@ -1065,33 +1399,41 @@ function ComparisonCountryPane({
           </View>
         </CountryPageSection>
 
-        <FavoriteArtistsSection country={country} selectedYear={selectedYear} onOpenHiddenGems={openForCountry} />
+        <FavoriteArtistsSection
+          country={country}
+          selectedYear={selectedYear}
+          artists={favoriteArtists}
+          isLoading={initialLoadingProfile}
+          onOpenHiddenGems={openForCountry}
+        />
 
         <View style={styles.statStripRow}>
-          <StatSquare label="Songs in This View" value={`${profile.totalCharted}`} note="songs" style={styles.statStripItem} />
-          <StatSquare label="Loved in This Country" value={`${profile.uniqueCount}`} note="songs" style={styles.statStripItem} />
+          <StatSquare label="Songs in This View" value={isCoreLoading ? loadingText : `${profileStats.totalCharted}`} note="songs" style={styles.statStripItem} />
+          <StatSquare label="Loved in This Country" value={isCoreLoading ? loadingText : `${profileStats.uniqueCount}`} note="songs" style={styles.statStripItem} />
           <StatSquare
             label="Loved Here and Elsewhere"
-            value={`${profile.sharedCount}`}
+            value={isCoreLoading ? loadingText : `${profileStats.sharedCount}`}
             note="songs"
             style={styles.statStripItem}
           />
           <StatSquare
             label="Loved Here and Elsewhere"
-            value={`${profile.overlapPercent}%`}
+            value={isCoreLoading ? loadingText : `${profileStats.overlapPercent}%`}
             note="% of this view"
             style={styles.statStripItem}
           />
         </View>
 
         <View style={styles.genreAndLanguageSections}>
-          <GenreSection title={`${country.name}'s Loved Genres`} items={profile.genreBreakdown} visual="pie" />
-          <LanguageSection title={`${country.name}'s Languages`} items={profile.languageBreakdown} />
+          <GenreSection title={`${country.name}'s Loved Genres`} items={profileStats.genreBreakdown} visual="pie" />
+          <LanguageSection title={`${country.name}'s Languages`} items={profileStats.languageBreakdown} />
         </View>
 
         <HiddenSongsCarouselSection
           countryName={country.name}
           songs={hiddenGemSongs}
+          isLoading={initialLoadingPreview}
+          loadingText={loadingText}
           onOpenHiddenGems={openForCountry}
         />
 
@@ -1099,15 +1441,23 @@ function ComparisonCountryPane({
           <View style={styles.mainComparisonColumns}>
             <MainComparisonArea
               title="Most Loved in This Country"
-              songs={profile.uniqueSongs}
+              songs={profileStats.uniqueSongs}
               onOpenHiddenGems={openForCountry}
+              isInitialLoading={initialLoadingUnique}
+              hasMore={uniqueHasMore}
+              isLoadingMore={loadingMoreUnique}
+              onLoadMore={loadMoreUniqueSongs}
               darkTheme
             />
             <View style={styles.mainComparisonSectionDivider} />
             <MainComparisonArea
               title="Loved Here and Elsewhere"
-              songs={profile.sharedSongs}
+              songs={profileStats.sharedSongs}
               onOpenHiddenGems={openForCountry}
+              isInitialLoading={initialLoadingShared}
+              hasMore={sharedHasMore}
+              isLoadingMore={loadingMoreShared}
+              onLoadMore={loadMoreSharedSongs}
               darkTheme
             />
           </View>
@@ -1147,6 +1497,8 @@ export function ComparisonResultsScreen({
 }: Props) {
   const leftCountry = countries[0];
   const rightCountry = countries[1];
+  const [leftPaneYear, setLeftPaneYear] = useState(selectedYear);
+  const [rightPaneYear, setRightPaneYear] = useState(selectedYear);
 
   return (
     <ScreenScaffold>
@@ -1160,8 +1512,8 @@ export function ComparisonResultsScreen({
               availableCountries={availableCountries}
               unavailableCountryId={rightCountry?.id}
               country={leftCountry}
-              selectedYear={selectedYear}
-              onChangeYear={onChangeYear}
+              selectedYear={leftPaneYear}
+              onChangeYear={setLeftPaneYear}
               onChangeCountry={(countryId) => onChangeCountryAtIndex(0, countryId)}
               onOpenCountry={onOpenCountry}
               onOpenHiddenGemsForCountry={onOpenHiddenGemsForCountry}
@@ -1174,8 +1526,8 @@ export function ComparisonResultsScreen({
               availableCountries={availableCountries}
               unavailableCountryId={leftCountry?.id}
               country={rightCountry}
-              selectedYear={selectedYear}
-              onChangeYear={onChangeYear}
+              selectedYear={rightPaneYear}
+              onChangeYear={setRightPaneYear}
               onChangeCountry={(countryId) => onChangeCountryAtIndex(1, countryId)}
               onOpenCountry={onOpenCountry}
               onOpenHiddenGemsForCountry={onOpenHiddenGemsForCountry}
@@ -1618,6 +1970,14 @@ const styles = StyleSheet.create({
   snapshotPanel: {
     minWidth: 320,
   },
+  favoriteArtistsScroll: {
+    ...(Platform.OS === "web"
+      ? ({
+          overflowX: "scroll",
+          overflowY: "hidden",
+        } as ViewStyle)
+      : null),
+  },
   panelTitle: {
     color: colors.textStrong,
     fontFamily: typefaces.display,
@@ -1636,8 +1996,8 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     gap: 14,
     alignItems: "flex-start",
-    justifyContent: "center",
-    flex: 1,
+    justifyContent: "flex-start",
+    paddingBottom: 6,
   },
   favoriteArtistItem: {
     alignItems: "center",
@@ -1650,6 +2010,14 @@ const styles = StyleSheet.create({
     fontSize: 13,
     lineHeight: 17,
     textAlign: "center",
+  },
+  favoriteArtistSongName: {
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 11,
+    lineHeight: 14,
+    textAlign: "center",
+    minHeight: 14,
   },
   hiddenSongsCarouselSection: {
     minHeight: 0,
@@ -1821,6 +2189,20 @@ const styles = StyleSheet.create({
     paddingRight: 28,
     paddingBottom: 10,
     gap: 10,
+  },
+  songListLoadingRow: {
+    minHeight: 62,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  songListLoadingText: {
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 16,
+    lineHeight: 20,
+  },
+  songListLoadingTextDark: {
+    color: colors.border,
   },
   mainComparisonScrollbarTrack: {
     position: "absolute",

--- a/hidden-gem-music-app/src/screens/ComparisonSelectScreen.web.tsx
+++ b/hidden-gem-music-app/src/screens/ComparisonSelectScreen.web.tsx
@@ -19,7 +19,8 @@ import { Panel } from "../components/Panel";
 import { ScreenScaffold } from "../components/ScreenScaffold";
 import { SecondarySurfaceFill } from "../components/SecondarySurfaceFill";
 import { GlobePanel } from "../components/globe/GlobePanel";
-import { availableYears } from "../data/mockData";
+import { loadAvailableYears } from "../data/countryApi";
+import { getSongsForCountryYear } from "../data/mockData";
 import { Country } from "../types/content";
 import { colors } from "../theme/colors";
 import { typefaces } from "../theme/typography";
@@ -28,6 +29,7 @@ export type Props = {
   countries: Country[];
   selectedCountryIds: string[];
   onToggleCountry: (countryId: string) => void;
+  onClearSelections: () => void;
   onDone: () => void;
   selectedYear: number;
   onChangeYear: (year: number) => void;
@@ -46,7 +48,6 @@ const activeGradient = [colors.navGradient, colors.backgroundRaised, colors.back
 const comparisonPanelGradient = [colors.backgroundSoft, "#74819B", "#7A4762"] as const;
 const softPanelGradient = [colors.backgroundSoft, "#74819B", "#5D6983", "#36405B"] as const;
 const continentOptions = ["Africa", "Asia", "Europe", "North America", "Oceania", "South America"] as const;
-
 function toggleFilterSelection(currentValues: string[], option: string) {
   if (option === "All") {
     return ["All"];
@@ -64,19 +65,44 @@ function toggleFilterSelection(currentValues: string[], option: string) {
 
 function YearDropdown({
   selectedYear,
+  availableYears,
   onSelectYear,
 }: {
   selectedYear: number | null;
+  availableYears: number[];
   onSelectYear: (year: number) => void;
 }) {
   const [isOpen, setIsOpen] = useState(false);
   const [hoveredYear, setHoveredYear] = useState<number | null>(null);
   const [isHovered, setIsHovered] = useState(false);
   const [isPressed, setIsPressed] = useState(false);
+  const containerRef = useRef<View>(null);
   const showButtonGradient = isHovered || isPressed || isOpen;
 
+  useEffect(() => {
+    if (Platform.OS !== "web" || !isOpen || typeof document === "undefined") {
+      return;
+    }
+
+    const handleDocumentMouseDown = (event: MouseEvent) => {
+      const node = containerRef.current as any;
+      const targetNode = event.target as Node | null;
+      const isInside = Boolean(node?.contains?.(targetNode));
+
+      if (!isInside) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleDocumentMouseDown);
+
+    return () => {
+      document.removeEventListener("mousedown", handleDocumentMouseDown);
+    };
+  }, [isOpen]);
+
   return (
-    <View style={styles.yearDropdownWrap}>
+    <View ref={containerRef} style={styles.yearDropdownWrap}>
       <Pressable
         onPress={() => setIsOpen((current) => !current)}
         onHoverIn={() => setIsHovered(true)}
@@ -150,10 +176,12 @@ function YearDropdown({
 
 function ComparisonBlurb({
   selectedYear,
+  availableYears,
   onSelectYear,
   onDone,
 }: {
   selectedYear: number | null;
+  availableYears: number[];
   onSelectYear: (year: number) => void;
   onDone: () => void;
 }) {
@@ -174,12 +202,12 @@ function ComparisonBlurb({
             <GemIcon size={16} style={styles.blurbIcon} />
             {"  "}
             <Text style={styles.blurbBody}>
-              This is text about how to use the comparison view, and how to use the filters, lorem ipsum yadayada.
+              Use Comparison View by selecting a year in the dropdown and optional filters like region, Biggest Hits, Fast Rising Songs, All Songs, and more, and then select two countries in the list before selecting 'Done' to view comparison results. The country list displays countries that have songs included in the app data for that year. Selecting other years may display different countries. On the comparison results screen, you can also select different countries and years to keep discovering even further.
             </Text>
           </Text>
         </View>
         <View style={styles.blurbActions}>
-          <YearDropdown selectedYear={selectedYear} onSelectYear={onSelectYear} />
+          <YearDropdown selectedYear={selectedYear} availableYears={availableYears} onSelectYear={onSelectYear} />
           <ActionButton label="Done" size="small" onPress={onDone} />
         </View>
       </View>
@@ -189,8 +217,10 @@ function ComparisonBlurb({
 
 function ComparisonSidebarPanels({
   visibleCountries,
+  totalCountries,
   selectedCountryIds,
   onToggleCountry,
+  onClearSelections,
   filters,
   onChangeFilter,
   regionOptions,
@@ -198,8 +228,10 @@ function ComparisonSidebarPanels({
   genreOptions,
 }: {
   visibleCountries: Country[];
+  totalCountries: number;
   selectedCountryIds: string[];
   onToggleCountry: (countryId: string) => void;
+  onClearSelections: () => void;
   filters: ComparisonFilters;
   onChangeFilter: (key: keyof ComparisonFilters, value: string[]) => void;
   regionOptions: string[];
@@ -209,6 +241,8 @@ function ComparisonSidebarPanels({
   const [expandedPanel, setExpandedPanel] = useState<ExpandedPanel>("list");
   const [hoveredFilterOption, setHoveredFilterOption] = useState<string | null>(null);
   const [hoveredCountryId, setHoveredCountryId] = useState<string | null>(null);
+  const [isClearHovered, setIsClearHovered] = useState(false);
+  const [isClearPressed, setIsClearPressed] = useState(false);
   const filterScrollRef = useRef<ScrollView>(null);
   const filterTrackRef = useRef<View>(null);
   const listScrollRef = useRef<ScrollView>(null);
@@ -517,7 +551,40 @@ function ComparisonSidebarPanels({
         >
           <View style={styles.sectionHeaderCopy}>
             <Text style={styles.sectionTitle}>Select Two Countries</Text>
-            <Text style={styles.sectionHelper}>{`${selectedCountryIds.length} out of 2 countries selected.`}</Text>
+            <View style={styles.selectionSummaryRow}>
+              {expandedPanel === "list" ? (
+                <Pressable
+                  onPress={(event) => {
+                    event.stopPropagation();
+                    onClearSelections();
+                  }}
+                  onHoverIn={() => setIsClearHovered(true)}
+                  onHoverOut={() => setIsClearHovered(false)}
+                  onPressIn={() => setIsClearPressed(true)}
+                  onPressOut={() => setIsClearPressed(false)}
+                  style={styles.clearSelectionButtonShell}
+                >
+                  {isClearHovered || isClearPressed ? (
+                    <LinearGradient
+                      colors={isClearPressed ? activeGradient : hoverGradient}
+                      locations={[0, 0.34, 1]}
+                      start={{ x: 0, y: 0.5 }}
+                      end={{ x: 1, y: 0.5 }}
+                      style={styles.clearSelectionButtonGradient}
+                    />
+                  ) : null}
+                  <View
+                    style={[
+                      styles.clearSelectionButton,
+                      isClearHovered || isClearPressed ? styles.clearSelectionButtonActive : null,
+                    ]}
+                  >
+                    <Text style={styles.clearSelectionButtonText}>Clear Selections</Text>
+                  </View>
+                </Pressable>
+              ) : null}
+              <Text style={styles.sectionHelper}>{`${selectedCountryIds.length} out of 2 countries selected.`}</Text>
+            </View>
           </View>
           <Text style={styles.sectionToggle}>{expandedPanel === "list" ? "-" : "+"}</Text>
         </Pressable>
@@ -609,13 +676,15 @@ export function ComparisonSelectScreen({
   countries,
   selectedCountryIds,
   onToggleCountry,
+  onClearSelections,
   onDone,
   selectedYear,
   onChangeYear,
 }: Props) {
   const { width } = useWindowDimensions();
   const isStacked = width < 980;
-  const [comparisonYear, setComparisonYear] = useState<number | null>(null);
+  const [comparisonYear, setComparisonYear] = useState<number | null>(selectedYear);
+  const [availableYears, setAvailableYears] = useState<number[]>([]);
   const [validationOpen, setValidationOpen] = useState(false);
   const [filters, setFilters] = useState<ComparisonFilters>({
     popularity: ["All Songs"],
@@ -623,18 +692,49 @@ export function ComparisonSelectScreen({
     language: ["All"],
     genre: ["All"],
   });
-  const regionOptions = useMemo(() => [...continentOptions], []);
+  const regionOptions = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          [...continentOptions, ...countries.map((country) => country.region).filter(Boolean)].filter(
+            (value) => value !== "Continent info coming soon." && value !== "Other"
+          )
+        )
+      ).sort((a, b) => a.localeCompare(b)),
+    [countries]
+  );
   const languageOptions = useMemo(
-    () => Array.from(new Set(countries.flatMap((country) => country.languages ?? []))).sort((a, b) => a.localeCompare(b)),
+    () =>
+      Array.from(new Set(countries.flatMap((country) => country.languages ?? [])))
+        .filter((value) => value.trim().toLowerCase() !== "unknown")
+        .sort((a, b) => a.localeCompare(b)),
     [countries]
   );
   const genreOptions = useMemo(
-    () => Array.from(new Set(countries.flatMap((country) => country.genres ?? []))).sort((a, b) => a.localeCompare(b)),
+    () =>
+      Array.from(new Set(countries.flatMap((country) => country.genres ?? [])))
+        .filter((value) => value.trim().toLowerCase() !== "unknown")
+        .sort((a, b) => a.localeCompare(b)),
     [countries]
   );
   const filteredCountries = useMemo(
     () =>
       countries.filter((country) => {
+        // Include only countries that have songs in app data for this year.
+        if (getSongsForCountryYear(country.id, comparisonYear ?? selectedYear).length <= 0) {
+          return false;
+        }
+
+        if (filters.popularity.includes("Biggest Hits") && !filters.popularity.includes("All Songs")) {
+          if (country.hiddenSongs < 10) {
+            return false;
+          }
+        }
+        if (filters.popularity.includes("Fast Rising Songs") && !filters.popularity.includes("All Songs")) {
+          if (country.hiddenSongs >= 10) {
+            return false;
+          }
+        }
         if (!filters.region.includes("All") && !filters.region.includes(country.region)) {
           return false;
         }
@@ -649,9 +749,43 @@ export function ComparisonSelectScreen({
         }
         return true;
       }),
-    [countries, filters.genre, filters.language, filters.region]
+    [countries, filters.genre, filters.language, filters.popularity, filters.region]
   );
   const visibleCountries = filteredCountries.length > 0 ? filteredCountries : countries;
+
+  useEffect(() => {
+    setComparisonYear(selectedYear);
+  }, [selectedYear]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    loadAvailableYears()
+      .then((years) => {
+        if (!cancelled && years.length > 0) {
+          setAvailableYears(years);
+        }
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          console.warn("Failed to load available years metadata for Comparison Mode; falling back to selected year.", error);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const yearOptions = useMemo(() => {
+    if (availableYears.length === 0) {
+      return comparisonYear != null ? [comparisonYear] : [selectedYear];
+    }
+    if (comparisonYear == null || availableYears.includes(comparisonYear)) {
+      return availableYears;
+    }
+    return [...availableYears, comparisonYear].sort((a, b) => a - b);
+  }, [availableYears, comparisonYear, selectedYear]);
 
   const handleDone = () => {
     if (comparisonYear == null || selectedCountryIds.length !== 2) {
@@ -680,10 +814,15 @@ export function ComparisonSelectScreen({
     <View style={[styles.rightColumn, isStacked ? styles.columnStacked : null]}>
       <ComparisonSidebarPanels
         visibleCountries={visibleCountries}
+        totalCountries={countries.length}
         selectedCountryIds={selectedCountryIds}
         onToggleCountry={onToggleCountry}
+        onClearSelections={onClearSelections}
         filters={filters}
-        onChangeFilter={(key, value) => setFilters((current) => ({ ...current, [key]: value }))}
+        onChangeFilter={(key, value) => {
+          onClearSelections();
+          setFilters((current) => ({ ...current, [key]: value }));
+        }}
         regionOptions={regionOptions}
         languageOptions={languageOptions}
         genreOptions={genreOptions}
@@ -695,6 +834,7 @@ export function ComparisonSelectScreen({
     <View style={styles.stack}>
       <ComparisonBlurb
         selectedYear={comparisonYear}
+        availableYears={yearOptions}
         onSelectYear={(year) => {
           setComparisonYear(year);
           onChangeYear(year);
@@ -945,8 +1085,44 @@ const styles = StyleSheet.create({
     fontSize: 14,
     lineHeight: 16,
     textAlign: "right",
-    maxWidth: 260,
+    maxWidth: 300,
     flexShrink: 1,
+  },
+  selectionSummaryRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "flex-end",
+    gap: 10,
+    flexShrink: 1,
+  },
+  clearSelectionButtonShell: {
+    position: "relative",
+    borderRadius: 999,
+    overflow: "hidden",
+    flexShrink: 0,
+  },
+  clearSelectionButtonGradient: {
+    ...StyleSheet.absoluteFillObject,
+    opacity: 0.45,
+  },
+  clearSelectionButton: {
+    borderRadius: 999,
+    borderWidth: 2,
+    borderColor: colors.border,
+    backgroundColor: "rgba(32,38,56,0.42)",
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    minHeight: 32,
+    justifyContent: "center",
+  },
+  clearSelectionButtonActive: {
+    backgroundColor: "rgba(22,26,38,0.32)",
+  },
+  clearSelectionButtonText: {
+    color: colors.border,
+    fontFamily: typefaces.body,
+    fontSize: 12,
+    lineHeight: 14,
   },
   sectionToggle: {
     color: colors.border,

--- a/hidden-gem-music-app/src/screens/CountryScreen.web.tsx
+++ b/hidden-gem-music-app/src/screens/CountryScreen.web.tsx
@@ -19,7 +19,8 @@ import { GemIcon } from "../components/GemIcon";
 import { Panel } from "../components/Panel";
 import { ScreenScaffold } from "../components/ScreenScaffold";
 import { SecondarySurfaceFill } from "../components/SecondarySurfaceFill";
-import { availableYears as allAvailableYears, getSongsForCountryYear } from "../data/mockData";
+import { loadAvailableYears, loadCountryHiddenGemsPreview, loadCountryProfile, loadCountrySongsPage } from "../data/countryApi";
+import { mapApiCountryProfile, mapApiHiddenGem, mapApiSong } from "../data/apiMappers";
 import { Country, Song } from "../types/content";
 import { colors } from "../theme/colors";
 import { typefaces } from "../theme/typography";
@@ -136,6 +137,10 @@ function createSongPreview(title: string, artist: string, detail: string, score:
   };
 }
 
+function toSongPreview(song: { title: string; artist: string }, detail: string, score: number): SongPreview {
+  return createSongPreview(song.title, song.artist, detail, score);
+}
+
 function buildCountryProfile(country: Country, year: number): CountryProfileViewModel {
   const seed = hashString(`${country.code}-${year}`);
   const totalCharted = clamp(
@@ -242,11 +247,31 @@ function CountryPageSection({
   );
 }
 
-function StatSquare({ label, value, note }: { label: string; value: string; note: string }) {
+function StatSquare({
+  label,
+  value,
+  note,
+  valueOffsetY = 0,
+  useLoadingStyle = false,
+}: {
+  label: string;
+  value: ReactNode;
+  note: string;
+  valueOffsetY?: number;
+  useLoadingStyle?: boolean;
+}) {
   return (
     <CountryPageSection style={styles.statSquare} contentStyle={styles.statSquareContent}>
       <Text style={styles.statSquareLabel}>{label}</Text>
-      <Text style={styles.statSquareValue}>{value}</Text>
+      <Text
+        style={[
+          styles.statSquareValue,
+          useLoadingStyle ? styles.statSquareValueLoading : null,
+          valueOffsetY !== 0 ? { transform: [{ translateY: valueOffsetY }] } : null,
+        ]}
+      >
+        {value}
+      </Text>
       <Text style={styles.statSquareNote}>{note}</Text>
     </CountryPageSection>
   );
@@ -286,11 +311,19 @@ function MainComparisonArea({
   title,
   songs,
   onOpenHiddenGems,
+  isInitialLoading = false,
+  hasMore = false,
+  isLoadingMore = false,
+  onLoadMore,
   darkTheme = false,
 }: {
   title: string;
   songs: SongPreview[];
   onOpenHiddenGems: (selection?: { songTitle?: string; artist?: string }) => void;
+  isInitialLoading?: boolean;
+  hasMore?: boolean;
+  isLoadingMore?: boolean;
+  onLoadMore?: () => void;
   darkTheme?: boolean;
 }) {
   const scrollRef = useRef<ScrollView>(null);
@@ -300,6 +333,7 @@ function MainComparisonArea({
   const [contentHeight, setContentHeight] = useState(0);
   const [scrollY, setScrollY] = useState(0);
   const [isDraggingScrollbar, setIsDraggingScrollbar] = useState(false);
+  const [loadingDots, setLoadingDots] = useState(1);
   const scrollbarVisible = Platform.OS === "web" && viewportHeight > 0;
   const hasOverflow = scrollbarVisible && contentHeight > viewportHeight;
   const trackHeight = Math.max(viewportHeight - 20, 1);
@@ -311,7 +345,17 @@ function MainComparisonArea({
   const thumbTop = hasOverflow ? (scrollY / (contentHeight - viewportHeight)) * (viewportHeight - thumbHeight) : 0;
 
   const handleScroll = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
-    setScrollY(event.nativeEvent.contentOffset.y);
+    const nextScrollY = event.nativeEvent.contentOffset.y;
+    setScrollY(nextScrollY);
+
+    if (!hasMore || isLoadingMore || !onLoadMore || contentHeight <= 0 || viewportHeight <= 0) {
+      return;
+    }
+
+    const remaining = contentHeight - (nextScrollY + viewportHeight);
+    if (remaining < 220) {
+      onLoadMore();
+    }
   };
 
   const scrollToTrackLocation = (locationY: number) => {
@@ -362,6 +406,19 @@ function MainComparisonArea({
     };
   }, [isDraggingScrollbar, hasOverflow, thumbHeight, trackHeight, contentHeight, viewportHeight]);
 
+  useEffect(() => {
+    if (!isInitialLoading) {
+      setLoadingDots(1);
+      return;
+    }
+
+    const timer = setInterval(() => {
+      setLoadingDots((current) => (current >= 3 ? 1 : current + 1));
+    }, 350);
+
+    return () => clearInterval(timer);
+  }, [isInitialLoading]);
+
   return (
     <View style={styles.mainComparisonArea}>
       <Text style={[styles.panelTitle, darkTheme ? styles.panelTitleDark : null]}>{title}</Text>
@@ -377,6 +434,13 @@ function MainComparisonArea({
           onScroll={handleScroll}
           scrollEventThrottle={16}
         >
+          {songs.length === 0 && isInitialLoading ? (
+            <View style={styles.songListLoadingRow}>
+              <Text style={[styles.songListLoadingText, darkTheme ? styles.songListLoadingTextDark : null]}>
+                {`Loading${".".repeat(loadingDots)}`}
+              </Text>
+            </View>
+          ) : null}
           {songs.map((song, index) => (
             <Pressable
               key={`${title}-${song.title}-${song.artist}`}
@@ -428,6 +492,11 @@ function MainComparisonArea({
               }}
             </Pressable>
           ))}
+          {isLoadingMore ? (
+            <View style={styles.songListLoadingRow}>
+              <Text style={[styles.songListLoadingText, darkTheme ? styles.songListLoadingTextDark : null]}>Loading more...</Text>
+            </View>
+          ) : null}
         </ScrollView>
         {scrollbarVisible ? (
           <View
@@ -573,16 +642,18 @@ function CountryHeaderDropdownStack({
   countries,
   country,
   selectedYear,
+  availableYears,
   onSelectCountry,
   onChangeYear,
 }: {
   countries: Country[];
   country: Country;
   selectedYear: number;
+  availableYears: number[];
   onSelectCountry: (countryId: string) => void;
   onChangeYear: (year: number) => void;
 }) {
-  const yearOptions = useMemo(() => [...allAvailableYears], []);
+  const yearOptions = useMemo(() => [...availableYears], [availableYears]);
   const [isCountryDropdownOpen, setIsCountryDropdownOpen] = useState(false);
   const [isYearDropdownOpen, setIsYearDropdownOpen] = useState(false);
   const [isCountryDropdownHovered, setIsCountryDropdownHovered] = useState(false);
@@ -591,13 +662,37 @@ function CountryHeaderDropdownStack({
   const [isYearDropdownPressed, setIsYearDropdownPressed] = useState(false);
   const [hoveredCountryId, setHoveredCountryId] = useState<string | null>(null);
   const [hoveredYear, setHoveredYear] = useState<number | null>(null);
+  const containerRef = useRef<View>(null);
 
   const showCountryDropdownGradient =
     isCountryDropdownOpen || isCountryDropdownHovered || isCountryDropdownPressed;
   const showYearDropdownGradient = isYearDropdownOpen || isYearDropdownHovered || isYearDropdownPressed;
 
+  useEffect(() => {
+    if (Platform.OS !== "web" || (!isCountryDropdownOpen && !isYearDropdownOpen)) {
+      return;
+    }
+
+    const handleDocumentMouseDown = (event: MouseEvent) => {
+      const node = containerRef.current as any;
+      const targetNode = event.target as Node | null;
+      const isInside = Boolean(node?.contains?.(targetNode));
+
+      if (!isInside) {
+        setIsCountryDropdownOpen(false);
+        setIsYearDropdownOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleDocumentMouseDown);
+
+    return () => {
+      document.removeEventListener("mousedown", handleDocumentMouseDown);
+    };
+  }, [isCountryDropdownOpen, isYearDropdownOpen]);
+
   return (
-    <View style={styles.headerDropdownStack}>
+    <View ref={containerRef} style={styles.headerDropdownStack}>
       <View style={[styles.headerDropdownWrap, styles.headerCountryDropdownWrap]}>
         <Pressable
           onPress={() => {
@@ -816,10 +911,14 @@ function CountryHeaderDropdownStack({
 function HiddenSongsCarouselSection({
   countryName,
   songs,
+  isLoading,
+  loadingText,
   onOpenHiddenGems,
 }: {
   countryName: string;
   songs: Pick<Song, "title" | "artist">[];
+  isLoading: boolean;
+  loadingText: string;
   onOpenHiddenGems: (selection?: { songTitle?: string; artist?: string }) => void;
 }) {
   const songCount = songs.length;
@@ -847,6 +946,10 @@ function HiddenSongsCarouselSection({
   };
 
   const handleCarouselItemPress = (songIndex: number, isCenter: boolean) => {
+    if (isLoading) {
+      return;
+    }
+
     const song = songs[songIndex];
     if (!song) {
       return;
@@ -866,7 +969,7 @@ function HiddenSongsCarouselSection({
         <View style={styles.hiddenSongsCarouselHeaderLeft}>
           <Text style={styles.panelTitle}>Preview {countryName}'s Hidden Gems</Text>
           <Text style={styles.hiddenSongsCarouselHelper}>
-            Click a song to listen to a 30 second preview on the Hidden Gems page.
+            {isLoading ? loadingText : "Click a song to listen to a 30 second preview on the Hidden Gems page."}
           </Text>
         </View>
         <Pressable onPress={() => onOpenHiddenGems()} style={styles.hiddenSongsCarouselHelperAction}>
@@ -957,27 +1060,36 @@ function HiddenSongsCarouselSection({
 function FavoriteArtistsSection({
   country,
   selectedYear,
+  artists,
+  isLoading,
   onOpenHiddenGems,
 }: {
   country: Country;
   selectedYear: number;
+  artists: string[];
+  isLoading: boolean;
   onOpenHiddenGems: (selection?: { songTitle?: string; artist?: string }) => void;
 }) {
-  const artists = Array.from({ length: 8 }, (_, index) => country.featuredArtists[index % country.featuredArtists.length]);
+  const artistRows = Array.from({ length: 8 }, (_, index) => artists[index] ?? "");
 
   return (
     <CountryPageSection style={styles.snapshotPanel}>
       <Text style={styles.panelTitle}>{`${country.name}'s Favorite Artists in ${selectedYear}`}</Text>
 
       <View style={styles.favoriteArtistsRow}>
-        {artists.map((artist, index) => (
+        {artistRows.map((artist, index) => (
           <Pressable
             key={`${artist}-${index}`}
-            onPress={() => onOpenHiddenGems({ artist })}
+            onPress={() => {
+              if (!isLoading && artist) {
+                onOpenHiddenGems({ artist });
+              }
+            }}
             style={styles.favoriteArtistItem}
           >
             <CdCase size={104} artColor={carouselBackdropColors[index % carouselBackdropColors.length]} />
-            <Text style={styles.favoriteArtistName}>{artist}</Text>
+            <Text style={styles.favoriteArtistName}>{isLoading ? "Loading..." : artist}</Text>
+            <Text style={styles.favoriteArtistSongName}>{isLoading ? "Loading..." : ""}</Text>
           </Pressable>
         ))}
       </View>
@@ -1039,8 +1151,23 @@ export function CountryScreen({
   const { width } = useWindowDimensions();
   const isStacked = width < 1120;
   const isCompact = width < 760;
-  const profile = useMemo(() => buildCountryProfile(country, selectedYear), [country, selectedYear]);
-  const hiddenGemSongs = useMemo(() => getSongsForCountryYear(country.id, selectedYear), [country.id, selectedYear]);
+  const fallbackProfile = useMemo(() => buildCountryProfile(country, selectedYear), [country, selectedYear]);
+  const [availableYears, setAvailableYears] = useState<number[]>([]);
+  const [apiProfile, setApiProfile] = useState<ReturnType<typeof mapApiCountryProfile> | null>(null);
+  const [previewSongs, setPreviewSongs] = useState<Array<{ title: string; artist: string }>>([]);
+  const [uniqueSongs, setUniqueSongs] = useState<SongPreview[]>([]);
+  const [sharedSongs, setSharedSongs] = useState<SongPreview[]>([]);
+  const [uniquePage, setUniquePage] = useState(1);
+  const [sharedPage, setSharedPage] = useState(1);
+  const [uniqueHasMore, setUniqueHasMore] = useState(false);
+  const [sharedHasMore, setSharedHasMore] = useState(false);
+  const [loadingMoreUnique, setLoadingMoreUnique] = useState(false);
+  const [loadingMoreShared, setLoadingMoreShared] = useState(false);
+  const [initialLoadingUnique, setInitialLoadingUnique] = useState(false);
+  const [initialLoadingShared, setInitialLoadingShared] = useState(false);
+  const [initialLoadingProfile, setInitialLoadingProfile] = useState(false);
+  const [initialLoadingPreview, setInitialLoadingPreview] = useState(false);
+  const [loadingDots, setLoadingDots] = useState(1);
   const pageScrollRef = useRef<ScrollView>(null);
   const pageTrackRef = useRef<View>(null);
   const [pageViewportHeight, setPageViewportHeight] = useState(0);
@@ -1056,6 +1183,300 @@ export function CountryScreen({
       : pageTrackHeight
     : 0;
   const pageThumbTop = pageHasOverflow ? (pageScrollY / (pageContentHeight - pageViewportHeight)) * (pageViewportHeight - pageThumbHeight) : 0;
+  const latestRequestRef = useRef(0);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    loadAvailableYears()
+      .then((years) => {
+        if (!cancelled && years.length > 0) {
+          setAvailableYears(years);
+        }
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          console.warn("Failed to load available years metadata. Falling back to current year selection.", error);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    const requestId = latestRequestRef.current + 1;
+    latestRequestRef.current = requestId;
+    setUniqueSongs([]);
+    setSharedSongs([]);
+    setUniquePage(1);
+    setSharedPage(1);
+    setUniqueHasMore(false);
+    setSharedHasMore(false);
+    setLoadingMoreUnique(false);
+    setLoadingMoreShared(false);
+    setInitialLoadingUnique(true);
+    setInitialLoadingShared(true);
+    setInitialLoadingProfile(true);
+    setInitialLoadingPreview(true);
+
+    loadCountryProfile(country.code, selectedYear)
+      .then((profilePayload) => {
+        if (latestRequestRef.current !== requestId) {
+          return;
+        }
+
+        setApiProfile(mapApiCountryProfile(profilePayload));
+        setInitialLoadingProfile(false);
+      })
+      .catch((error) => {
+        if (latestRequestRef.current !== requestId) {
+          return;
+        }
+
+        console.warn(`Failed to load country profile API data for ${country.code} ${selectedYear}.`, error);
+        setApiProfile(null);
+        setInitialLoadingProfile(false);
+      });
+
+    loadCountryHiddenGemsPreview(country.code, selectedYear, 13)
+      .then((hiddenGemsPayload) => {
+        if (latestRequestRef.current !== requestId) {
+          return;
+        }
+
+        setPreviewSongs(
+          hiddenGemsPayload.map((item) => {
+            const mapped = mapApiHiddenGem(item);
+            return { title: mapped.title, artist: mapped.artist };
+          })
+        );
+        setInitialLoadingPreview(false);
+      })
+      .catch((error) => {
+        if (latestRequestRef.current !== requestId) {
+          return;
+        }
+
+        console.warn(`Failed to load hidden gems preview API data for ${country.code} ${selectedYear}.`, error);
+        setPreviewSongs([]);
+        setInitialLoadingPreview(false);
+      });
+
+    loadCountrySongsPage(country.code, selectedYear, "unique", 1, 50)
+      .then((payload) => {
+        if (latestRequestRef.current !== requestId) {
+          return;
+        }
+
+        setUniqueSongs(
+          payload.items.map((song, index) =>
+            toSongPreview(mapApiSong(song), `Feels especially loved in ${country.name}`, clamp(95 - index * 2, 34, 95))
+          )
+        );
+        setUniqueHasMore(payload.hasMore);
+        setInitialLoadingUnique(false);
+      })
+      .catch((error) => {
+        if (latestRequestRef.current !== requestId) {
+          return;
+        }
+
+        console.warn(`Failed to load unique songs page for ${country.code} ${selectedYear}.`, error);
+        setUniqueSongs([]);
+        setInitialLoadingUnique(false);
+      });
+
+    loadCountrySongsPage(country.code, selectedYear, "shared", 1, 50)
+      .then((payload) => {
+        if (latestRequestRef.current !== requestId) {
+          return;
+        }
+
+        setSharedSongs(
+          payload.items.map((song, index) =>
+            toSongPreview(mapApiSong(song), "Loved in this country and echoed across other countries", clamp(95 - index * 2, 34, 95))
+          )
+        );
+        setSharedHasMore(payload.hasMore);
+        setInitialLoadingShared(false);
+      })
+      .catch((error) => {
+        if (latestRequestRef.current !== requestId) {
+          return;
+        }
+
+        console.warn(`Failed to load shared songs page for ${country.code} ${selectedYear}.`, error);
+        setSharedSongs([]);
+        setInitialLoadingShared(false);
+      });
+  }, [country.code, selectedYear]);
+
+  const yearOptions = useMemo(() => {
+    if (availableYears.length === 0) {
+      return [selectedYear];
+    }
+
+    if (availableYears.includes(selectedYear)) {
+      return availableYears;
+    }
+
+    return [...availableYears, selectedYear].sort((a, b) => a - b);
+  }, [availableYears, selectedYear]);
+
+  const loadMoreUniqueSongs = () => {
+    if (loadingMoreUnique || !uniqueHasMore) {
+      return;
+    }
+
+    const requestId = latestRequestRef.current;
+    const nextPage = uniquePage + 1;
+    setLoadingMoreUnique(true);
+
+    loadCountrySongsPage(country.code, selectedYear, "unique", nextPage, 50)
+      .then((payload) => {
+        if (latestRequestRef.current !== requestId) {
+          return;
+        }
+
+        setUniqueSongs((current) => {
+          const nextItems = payload.items.map((song, index) =>
+            toSongPreview(mapApiSong(song), `Feels especially loved in ${country.name}`, clamp(95 - (current.length + index) * 2, 34, 95))
+          );
+          return [...current, ...nextItems];
+        });
+        setUniquePage(nextPage);
+        setUniqueHasMore(payload.hasMore);
+      })
+      .catch((error) => {
+        if (latestRequestRef.current !== requestId) {
+          return;
+        }
+        console.warn(`Failed loading additional unique songs for ${country.code} ${selectedYear}.`, error);
+      })
+      .finally(() => {
+        if (latestRequestRef.current === requestId) {
+          setLoadingMoreUnique(false);
+        }
+      });
+  };
+
+  const loadMoreSharedSongs = () => {
+    if (loadingMoreShared || !sharedHasMore) {
+      return;
+    }
+
+    const requestId = latestRequestRef.current;
+    const nextPage = sharedPage + 1;
+    setLoadingMoreShared(true);
+
+    loadCountrySongsPage(country.code, selectedYear, "shared", nextPage, 50)
+      .then((payload) => {
+        if (latestRequestRef.current !== requestId) {
+          return;
+        }
+
+        setSharedSongs((current) => {
+          const nextItems = payload.items.map((song, index) =>
+            toSongPreview(
+              mapApiSong(song),
+              "Loved in this country and echoed across other countries",
+              clamp(95 - (current.length + index) * 2, 34, 95)
+            )
+          );
+          return [...current, ...nextItems];
+        });
+        setSharedPage(nextPage);
+        setSharedHasMore(payload.hasMore);
+      })
+      .catch((error) => {
+        if (latestRequestRef.current !== requestId) {
+          return;
+        }
+        console.warn(`Failed loading additional shared songs for ${country.code} ${selectedYear}.`, error);
+      })
+      .finally(() => {
+        if (latestRequestRef.current === requestId) {
+          setLoadingMoreShared(false);
+        }
+      });
+  };
+
+  const favoriteArtists = useMemo(() => {
+    if (!apiProfile) {
+      return [];
+    }
+
+    const selectedArtists: string[] = [];
+    const seen = new Set<string>();
+    const addArtist = (name: string) => {
+      const normalized = name.trim().toLowerCase();
+      if (!normalized || seen.has(normalized) || selectedArtists.length >= 8) {
+        return;
+      }
+
+      seen.add(normalized);
+      selectedArtists.push(name);
+    };
+
+    apiProfile.topUniqueSongs.forEach((song) => addArtist(song.artist));
+    if (selectedArtists.length < 8) {
+      apiProfile.topSharedSongs.forEach((song) => addArtist(song.artist));
+    }
+
+    return selectedArtists;
+  }, [apiProfile]);
+
+  const hiddenGemSongs = useMemo(() => {
+    return previewSongs;
+  }, [previewSongs]);
+
+  const profileStats = useMemo(
+    () => ({
+      totalCharted: apiProfile?.totalCharted ?? fallbackProfile.totalCharted,
+      uniqueCount: apiProfile?.uniqueCount ?? fallbackProfile.uniqueCount,
+      sharedCount: apiProfile?.sharedCount ?? fallbackProfile.sharedCount,
+      overlapPercent: apiProfile?.overlapPercent ?? fallbackProfile.overlapPercent,
+      uniqueSongs,
+      sharedSongs,
+      genreBreakdown: fallbackProfile.genreBreakdown,
+      languageBreakdown: fallbackProfile.languageBreakdown,
+    }),
+    [apiProfile, fallbackProfile, sharedSongs, uniqueSongs]
+  );
+
+  const isCoreLoading = initialLoadingProfile || initialLoadingUnique || initialLoadingShared;
+  const loadingText = `Loading${".".repeat(loadingDots)}`;
+
+  useEffect(() => {
+    if (!(isCoreLoading || initialLoadingPreview)) {
+      setLoadingDots(1);
+      return;
+    }
+
+    const timer = setInterval(() => {
+      setLoadingDots((current) => (current >= 3 ? 1 : current + 1));
+    }, 350);
+
+    return () => clearInterval(timer);
+  }, [initialLoadingPreview, isCoreLoading]);
+
+  const generalDescriptionText = useMemo(() => {
+    const genreA = country.genres[0] ?? "Unknown Genre";
+    const genreB = country.genres[1] ?? genreA;
+    const genreC = country.genres[2] ?? genreB;
+    const artistA = favoriteArtists[0];
+    const artistB = favoriteArtists[1];
+    const songA = profileStats.uniqueSongs[0] ?? profileStats.sharedSongs[0];
+    const songB = profileStats.uniqueSongs[1] ?? profileStats.sharedSongs[1] ?? profileStats.sharedSongs[0];
+
+    if (!artistA || !artistB || !songA || !songB) {
+      return `A mix of ${genreA}, ${genreB}, and ${genreC} are ${country.name}'s favorites in ${selectedYear}. Favorite artists include ${loadingText} and ${loadingText}, and favorite songs that year included ${loadingText} and ${loadingText}.`;
+    }
+
+    return `A mix of ${genreA}, ${genreB}, and ${genreC} are ${country.name}'s favorites in ${selectedYear}. Favorite artists include ${artistA} and ${artistB}, and favorite songs that year included ${songA.title} by ${songA.artist} and ${songB.title} by ${songB.artist}.`;
+  }, [country.genres, country.name, favoriteArtists, loadingText, profileStats.sharedSongs, profileStats.uniqueSongs, selectedYear]);
 
   const handlePageScroll = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
     setPageScrollY(event.nativeEvent.contentOffset.y);
@@ -1134,6 +1555,7 @@ export function CountryScreen({
               countries={countries}
               country={country}
               selectedYear={selectedYear}
+              availableYears={yearOptions}
               onSelectCountry={onSelectCountry}
               onChangeYear={onChangeYear}
             />
@@ -1149,7 +1571,7 @@ export function CountryScreen({
                 <Text style={[styles.countrySummarySectionDetailTitle, styles.countrySummarySectionTextDark]}>General Description</Text>
                 <View style={styles.countrySummarySectionDetailTitleUnderline} />
               </View>
-              <Text style={[styles.countrySummarySectionDetailText, styles.countrySummarySectionTextDark]}>{country.sceneNote}</Text>
+              <Text style={[styles.countrySummarySectionDetailText, styles.countrySummarySectionTextDark]}>{generalDescriptionText}</Text>
             </View>
             <View style={styles.countrySummarySectionDetailCard}>
               <View style={styles.countrySummarySectionDetailTitleWrap}>
@@ -1164,46 +1586,95 @@ export function CountryScreen({
           </View>
         </CountryPageSection>
 
-        <FavoriteArtistsSection country={country} selectedYear={selectedYear} onOpenHiddenGems={onOpenHiddenGems} />
+        <FavoriteArtistsSection
+          country={country}
+          selectedYear={selectedYear}
+          artists={favoriteArtists}
+          isLoading={initialLoadingProfile}
+          onOpenHiddenGems={onOpenHiddenGems}
+        />
 
         <View style={[styles.statSquaresAndGenreSectionRow, isStacked ? styles.stackRow : null]}>
           <View style={styles.statSquaresBlock}>
             <View style={styles.statSquaresGrid}>
-              <StatSquare label="Songs in This View" value={`${profile.totalCharted}`} note="songs" />
-              <StatSquare label="Loved in This Country" value={`${profile.uniqueCount}`} note="songs" />
-              <StatSquare label="Loved Here and Elsewhere" value={`${profile.sharedCount}`} note="songs" />
-              <StatSquare label="Loved Here and Elsewhere" value={`${profile.overlapPercent}%`} note="% of this view" />
+              <StatSquare
+                label="Songs in This View"
+                value={isCoreLoading ? loadingText : `${profileStats.totalCharted}`}
+                note="songs"
+                valueOffsetY={6}
+                useLoadingStyle={isCoreLoading}
+              />
+              <StatSquare
+                label="Loved in This Country"
+                value={isCoreLoading ? loadingText : `${profileStats.uniqueCount}`}
+                note="songs"
+                valueOffsetY={6}
+                useLoadingStyle={isCoreLoading}
+              />
+              <StatSquare
+                label="Loved Here and Elsewhere"
+                value={isCoreLoading ? loadingText : `${profileStats.sharedCount}`}
+                note="songs"
+                useLoadingStyle={isCoreLoading}
+              />
+              <StatSquare
+                label="Loved Here and Elsewhere"
+                value={isCoreLoading ? (
+                  loadingText
+                ) : (
+                  <>
+                    {profileStats.overlapPercent}
+                    <Text style={styles.statSquareValuePercentSymbol}>%</Text>
+                  </>
+                )}
+                note="% of this view"
+                useLoadingStyle={isCoreLoading}
+              />
             </View>
           </View>
           <View style={[styles.genreAndLanguageSections, isCompact ? styles.stackRow : null]}>
             <GenreSection
               title={`${country.name}'s Loved Genres`}
               subtitle="Genres most loved in this country view"
-              items={profile.genreBreakdown}
+              items={profileStats.genreBreakdown}
               visual="pie"
             />
             <LanguageSection
-              title={`${country.name}'s Languages`}
+              title={`${country.name}'s Language(s) in Music`}
               subtitle="Languages most represented in this country view"
-              items={profile.languageBreakdown}
+              items={profileStats.languageBreakdown}
             />
           </View>
         </View>
 
-        <HiddenSongsCarouselSection countryName={country.name} songs={hiddenGemSongs} onOpenHiddenGems={onOpenHiddenGems} />
+        <HiddenSongsCarouselSection
+          countryName={country.name}
+          songs={hiddenGemSongs.length > 0 ? hiddenGemSongs : [{ title: loadingText, artist: loadingText }]}
+          isLoading={initialLoadingPreview}
+          loadingText={loadingText}
+          onOpenHiddenGems={onOpenHiddenGems}
+        />
 
         <CountryPageSection style={styles.mainComparisonSection} fillVariant="comparisonBlue">
           <View style={[styles.mainComparisonColumns, isStacked ? styles.stackRow : null]}>
             <MainComparisonArea
               title="Most Loved in This Country"
-              songs={profile.uniqueSongs}
+              songs={profileStats.uniqueSongs}
               onOpenHiddenGems={onOpenHiddenGems}
+              isInitialLoading={initialLoadingUnique}
+              hasMore={uniqueHasMore}
+              isLoadingMore={loadingMoreUnique}
+              onLoadMore={loadMoreUniqueSongs}
               darkTheme
             />
             <MainComparisonArea
               title="Loved Here and Elsewhere"
-              songs={profile.sharedSongs}
+              songs={profileStats.sharedSongs}
               onOpenHiddenGems={onOpenHiddenGems}
+              isInitialLoading={initialLoadingShared}
+              hasMore={sharedHasMore}
+              isLoadingMore={loadingMoreShared}
+              onLoadMore={loadMoreSharedSongs}
               darkTheme
             />
           </View>
@@ -1553,6 +2024,14 @@ const styles = StyleSheet.create({
     fontSize: 42,
     lineHeight: 46,
   },
+  statSquareValueLoading: {
+    fontSize: 22,
+    lineHeight: 26,
+  },
+  statSquareValuePercentSymbol: {
+    fontSize: 19,
+    lineHeight: 22,
+  },
   statSquareNote: {
     color: colors.text,
     fontFamily: typefaces.body,
@@ -1696,6 +2175,20 @@ const styles = StyleSheet.create({
     color: colors.text,
   },
   songTextActiveDark: {
+    color: colors.border,
+  },
+  songListLoadingRow: {
+    minHeight: 50,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  songListLoadingText: {
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 13,
+    lineHeight: 17,
+  },
+  songListLoadingTextDark: {
     color: colors.border,
   },
   genreSection: {
@@ -2041,6 +2534,14 @@ const styles = StyleSheet.create({
     fontSize: 13,
     lineHeight: 17,
     textAlign: "center",
+  },
+  favoriteArtistSongName: {
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 12,
+    lineHeight: 16,
+    textAlign: "center",
+    minHeight: 16,
   },
   stackRow: {
     flexDirection: "column",

--- a/hidden-gem-music-app/src/screens/DiscoveryScreen.web.tsx
+++ b/hidden-gem-music-app/src/screens/DiscoveryScreen.web.tsx
@@ -1,13 +1,15 @@
 import { LinearGradient } from "expo-linear-gradient";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Platform, Pressable, ScrollView, StyleSheet, Text, useWindowDimensions, View, ViewStyle } from "react-native";
 
 import { Country } from "../types/content";
 import { DiscoveryBlurb } from "../components/DiscoveryBlurb";
 import { DiscoverySidebarPanels } from "../components/DiscoverySidebarPanels";
+import { GemIcon } from "../components/GemIcon";
 import { GlobePanel } from "../components/globe/GlobePanel";
 import { Panel } from "../components/Panel";
 import { ScreenScaffold } from "../components/ScreenScaffold";
+import { SecondarySurfaceFill } from "../components/SecondarySurfaceFill";
 import { YearSlider } from "../components/YearSlider";
 import { colors } from "../theme/colors";
 import { typefaces } from "../theme/typography";
@@ -19,6 +21,18 @@ export type Props = {
   onOpenCountry: (countryId: string) => void;
   selectedYear: number;
   onChangeYear: (year: number) => void;
+};
+
+type SortOption = "a-z" | "z-a" | "gems-desc" | "gems-asc";
+const activeGradient = [colors.navGradient, colors.backgroundRaised, colors.backgroundRaised] as const;
+const normalizeContinent = (region: string) => {
+  if (region === "Continent info coming soon.") {
+    return "Unknown / Missing";
+  }
+  if (region === "Other") {
+    return "Other / Territories";
+  }
+  return region;
 };
 
 export function DiscoveryScreen({
@@ -35,6 +49,60 @@ export function DiscoveryScreen({
   const isStacked = width < 980;
   const [allFiltersOpen, setAllFiltersOpen] = useState(false);
   const [listAutoScrollSignal, setListAutoScrollSignal] = useState(0);
+  const [sortOption, setSortOption] = useState<SortOption | null>(null);
+  const [selectedContinents, setSelectedContinents] = useState<string[]>([]);
+  const [onlyWithHiddenGems, setOnlyWithHiddenGems] = useState(true);
+  const [onlyWithoutHiddenGems, setOnlyWithoutHiddenGems] = useState(false);
+  const [isCloseHovered, setIsCloseHovered] = useState(false);
+  const [isClosePressed, setIsClosePressed] = useState(false);
+
+  const continentOptions = useMemo(() => {
+    const continents = Array.from(
+      new Set(countries.map((country) => normalizeContinent(country.region)).filter(Boolean))
+    ).sort((a, b) =>
+      a.localeCompare(b)
+    );
+    return ["all", ...continents];
+  }, [countries]);
+
+  const filteredCountries = useMemo(() => {
+    let next = [...countries];
+
+    if (selectedContinents.length > 0) {
+      const continentSet = new Set(selectedContinents);
+      next = next.filter((country) => continentSet.has(normalizeContinent(country.region)));
+    }
+
+    if (onlyWithHiddenGems) {
+      next = next.filter((country) => country.hiddenSongs > 0);
+    }
+    if (onlyWithoutHiddenGems) {
+      next = next.filter((country) => country.hiddenSongs <= 0);
+    }
+
+    if (sortOption) {
+      next.sort((a, b) => {
+        switch (sortOption) {
+          case "a-z":
+            return a.name.localeCompare(b.name);
+          case "z-a":
+            return b.name.localeCompare(a.name);
+          case "gems-desc":
+            return b.hiddenSongs - a.hiddenSongs || a.name.localeCompare(b.name);
+          case "gems-asc":
+            return a.hiddenSongs - b.hiddenSongs || a.name.localeCompare(b.name);
+          default:
+            return 0;
+        }
+      });
+    }
+
+    return next;
+  }, [countries, onlyWithHiddenGems, onlyWithoutHiddenGems, selectedContinents, sortOption]);
+
+  const visibleSelectedCountryId = filteredCountries.some((country) => country.id === selectedCountryId)
+    ? selectedCountryId
+    : filteredCountries[0]?.id ?? selectedCountryId;
 
   const handleGlobeFocus = (countryId: string) => {
     onSelectCountry(countryId);
@@ -44,8 +112,9 @@ export function DiscoveryScreen({
   const listColumn = (
     <View style={[styles.leftColumn, isStacked ? styles.columnStacked : null]}>
       <DiscoverySidebarPanels
-        countries={countries}
-        selectedCountryId={selectedCountryId}
+        countries={filteredCountries}
+        selectedYear={selectedYear}
+        selectedCountryId={visibleSelectedCountryId}
         onSelectCountry={onSelectCountry}
         onOpenCountry={onOpenCountry}
         autoScrollSignal={listAutoScrollSignal}
@@ -56,8 +125,9 @@ export function DiscoveryScreen({
   const globeColumn = (
     <View style={[styles.rightColumn, isStacked ? styles.columnStacked : null]}>
       <GlobePanel
-        countries={countries}
-        activeCountryId={selectedCountryId}
+        countries={filteredCountries}
+        activeCountryId={visibleSelectedCountryId}
+        selectedYear={selectedYear}
         onSelectCountry={handleGlobeFocus}
         onOpenCountry={onOpenCountry}
         title="Globe View"
@@ -125,10 +195,180 @@ export function DiscoveryScreen({
           <Panel style={styles.modal}>
             <View style={styles.modalHeader}>
               <Text style={styles.modalTitle}>All Filters</Text>
-              <Pressable onPress={() => setAllFiltersOpen(false)}>
-                <Text style={styles.modalClose}>Close</Text>
+              <Pressable
+                onPress={() => setAllFiltersOpen(false)}
+                onHoverIn={() => setIsCloseHovered(true)}
+                onHoverOut={() => setIsCloseHovered(false)}
+                onPressIn={() => setIsClosePressed(true)}
+                onPressOut={() => setIsClosePressed(false)}
+                style={styles.closeButtonShell}
+              >
+                {isCloseHovered || isClosePressed ? (
+                  <LinearGradient
+                    colors={isClosePressed ? activeGradient : ["rgba(117,82,107,0.52)", "rgba(108,119,142,0.44)", "rgba(108,119,142,0.36)"]}
+                    locations={[0, 0.34, 1]}
+                    start={{ x: 0, y: 0.5 }}
+                    end={{ x: 1, y: 0.5 }}
+                    style={styles.closeButtonGradient}
+                  />
+                ) : null}
+                <View style={[styles.closeButton, isCloseHovered || isClosePressed ? styles.closeButtonActive : null]}>
+                  <Text style={[styles.closeButtonText, isCloseHovered || isClosePressed ? styles.closeButtonTextActive : null]}>
+                    Close
+                  </Text>
+                </View>
               </Pressable>
             </View>
+            <ScrollView
+              style={styles.modalScroll}
+              contentContainerStyle={styles.filtersPanelStack}
+              showsVerticalScrollIndicator={false}
+            >
+              <Panel style={styles.filterSection}>
+                <SecondarySurfaceFill />
+                <Text style={styles.filterSectionTitle}>Sort By</Text>
+                <View style={styles.optionGroup}>
+                  <Pressable style={styles.filterButtonShell} onPress={() => setSortOption((current) => (current === "a-z" ? null : "a-z"))}>
+                    {sortOption === "a-z" ? <LinearGradient colors={activeGradient} locations={[0, 0.34, 1]} start={{ x: 0, y: 0.5 }} end={{ x: 1, y: 0.5 }} style={styles.filterButtonGradient} /> : null}
+                    <View style={[styles.filterButton, sortOption === "a-z" ? styles.filterButtonActive : null]}>
+                      <View style={styles.filterButtonContent}>
+                        <View style={styles.filterButtonLead}>
+                          <GemIcon size={16} />
+                          <Text style={[styles.filterButtonText, sortOption === "a-z" ? styles.filterButtonTextActive : null]}>A--Z</Text>
+                        </View>
+                      </View>
+                    </View>
+                  </Pressable>
+                  <Pressable style={styles.filterButtonShell} onPress={() => setSortOption((current) => (current === "z-a" ? null : "z-a"))}>
+                    {sortOption === "z-a" ? <LinearGradient colors={activeGradient} locations={[0, 0.34, 1]} start={{ x: 0, y: 0.5 }} end={{ x: 1, y: 0.5 }} style={styles.filterButtonGradient} /> : null}
+                    <View style={[styles.filterButton, sortOption === "z-a" ? styles.filterButtonActive : null]}>
+                      <View style={styles.filterButtonContent}>
+                        <View style={styles.filterButtonLead}>
+                          <GemIcon size={16} />
+                          <Text style={[styles.filterButtonText, sortOption === "z-a" ? styles.filterButtonTextActive : null]}>Z--A</Text>
+                        </View>
+                      </View>
+                    </View>
+                  </Pressable>
+                  <Pressable style={styles.filterButtonShell} onPress={() => setSortOption((current) => (current === "gems-desc" ? null : "gems-desc"))}>
+                    {sortOption === "gems-desc" ? <LinearGradient colors={activeGradient} locations={[0, 0.34, 1]} start={{ x: 0, y: 0.5 }} end={{ x: 1, y: 0.5 }} style={styles.filterButtonGradient} /> : null}
+                    <View style={[styles.filterButton, sortOption === "gems-desc" ? styles.filterButtonActive : null]}>
+                      <View style={styles.filterButtonContent}>
+                        <View style={styles.filterButtonLead}>
+                          <GemIcon size={16} />
+                          <Text style={[styles.filterButtonText, sortOption === "gems-desc" ? styles.filterButtonTextActive : null]}>
+                            Most Hidden Gems to Least
+                          </Text>
+                        </View>
+                      </View>
+                    </View>
+                  </Pressable>
+                  <Pressable style={styles.filterButtonShell} onPress={() => setSortOption((current) => (current === "gems-asc" ? null : "gems-asc"))}>
+                    {sortOption === "gems-asc" ? <LinearGradient colors={activeGradient} locations={[0, 0.34, 1]} start={{ x: 0, y: 0.5 }} end={{ x: 1, y: 0.5 }} style={styles.filterButtonGradient} /> : null}
+                    <View style={[styles.filterButton, sortOption === "gems-asc" ? styles.filterButtonActive : null]}>
+                      <View style={styles.filterButtonContent}>
+                        <View style={styles.filterButtonLead}>
+                          <GemIcon size={16} />
+                          <Text style={[styles.filterButtonText, sortOption === "gems-asc" ? styles.filterButtonTextActive : null]}>
+                            Least Hidden Gems to Most
+                          </Text>
+                        </View>
+                      </View>
+                    </View>
+                  </Pressable>
+                  <Pressable
+                    style={styles.filterButtonShell}
+                    onPress={() =>
+                      setOnlyWithHiddenGems((current) => {
+                        const next = !current;
+                        if (next) {
+                          setOnlyWithoutHiddenGems(false);
+                        }
+                        return next;
+                      })
+                    }
+                  >
+                    {onlyWithHiddenGems ? <LinearGradient colors={activeGradient} locations={[0, 0.34, 1]} start={{ x: 0, y: 0.5 }} end={{ x: 1, y: 0.5 }} style={styles.filterButtonGradient} /> : null}
+                    <View style={[styles.filterButton, onlyWithHiddenGems ? styles.filterButtonActive : null]}>
+                      <View style={styles.filterButtonContent}>
+                        <View style={styles.filterButtonLead}>
+                          <GemIcon size={16} />
+                          <Text style={[styles.filterButtonText, onlyWithHiddenGems ? styles.filterButtonTextActive : null]}>
+                            Only Show Countries with Hidden Gems
+                          </Text>
+                        </View>
+                      </View>
+                    </View>
+                  </Pressable>
+                  <Pressable
+                    style={styles.filterButtonShell}
+                    onPress={() =>
+                      setOnlyWithoutHiddenGems((current) => {
+                        const next = !current;
+                        if (next) {
+                          setOnlyWithHiddenGems(false);
+                        }
+                        return next;
+                      })
+                    }
+                  >
+                    {onlyWithoutHiddenGems ? <LinearGradient colors={activeGradient} locations={[0, 0.34, 1]} start={{ x: 0, y: 0.5 }} end={{ x: 1, y: 0.5 }} style={styles.filterButtonGradient} /> : null}
+                    <View style={[styles.filterButton, onlyWithoutHiddenGems ? styles.filterButtonActive : null]}>
+                      <View style={styles.filterButtonContent}>
+                        <View style={styles.filterButtonLead}>
+                          <GemIcon size={16} />
+                          <Text style={[styles.filterButtonText, onlyWithoutHiddenGems ? styles.filterButtonTextActive : null]}>
+                            Show Countries Without Hidden Gems
+                          </Text>
+                        </View>
+                      </View>
+                    </View>
+                  </Pressable>
+                </View>
+              </Panel>
+
+              <Panel style={styles.filterSection}>
+                <SecondarySurfaceFill />
+                <Text style={styles.filterSectionTitle}>Continent</Text>
+                <View style={styles.optionGroup}>
+                  {continentOptions.map((continentOption) => {
+                    const isActive =
+                      continentOption === "all"
+                        ? selectedContinents.length === 0
+                        : selectedContinents.includes(continentOption);
+                    const label = continentOption === "all" ? "All Continents" : continentOption;
+                    return (
+                      <Pressable
+                        key={continentOption}
+                        style={styles.filterButtonShell}
+                        onPress={() => {
+                          if (continentOption === "all") {
+                            setSelectedContinents([]);
+                            return;
+                          }
+
+                          setSelectedContinents((current) =>
+                            current.includes(continentOption)
+                              ? current.filter((continent) => continent !== continentOption)
+                              : [...current, continentOption]
+                          );
+                        }}
+                      >
+                        {isActive ? <LinearGradient colors={activeGradient} locations={[0, 0.34, 1]} start={{ x: 0, y: 0.5 }} end={{ x: 1, y: 0.5 }} style={styles.filterButtonGradient} /> : null}
+                        <View style={[styles.filterButton, isActive ? styles.filterButtonActive : null]}>
+                          <View style={styles.filterButtonContent}>
+                            <View style={styles.filterButtonLead}>
+                              <GemIcon size={16} />
+                              <Text style={[styles.filterButtonText, isActive ? styles.filterButtonTextActive : null]}>{label}</Text>
+                            </View>
+                          </View>
+                        </View>
+                      </Pressable>
+                    );
+                  })}
+                </View>
+              </Panel>
+            </ScrollView>
           </Panel>
         </View>
       ) : null}
@@ -197,11 +437,16 @@ const styles = StyleSheet.create({
   },
   modal: {
     width: "100%",
-    maxWidth: 760,
-    minHeight: 360,
-    paddingVertical: 32,
-    paddingHorizontal: 24,
+    maxWidth: 660,
+    maxHeight: "82%",
+    paddingVertical: 18,
+    paddingHorizontal: 16,
     backgroundColor: colors.panel,
+    gap: 12,
+    borderRadius: 20,
+    borderWidth: 2,
+    borderColor: "rgba(169, 176, 209, 0.24)",
+    overflow: "hidden",
   },
   modalHeader: {
     flexDirection: "row",
@@ -212,12 +457,115 @@ const styles = StyleSheet.create({
   modalTitle: {
     color: colors.textStrong,
     fontFamily: typefaces.display,
-    fontSize: 48,
+    fontSize: 30,
     fontWeight: "700",
   },
-  modalClose: {
-    color: colors.accent,
-    fontFamily: typefaces.body,
+  closeButtonShell: {
+    borderRadius: 12,
+    overflow: "hidden",
+  },
+  closeButtonGradient: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  closeButton: {
+    minHeight: 42,
+    minWidth: 110,
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 12,
+    borderWidth: 2,
+    borderColor: colors.border,
+    backgroundColor: colors.button,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  closeButtonActive: {
+    backgroundColor: "transparent",
+  },
+  closeButtonText: {
+    color: colors.border,
+    fontFamily: typefaces.condensed,
     fontSize: 18,
+    fontWeight: "700",
+    lineHeight: 20,
+  },
+  closeButtonTextActive: {
+    color: colors.text,
+  },
+  modalScroll: {
+    flex: 1,
+    minHeight: 0,
+  },
+  filtersPanelStack: {
+    gap: 14,
+    paddingBottom: 8,
+  },
+  filterSection: {
+    backgroundColor: "transparent",
+    paddingVertical: 14,
+    paddingHorizontal: 14,
+    gap: 12,
+    borderRadius: 16,
+    overflow: "hidden",
+    borderWidth: 1,
+    borderColor: "rgba(169, 176, 209, 0.18)",
+  },
+  filterSectionTitle: {
+    color: colors.textStrong,
+    fontFamily: typefaces.display,
+    fontSize: 22,
+  },
+  optionGroup: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 10,
+    alignItems: "flex-start",
+  },
+  filterButtonShell: {
+    position: "relative",
+    borderRadius: 12,
+    overflow: "hidden",
+    alignSelf: "flex-start",
+    maxWidth: "100%",
+  },
+  filterButtonGradient: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  filterButton: {
+    minHeight: 44,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 12,
+    borderWidth: 2,
+    borderColor: colors.border,
+    backgroundColor: colors.button,
+    justifyContent: "center",
+  },
+  filterButtonActive: {
+    backgroundColor: "transparent",
+  },
+  filterButtonContent: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 10,
+  },
+  filterButtonLead: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    minWidth: 0,
+    flexShrink: 1,
+  },
+  filterButtonText: {
+    color: colors.border,
+    fontFamily: typefaces.body,
+    fontSize: 15,
+    lineHeight: 18,
+    textAlign: "left",
+    flexShrink: 1,
+  },
+  filterButtonTextActive: {
+    color: colors.text,
   },
 });

--- a/hidden-gem-music-app/src/screens/DiscoveryScreen.web.tsx
+++ b/hidden-gem-music-app/src/screens/DiscoveryScreen.web.tsx
@@ -21,6 +21,7 @@ export type Props = {
   onOpenCountry: (countryId: string) => void;
   selectedYear: number;
   onChangeYear: (year: number) => void;
+  availableYears?: number[];
 };
 
 type SortOption = "a-z" | "z-a" | "gems-desc" | "gems-asc";
@@ -42,6 +43,7 @@ export function DiscoveryScreen({
   onOpenCountry,
   selectedYear,
   onChangeYear,
+  availableYears,
 }: Props) {
   // Issue #6 shell: this screen owns the core Discovery Globe layout,
   // including globe rendering, country selection, panel structure, and dummy-data wiring.
@@ -134,7 +136,7 @@ export function DiscoveryScreen({
         onRightAction={() => setAllFiltersOpen(true)}
         showHeader={false}
       />
-      <YearSlider year={selectedYear} onChangeYear={onChangeYear} />
+      <YearSlider year={selectedYear} onChangeYear={onChangeYear} years={availableYears} />
     </View>
   );
 

--- a/hidden-gem-music-app/src/screens/WelcomeScreen.web.tsx
+++ b/hidden-gem-music-app/src/screens/WelcomeScreen.web.tsx
@@ -1,6 +1,6 @@
 import { LinearGradient } from "expo-linear-gradient";
 import { useState } from "react";
-import { StyleSheet, Text, useWindowDimensions, View } from "react-native";
+import { Pressable, StyleSheet, Text, useWindowDimensions, View } from "react-native";
 
 import { Country } from "../types/content";
 import { ActionButton } from "../components/ActionButton";
@@ -26,11 +26,13 @@ export function WelcomeScreen({ countries, onNavigate, onSelectCountry, selected
   const previewCountries = countries.slice(0, 5);
   const { width } = useWindowDimensions();
   const isStacked = width < 980;
+  const [isWelcomeModalVisible, setIsWelcomeModalVisible] = useState(true);
 
   const listColumn = (
     <View style={[styles.leftColumn, isStacked ? styles.columnStacked : null]}>
       <DiscoverySidebarPanels
         countries={previewCountries}
+        selectedYear={selectedYear}
         selectedCountryId={previewCountries[0]?.id}
         onSelectCountry={onSelectCountry}
         onOpenCountry={onSelectCountry}
@@ -43,6 +45,7 @@ export function WelcomeScreen({ countries, onNavigate, onSelectCountry, selected
       <GlobePanel
         countries={countries}
         activeCountryId={countries[0].id}
+        selectedYear={selectedYear}
         onSelectCountry={onSelectCountry}
         onOpenCountry={onSelectCountry}
         title="Globe View"
@@ -62,41 +65,45 @@ export function WelcomeScreen({ countries, onNavigate, onSelectCountry, selected
         </View>
       </View>
 
-      <View style={styles.overlay}>
-        <View style={styles.overlayGradientWrap}>
-          <LinearGradient
-            colors={["rgba(22,26,38,0.62)", "rgba(22,26,38,0.36)", "rgba(66,72,101,0.18)"]}
-            start={{ x: 0.5, y: 0 }}
-            end={{ x: 0.5, y: 1 }}
-            style={styles.overlayGradient}
-          />
-          <LinearGradient
-            colors={["rgba(117,82,107,0.16)", "rgba(117,82,107,0.05)", "rgba(117,82,107,0.00)"]}
-            start={{ x: 0.0, y: 0.04 }}
-            end={{ x: 1.0, y: 0.72 }}
-            style={styles.overlayGradient}
-          />
-          <LinearGradient
-            colors={["rgba(108,119,142,0.16)", "rgba(108,119,142,0.05)", "rgba(108,119,142,0.00)"]}
-            start={{ x: 1.0, y: 0.0 }}
-            end={{ x: 0.08, y: 0.94 }}
-            style={styles.overlayGradient}
-          />
-        </View>
-        <Panel style={styles.modal}>
-          <Text style={styles.brand}>Hidden Gem Music</Text>
-          <Text style={styles.summary}>
-            Insert somewhat long text about the project and the problem and the solution
-          </Text>
-          <View style={styles.buttonStack}>
-            <ActionButton label="Discovery Globe" size="compact" onPress={() => onNavigate("discovery")} />
-            <ActionButton label="Comparison Mode" size="compact" onPress={() => onNavigate("comparisonSelect")} />
-            <ActionButton label="Hidden Songs" size="compact" onPress={() => onNavigate("hiddenGems")} />
-            <ActionButton label="Dashboard" size="compact" onPress={() => onNavigate("dashboard")} />
-            <ActionButton label="Credits" size="compact" onPress={() => onNavigate("credits")} />
+      {isWelcomeModalVisible ? (
+        <Pressable style={styles.overlay} onPress={() => setIsWelcomeModalVisible(false)}>
+          <View style={styles.overlayGradientWrap}>
+            <LinearGradient
+              colors={["rgba(22,26,38,0.62)", "rgba(22,26,38,0.36)", "rgba(66,72,101,0.18)"]}
+              start={{ x: 0.5, y: 0 }}
+              end={{ x: 0.5, y: 1 }}
+              style={styles.overlayGradient}
+            />
+            <LinearGradient
+              colors={["rgba(117,82,107,0.16)", "rgba(117,82,107,0.05)", "rgba(117,82,107,0.00)"]}
+              start={{ x: 0.0, y: 0.04 }}
+              end={{ x: 1.0, y: 0.72 }}
+              style={styles.overlayGradient}
+            />
+            <LinearGradient
+              colors={["rgba(108,119,142,0.16)", "rgba(108,119,142,0.05)", "rgba(108,119,142,0.00)"]}
+              start={{ x: 1.0, y: 0.0 }}
+              end={{ x: 0.08, y: 0.94 }}
+              style={styles.overlayGradient}
+            />
           </View>
-        </Panel>
-      </View>
+          <Pressable style={styles.modalPressTarget} onPress={(event) => event.stopPropagation()}>
+            <Panel style={styles.modal}>
+              <Text style={styles.brand}>Hidden Gem Music</Text>
+              <Text style={styles.summary}>
+                Insert somewhat long text about the project and the problem and the solution
+              </Text>
+              <View style={styles.buttonStack}>
+                <ActionButton label="Discovery Globe" size="compact" onPress={() => onNavigate("discovery")} />
+                <ActionButton label="Comparison Mode" size="compact" onPress={() => onNavigate("comparisonSelect")} />
+                <ActionButton label="Hidden Gems" size="compact" onPress={() => onNavigate("hiddenGems")} />
+                <ActionButton label="Dashboard" size="compact" onPress={() => onNavigate("dashboard")} />
+                <ActionButton label="Credits" size="compact" onPress={() => onNavigate("credits")} />
+              </View>
+            </Panel>
+          </Pressable>
+        </Pressable>
+      ) : null}
     </ScreenScaffold>
   );
 }
@@ -149,6 +156,10 @@ const styles = StyleSheet.create({
     paddingHorizontal: 24,
     backgroundColor: colors.panel,
     gap: 22,
+  },
+  modalPressTarget: {
+    width: "100%",
+    maxWidth: 760,
   },
   brand: {
     color: colors.textStrong,

--- a/hidden-gem-music-app/src/types/api.ts
+++ b/hidden-gem-music-app/src/types/api.ts
@@ -23,6 +23,14 @@ export type ApiCountryProfile = {
   topUniqueSongs: ApiSong[];
 };
 
+export type ApiCountrySongsPage = {
+  items: ApiSong[];
+  page: number;
+  pageSize: number;
+  totalCount: number;
+  hasMore: boolean;
+};
+
 export type ApiCountryComparisonSide = {
   countryCode: string | null;
   countryName: string | null;

--- a/hidden-gem-music-app/src/types/api.ts
+++ b/hidden-gem-music-app/src/types/api.ts
@@ -59,8 +59,10 @@ export type ApiHiddenGemResponse = {
 export type ApiCountryGlobeSummary = {
   countryCode: string | null;
   countryName: string | null;
+  region: string | null;
   lat: number;
   long: number;
   hiddenGemCount: number;
   topAlbumName: string | null;
+  topArtistName: string | null;
 };


### PR DESCRIPTION
## Summary:

This PR completes Issue 100 for **Country Comparison Mode Web Screen Data Implementation**.

Scope includes replacing placeholder behavior with functional data-driven behavior for the Comparison Mode screen, while keeping genre/language **data-content expansion** deferred as specified by issue scope.

## Work Performed:

### 1) Implemented data-driven Country list behavior for Comparison Mode:

- Updated Comparison Mode so country listing is gated by countries that have songs in app data for the selected year.
- This replaced prior placeholder-style listing behavior and aligned the list with issue intent of showing countries we can actually work with for comparison.

Files:
- `hidden-gem-music-app/src/screens/ComparisonSelectScreen.web.tsx`

### 2) Updated Select Year dropdown to strict available-year source:

- Replaced static/mock year list usage with metadata API years (`loadAvailableYears`).
- Year options now reflect the available dataset years rather than hardcoded placeholders.

Files:
- `hidden-gem-music-app/src/screens/ComparisonSelectScreen.web.tsx`

### 3) Added click-outside close behavior for Select Year dropdown:

- Added click-outside handling so the dropdown collapses when users click outside the control.

Files:
- `hidden-gem-music-app/src/screens/ComparisonSelectScreen.web.tsx`

### 4) Corrected Region filter options and cleaned placeholders:

- Region options were corrected to reflect intended continent coverage.
- Removed non-user-facing placeholder region options:
  - `Continent info coming soon.`
  - `Other`

Files:
- `hidden-gem-music-app/src/screens/ComparisonSelectScreen.web.tsx`

### 5) Preserved Language/Genre filters and kept scope-aligned defer handling:

- Language and Genre filter rows remain present and usable in UI.
- Unknown placeholder values were removed from filter options:
  - `Unknown` removed from Language options
  - `Unknown` removed from Genre options
- Genre/Language **future dataset depth** remains deferred per issue note.

Files:
- `hidden-gem-music-app/src/screens/ComparisonSelectScreen.web.tsx`

### 6) Ensured filters properly affect countries shown:

- Region, Language, Genre, and Popularity filters all apply to visible countries.
- Filter-change behavior now auto-clears selected countries to avoid invalid stale selections under a changed filter set.

Files:
- `hidden-gem-music-app/src/screens/ComparisonSelectScreen.web.tsx`
- `hidden-gem-music-app/App.tsx`

### 7) Implemented popularity filter functionality:

- `Biggest Hits`, `Fast Rising Songs`, and `All Songs` now have functional behavior and change the visible country set.

Files:
- `hidden-gem-music-app/src/screens/ComparisonSelectScreen.web.tsx`

### 8) Additional UX improvements completed during issue QA:

- Added `Clear Selections` button in the `Select Two Countries` header area.
- Styled it with the same filter-chip visual language and semitransparent treatment.
- Made it visible only when the `Select Two Countries` section is expanded.
- Updated Comparison Mode blurb copy to final issue-aligned instructional text.

Files:
- `hidden-gem-music-app/src/screens/ComparisonSelectScreen.web.tsx`
- `hidden-gem-music-app/App.tsx`

## Task-by-Task Status Against Issue Text:

1. **List of countries we have data for**: Completed.
2. **Select Year dropdown uses only available years**: Completed.
3. **Select Year dropdown click-outside collapse**: Completed.
4. **Regions in Filters are correct**: Completed.
5. **Language/Genre deferred handling**: Completed in scope.
6. **Filters properly affect countries shown**: Completed.
7. **Popularity filters functionality**: Completed.
8. **Ensure buttons navigate correctly**: Existing wiring preserved and integrated with updated data/filter behavior.

## Files Changed:

- `hidden-gem-music-app/src/screens/ComparisonSelectScreen.web.tsx`
- `hidden-gem-music-app/App.tsx`
- `Documents/mp3li implementation timeline document.txt`

## Verification:

- Frontend typecheck:
  - `cd hidden-gem-music-app && npx tsc --noEmit` -> success
- Manual testing in browser 