### PR TITLE
109 reimplement dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -498,3 +498,6 @@ appsettings.Local.json
 
 # Claude Code
 .claude/
+
+Dashboard_Brief.md
+

--- a/backend/Capstone.API/SQL Scripts/read/sp_GetCountrySongsPaged.sql
+++ b/backend/Capstone.API/SQL Scripts/read/sp_GetCountrySongsPaged.sql
@@ -56,8 +56,7 @@ BEGIN
                  AND NOT EXISTS (
                     SELECT 1
                     FROM HiddenGems hg
-                    WHERE hg.country_id = @CountryId
-                      AND hg.song_id = scp.song_id
+                    WHERE hg.song_id = scp.song_id
                       AND hg.chart_year = @Year
                  ))
               )

--- a/backend/Capstone.API/SQL Scripts/read/sp_GetDiscoverPageInfo.sql
+++ b/backend/Capstone.API/SQL Scripts/read/sp_GetDiscoverPageInfo.sql
@@ -61,7 +61,6 @@ BEGIN
     ) top_song ON top_song.country_id = c.country_id AND top_song.rn = 1
     WHERE c.latitude  IS NOT NULL
       AND c.longitude IS NOT NULL
-      AND LEN(LTRIM(RTRIM(c.iso_code))) = 2
     ORDER BY c.full_name;
 END;
 GO

--- a/backend/Capstone.API/SQL Scripts/read/sp_GetHiddenGems.sql
+++ b/backend/Capstone.API/SQL Scripts/read/sp_GetHiddenGems.sql
@@ -30,8 +30,7 @@ BEGIN
         s.spotify_id    AS preview_url,
         s.is_explicit,
         hg.countries_charting,
-        hg.trend_score,
-        COUNT(1) OVER() AS total_count
+        hg.trend_score
     FROM HiddenGems hg
     JOIN Country c ON c.country_id = hg.country_id
     JOIN DIM_Song s ON s.song_id = hg.song_id

--- a/hidden-gem-music-app/App.tsx
+++ b/hidden-gem-music-app/App.tsx
@@ -21,7 +21,6 @@ import {
   availableYears,
   getCountriesForYear,
   getCountryByYear,
-  getDashboardMetrics,
   getFeaturedCountry,
 } from "./src/data/mockData";
 import { getInitialNavigationSeed, getRouteParams, linking, RootStackParamList } from "./src/navigation/linking";
@@ -200,7 +199,6 @@ export default function App() {
     [comparisonIds, discoveryCountries]
   );
 
-  const dashboardMetrics = useMemo(() => getDashboardMetrics(selectedYear, countries), [countries, selectedYear]);
   const breadcrumbs = useMemo(() => {
     switch (currentRoute) {
       case "welcome":
@@ -301,7 +299,7 @@ export default function App() {
         navigationRef.navigate("comparisonResults", getRouteParams("comparisonResults", selectedYear, selectedCountryId));
         break;
       case "dashboard":
-        navigationRef.navigate("dashboard", getRouteParams("dashboard", selectedYear, selectedCountryId));
+        navigationRef.navigate("dashboard");
         break;
       case "credits":
         navigationRef.navigate("credits");
@@ -871,7 +869,7 @@ export default function App() {
               </Stack.Screen>
 
               <Stack.Screen name="dashboard" options={{ title: "Dashboard" }}>
-                {() => <DashboardScreen year={selectedYear} metrics={dashboardMetrics} countries={countries} />}
+                {() => <DashboardScreen />}
               </Stack.Screen>
 
               <Stack.Screen name="credits" component={CreditsScreen} options={{ title: "Credits" }} />

--- a/hidden-gem-music-app/src/types/api.ts
+++ b/hidden-gem-music-app/src/types/api.ts
@@ -23,6 +23,14 @@ export type ApiCountryProfile = {
   topUniqueSongs: ApiSong[];
 };
 
+export type ApiCountrySongsPage = {
+  items: ApiSong[];
+  page: number;
+  pageSize: number;
+  totalCount: number;
+  hasMore: boolean;
+};
+
 export type ApiCountryComparisonSide = {
   countryCode: string | null;
   countryName: string | null;
@@ -50,19 +58,31 @@ export type ApiHiddenGem = {
   countriesChartingCount: number;
 };
 
+export type ApiCountryHiddenGemPreview = {
+  songName: string | null;
+  albumName: string | null;
+  artistName: string | null;
+  trendScore: number;
+  countriesChartingCount: number;
+};
+
 export type ApiHiddenGemResponse = {
   items: ApiHiddenGem[];
   page: number;
   pageSize: number;
+  totalCount: number;
+  hasMore: boolean;
 };
 
 export type ApiCountryGlobeSummary = {
   countryCode: string | null;
   countryName: string | null;
+  region: string | null;
   lat: number;
   long: number;
   hiddenGemCount: number;
   topAlbumName: string | null;
+  topArtistName: string | null;
 };
 
 export type ApiOverlapRate = {


### PR DESCRIPTION
## Summary

Two categories of changes: SQL stored procedure bug fixes missing from `development`, and frontend type/prop corrections required by the rewritten `DashboardScreen`.

---

## Files Changed

| File | Change |
|------|--------|
| `backend/.../sp_GetCountrySongsPaged.sql` | Bug fix — unique song filter scoping |
| `backend/.../sp_GetDiscoverPageInfo.sql` | Bug fix — overly strict ISO code filter |
| `backend/.../sp_GetHiddenGems.sql` | Bug fix — removed conflicting window function |
| `hidden-gem-music-app/src/types/api.ts` | Added 4 missing types + extended 2 existing types |
| `hidden-gem-music-app/App.tsx` | Removed stale dashboard props and dead memo |
| `.gitignore` | Added `Dashboard_Brief.md` |

---

## SQL Stored Procedure Fixes

> **Note:** All three scripts must be re-run against any local database that hasn't already applied these fixes. These changes came from old PRs, ran and added here to match consistency

### `sp_GetCountrySongsPaged`
- **Bug:** The `unique` song filter's `NOT EXISTS` check was scoped to a specific country (`hg.country_id = @CountryId`), so globally-charting songs were incorrectly passing through as "unique."
- **Fix:** Removed the country scope — the check now only validates `hg.song_id` and `hg.chart_year`.

### `sp_GetDiscoverPageInfo`
- **Bug:** `AND LEN(LTRIM(RTRIM(c.iso_code))) = 2` was filtering out valid countries with unexpected whitespace in their ISO code column.
- **Fix:** Removed the filter — country validity is enforced at the data level.

### `sp_GetHiddenGems`
- **Bug:** `COUNT(1) OVER() AS total_count` conflicted with the C# pagination layer, which computes `totalCount` separately, causing incorrect paginated result sets.
- **Fix:** Removed `total_count` from the SP.

---

## Frontend — `api.ts`

Added missing types required by `CountryScreen.web.tsx`, `HiddenGemsScreen.web.tsx`, and `ComparisonResultsScreen.web.tsx`:

- Added `ApiCountrySongsPage` — paginated song list response
- Added `ApiCountryHiddenGemPreview` — gem preview type for country detail panel
- Added `totalCount` and `hasMore` to `ApiHiddenGemResponse` — required for pagination controls
- Added `region` and `topArtistName` to `ApiCountryGlobeSummary` — required by globe and discovery list rendering

---

## Frontend — `App.tsx`

`DashboardScreen` was rewritten to fetch its own data and now has `Props = Record<string, never>`. The following corrections were required:

- Removed `getDashboardMetrics` import and `dashboardMetrics` memo — dashboard no longer receives metrics as props
- Removed `year`, `metrics`, and `countries` props from `<DashboardScreen />` 
- Fixed `navigationRef.navigate("dashboard", ...)` — `dashboard` route is typed as `undefined` params, passing args caused a TypeScript error

---

## Known Open Issue

`YearSelector.tsx` is hardcoded to `mockData.availableYears` (1975–2021) and cannot navigate to years 2023–2025. Pre-existing, out of scope for this PR.
