### PR TITLE
113 dashboard screen overhaul v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -498,3 +498,6 @@ appsettings.Local.json
 
 # Claude Code
 .claude/
+
+# Brief
+Dashboard_Brief.md

--- a/Documents/Data Findings and Updates/adr-discovery-gap-data-quality.md
+++ b/Documents/Data Findings and Updates/adr-discovery-gap-data-quality.md
@@ -3,7 +3,7 @@
 
 **Project:** HiddenGemMusic Capstone  
 **Author:** Leena Komenski  
-**Date:** April 29, 2026  
+**Date:** April 29, 2026 — updated May 6, 2026  
 **Status:** Accepted  
 **Track:** BDA  
 
@@ -148,7 +148,79 @@ Any year filter in the application that includes 2023 is showing a Q4-only slice
 
 ---
 
-## 5. Affected Stored Procedures — Final State
+## 5. Issue 4 — Viral 50 / Top 200 Chart Type Conflation (May 6, 2026)
+
+### ⚠ KNOWN LIMITATION — Flagged for future iteration
+
+This issue was identified during dashboard design review on May 6, 2026. It does not represent a bug in any stored procedure — all SPs are functioning correctly given the data they receive. The issue is a measurement design concern with meaningful implications for interpretation.
+
+### What the problem is
+
+Dataset 1 contains two fundamentally different chart types mixed together in `FACT_ChartEntry`:
+
+- **Top 200** — demand-driven. A song earns its rank by accumulating streams. Reflects sustained listener adoption.
+- **Viral 50** — momentum-driven. A song enters based on rate-of-spread, not total streams. A track can appear on the Viral 50 the day it's released with almost no total plays, purely because it's being shared simultaneously across markets.
+
+All current stored procedures that query `FACT_ChartEntry` for DS1 data treat these two chart types as equivalent "charting events." They are not equivalent. They measure different phenomena.
+
+### Specific metrics affected
+
+**`sp_GetAverageDiscoveryGap` and `sp_GetDiscoveryGapDistribution`**
+
+The Viral 50 is the primary driver of the large 0–7d bucket (21,936 songs). Songs that go viral simultaneously across markets do not "discover" a new market — they explode everywhere at once by design. This compresses the measured discovery gap and causes the median (4 days) to understate the true time it takes for organic listener adoption to cross a border.
+
+The current interpretation note ("Viral 50 chart entries capture simultaneous cross-market momentum by design") acknowledges this but does not correct for it. A Top 200-only calculation would produce a more meaningful measure of organic crossover speed.
+
+**`sp_GetGlobalOverlapRate`**
+
+The 26% global overlap rate is inflated by Viral 50 entries. Songs that technically appear in multiple countries' Viral 50 charts simultaneously are counted as crossover events, but this reflects sharing behavior, not listener adoption in those markets. The true adoption-based overlap rate is likely lower than 26%.
+
+**`sp_GetPeakCrossRegionalReach`**
+
+Peak simultaneous country reach (70 countries — abcdefu by GAYLE) is almost certainly a Viral 50 phenomenon. This is a different kind of "global reach" than sustained Top 200 charting across many markets. It is not incorrect, but the distinction is meaningful and is currently absent from all UI copy.
+
+**`sp_GetGlobalReachOverTime`**
+
+Average countries per charting song per year is pulled upward by Viral 50 entries. DS1 years (2.9–3.2 average) are not purely measures of sustained global adoption — they include viral spread events.
+
+### Why this was not caught earlier
+
+The Viral 50 contamination of discovery gap metrics was noted during the April 29 QA session (see Issue 1 resolution, Root Cause C) but was accepted as a data characteristic rather than a measurement design problem. On reflection, the distinction matters more than initially assessed — particularly for any user-facing copy that describes the discovery gap as a measure of how long music takes to "travel" between markets.
+
+### Decision: Document and flag for future iteration
+
+No SP changes are being made at this time. The following applies:
+
+1. All affected metrics remain in the dashboard as-is
+2. UI copy for the Discovery Gap Distribution chart and KPI Card 2 must include a visible note that Viral 50 entries compress the measured gap (already present — verify it is prominent)
+3. The "About This Data" section must include the chart type conflation note (see updated copy in `dashboard-about-this-data-copy.md`)
+4. This limitation is to be treated as **visible and important** — not buried in fine print
+
+### Recommended future fix (Option 1 — low risk)
+
+Add a `@ChartTypeFilter` parameter to `sp_GetAverageDiscoveryGap` and `sp_GetDiscoveryGapDistribution` that defaults to `NULL` (all chart types) but accepts `'Top 200'` to produce a Top 200-only calculation. This is a WHERE clause addition, not a repopulation, and does not affect any other SP or summary table.
+
+```sql
+-- Proposed addition to SongFirstCrossing CTE
+WHERE days_to_spread > 0
+  AND (@ChartTypeFilter IS NULL 
+       OR EXISTS (
+           SELECT 1 FROM FACT_ChartEntry ce
+           JOIN ChartType ct ON ct.chart_type_id = ce.chart_type_id
+           WHERE ce.song_id = dgd.song_id
+             AND ct.name = @ChartTypeFilter
+       ))
+```
+
+A chart type toggle on the Discovery Gap Distribution chart in the UI would then allow users to compare "All charts" vs "Top 200 only" — which itself tells a meaningful story about the difference between virality and adoption.
+
+### Recommended future fix (Option 2 — more work, more insight)
+
+Add `chart_type_breakdown` output to `sp_GetGlobalOverlapRate` and `sp_GetDiscoveryGapDistribution` — returning separate rows for Top 200, Viral 50, and Top 50 — to enable direct comparison in the UI. This is a more significant SP change but produces genuinely interesting data.
+
+---
+
+## 6. Affected Stored Procedures — Final State
 
 | Procedure | Changed | Nature of Change |
 |-----------|---------|-----------------|
@@ -158,16 +230,17 @@ Any year filter in the application that includes 2023 is showing a Q4-only slice
 | `sp_PopulateSongCountryPresence` | No | Audited and confirmed correct. No changes. |
 | `sp_PopulateGlobalOverlapByYear` | No | Audited and confirmed correct. No changes. |
 | `sp_PopulateHiddenGems` | No | Audited and confirmed correct. Partial-year issue is a data scope limitation, not a logic bug. |
-| `sp_GetGlobalOverlapRate` | No | Not audited today. Not implicated in any of the three issues. |
-| `sp_GetPeakCrossRegionalReach` | No | Not audited today. Not implicated in any of the three issues. |
+| `sp_GetGlobalOverlapRate` | No | Not audited April 29. Affected by Issue 4 (chart type conflation) — see above. No changes pending. |
+| `sp_GetPeakCrossRegionalReach` | No | Not audited April 29. Affected by Issue 4 (likely Viral 50 result) — see above. No changes pending. |
 
 ---
 
-## 6. Consequences
+## 7. Consequences
 
 - `DiscoveryGapByDay` was truncated and repopulated after SP changes. All read SPs that query it now return clean data.
 - The dashboard Discovery Gap Distribution histogram now shows a shape that peaks at 0–7d, which is correct and consistent with the average and median KPI values.
 - The 22-month data gap (Dec 2021 – Oct 2023) and the 2023 partial year are now treated as first-class labeling concerns across the entire application, not just the dashboard.
 - Any future stored procedure that uses `YEAR(snapshot_date)` to filter or group by 2023 must account for the partial-year scope.
+- **Issue 4 (May 6, 2026):** Viral 50 / Top 200 conflation is a known, documented limitation affecting discovery gap metrics and overlap rate. No SP changes were made. UI copy and About This Data section updated to make this limitation visible. Recommended fixes documented above for a future iteration.
 
 *HiddenGemMusic Capstone | April 29, 2026*

--- a/Documents/Data Findings and Updates/dashboard-about-this-data-copy.md
+++ b/Documents/Data Findings and Updates/dashboard-about-this-data-copy.md
@@ -1,7 +1,7 @@
 # Dashboard — About This Data (In-App Copy)
 
 **Reference document for the methodology card at the bottom of the Global Overlap Dashboard.**  
-Last updated: April 29, 2026
+Last updated: May 6, 2026
 
 ---
 
@@ -23,6 +23,8 @@ All metrics on this dashboard are derived from two Kaggle datasets: Spotify Hist
 
 **Discovery Gap values reflect first crossings only.** The average (38 days) and median (4 days) diverge significantly because crossover is bimodal: most songs that cross any border do so within the first week, driven in part by Viral 50 chart entries which capture simultaneous cross-market momentum by design. A long tail of songs that took months to travel — or barely reached a second market — pulls the mean up to 38 days. Songs that never crossed any border are excluded from the discovery gap calculation entirely.
 
+**⚠ Known limitation — Viral 50 and Top 200 are treated as equivalent charting events in all current metrics.** These are fundamentally different chart types: the Top 200 measures sustained listener demand; the Viral 50 measures rate-of-spread regardless of total streams. Discovery gap times, global overlap rate, and peak reach figures all include Viral 50 entries. This compresses the measured crossover speed and inflates the overlap rate compared to what adoption-only (Top 200) metrics would show. A chart-type-separated view is planned for a future iteration. This limitation is most visible in the Discovery Gap Distribution chart, where the 0–7d bucket is disproportionately driven by Viral 50 simultaneous-spread events rather than organic market discovery.
+
 KPI calculations run in pre-computed SQL summary tables server-side and are never derived live from the raw 28M-row fact table. This ensures response times remain fast regardless of filter state.
 
 ---
@@ -31,6 +33,7 @@ KPI calculations run in pre-computed SQL summary tables server-side and are neve
 
 | Date | Change | Author |
 |------|--------|--------|
+| May 6, 2026 | Added Viral 50 / Top 200 conflation known limitation — flagged for future iteration | Leena |
 | April 29, 2026 | Added 2023 partial year disclaimer | Leena |
 | April 29, 2026 | Added chart scope difference note (Top 200 vs Top 50) | Leena |
 | April 29, 2026 | Updated Discovery Gap interpretation to reflect real data shape (bimodal, Viral 50 note) | Leena |

--- a/Documents/Data Findings and Updates/qa-findings-log-2026-04-29.md
+++ b/Documents/Data Findings and Updates/qa-findings-log-2026-04-29.md
@@ -17,6 +17,7 @@ Three data inconsistencies were identified during live dashboard integration tes
 | 1 | Avg Discovery Gap KPI contradicts Distribution chart | Resolved | SP rewrite + repopulate |
 | 2 | Global Reach values inconsistent with Overlap Rate KPI | Resolved | UI labeling only |
 | 3 | Argentina 2023 hidden gems dominated by Christmas songs | Known limitation | UI labeling only |
+| 4 | Viral 50 / Top 200 treated as equivalent charting events across all metrics | Known limitation — flagged for future iteration | UI copy + ADR documentation |
 
 ---
 
@@ -146,6 +147,45 @@ Any 2023 year filter across the entire application returns a Q4-only, seasonally
 
 ---
 
+## Issue 4 — Viral 50 / Top 200 Chart Type Conflation (May 6, 2026)
+
+**Severity:** Medium — affects interpretation of multiple dashboard metrics  
+**Status:** Known limitation, documented. Flagged for future iteration.  
+**Session:** May 6, 2026 — identified during dashboard design review
+
+### What was observed
+
+During dashboard narrative design review, it was identified that the Top 200 and Viral 50 chart types in Dataset 1 measure fundamentally different phenomena but are treated as equivalent charting events in all current stored procedures.
+
+- **Top 200:** sustained listener demand — streams-based, reflects adoption
+- **Viral 50:** rate-of-spread — a song can enter with minimal total streams by spreading simultaneously across markets
+
+### Metrics affected
+
+| Metric | How it's affected |
+|--------|------------------|
+| Discovery Gap mean (38d) / median (4d) | 0–7d bucket driven in part by Viral 50 simultaneous-spread events, compressing measured crossover speed |
+| Global Overlap Rate (26%) | Inflated by Viral 50 entries that technically cross borders but reflect sharing behavior, not adoption |
+| Peak Cross-Regional Reach (70 countries — abcdefu) | Almost certainly a Viral 50 result; represents viral spread, not sustained Top 200 charting across 70 markets |
+| Global Reach Over Time avg countries (2.9–3.2) | Pulled upward by Viral 50 entries throughout DS1 years |
+
+### Why no SP changes were made
+
+All SPs are functioning correctly given the data they receive. This is a measurement design concern, not a logic bug. Fixing it requires either a `@ChartTypeFilter` parameter addition to the gap SPs (low risk, WHERE clause only) or a full chart-type breakdown output (higher effort). Neither is being pursued at this time given project timeline.
+
+### Resolution
+
+- No SP changes
+- ADR updated with full analysis and recommended future fixes (`adr-discovery-gap-data-quality.md` Issue 4)
+- `dashboard-about-this-data-copy.md` updated with a prominent ⚠ known limitation entry
+- This QA log updated
+
+### Connection to prior findings
+
+The Viral 50 contribution to the 0–7d bucket was first noted during the April 29 QA session (Issue 1, Root Cause C decision) and accepted as a data characteristic. May 6 review elevated this from "data characteristic" to "measurement design limitation" given its impact on multiple metrics and user interpretation.
+
+---
+
 ## Queries Used During Investigation
 
 All diagnostic queries used during this session are preserved here for reference.
@@ -205,6 +245,7 @@ WHERE TABLE_NAME = 'DiscoveryGapByDay' ORDER BY ORDINAL_POSITION;
 - [ ] Apply "2023 (Oct–Dec)" year selector label across all screens — Hidden Gems, Country Profile, Country Comparison, Globe filter panel
 - [ ] Confirm `sp_GetDiscoveryGapDistribution` date range filter is correctly wired from the frontend date params
 - [ ] Issue 2 (Global Reach) frontend changes need to be verified on mobile layout as well as web
-- [ ] Consider whether to filter Viral 50 chart type separately in the distribution chart in a future enhancement — currently mixed with Top 200 and Top 50 data
+- [ ] **Issue 4 — Future iteration:** Add `@ChartTypeFilter` parameter to `sp_GetAverageDiscoveryGap` and `sp_GetDiscoveryGapDistribution` to enable Top 200-only calculation. See ADR Issue 4 for recommended SQL pattern.
+- [ ] **Issue 4 — Future iteration:** Consider chart type toggle on Discovery Gap Distribution chart in UI (All charts / Top 200 only / Viral 50 only) to make the Viral 50 vs adoption distinction visible and explorable.
 
 *HiddenGemMusic Capstone | QA Session April 29, 2026*

--- a/backend/Capstone.API/Infrastructure/Repositories/SqlServerRepository.cs
+++ b/backend/Capstone.API/Infrastructure/Repositories/SqlServerRepository.cs
@@ -34,6 +34,7 @@ namespace Capstone.API.Infrastructure.Interfaces.Repositories
             using (var command = new SqlCommand(storedProc, connection))
             {
                 command.CommandType = CommandType.StoredProcedure;
+                command.CommandTimeout = 120;
 
                 await connection.OpenAsync();
 
@@ -70,6 +71,7 @@ namespace Capstone.API.Infrastructure.Interfaces.Repositories
             using (var command = new SqlCommand(storedProc, connection))
             {
                 command.CommandType = CommandType.StoredProcedure;
+                command.CommandTimeout = 120;
 
                 if (parameters != null)
                 {
@@ -119,6 +121,7 @@ namespace Capstone.API.Infrastructure.Interfaces.Repositories
             using (var command = new SqlCommand(storedProc, connection))
             {
                 command.CommandType = CommandType.StoredProcedure;
+                command.CommandTimeout = 120;
 
                 if (parameters != null)
                 {

--- a/backend/Capstone.API/SQL Scripts/read/sp_GetDiscoverPageInfo.sql
+++ b/backend/Capstone.API/SQL Scripts/read/sp_GetDiscoverPageInfo.sql
@@ -56,12 +56,12 @@ BEGIN
            AND bsa_inner.artist_order = 1
         LEFT JOIN DIM_Artist a_inner ON a_inner.artist_id = bsa_inner.artist_id
         WHERE ce.country_id IS NOT NULL
-          AND YEAR(ce.snapshot_date) = @Year
+          AND ce.snapshot_date >= DATEFROMPARTS(@Year, 1, 1)
+          AND ce.snapshot_date <  DATEFROMPARTS(@Year + 1, 1, 1)
         GROUP BY ce.country_id, ce.song_id, s_inner.album_name, a_inner.artist_name
     ) top_song ON top_song.country_id = c.country_id AND top_song.rn = 1
     WHERE c.latitude  IS NOT NULL
       AND c.longitude IS NOT NULL
-      AND LEN(LTRIM(RTRIM(c.iso_code))) = 2
     ORDER BY c.full_name;
 END;
 GO

--- a/hidden-gem-music-app/src/screens/DashboardScreen.web.tsx
+++ b/hidden-gem-music-app/src/screens/DashboardScreen.web.tsx
@@ -4,6 +4,7 @@ import {
   NativeScrollEvent,
   NativeSyntheticEvent,
   Platform,
+  Pressable,
   ScrollView,
   StyleSheet,
   Text,
@@ -15,9 +16,7 @@ import {
   BarChart,
   CartesianGrid,
   Cell,
-  Line,
-  LineChart,
-  ReferenceArea,
+  ReferenceLine,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -26,7 +25,6 @@ import {
 
 import {
   loadDiscoveryGap,
-  loadGapDistribution,
   loadIsolationLeader,
   loadIsolationRanking,
   loadOverlapRate,
@@ -35,213 +33,53 @@ import {
 } from "../data/dashboardApi";
 import type {
   ApiDiscoveryGap,
-  ApiGapBucket,
   ApiIsolationEntry,
   ApiIsolationLeader,
   ApiOverlapRate,
   ApiPeakReach,
   ApiTrendPoint,
 } from "../types/api";
-import { DiscoveryBlurb } from "../components/DiscoveryBlurb";
-import { Panel } from "../components/Panel";
+import { GemIcon } from "../components/GemIcon";
 import { ScreenScaffold } from "../components/ScreenScaffold";
-import { SecondarySurfaceFill } from "../components/SecondarySurfaceFill";
 import { colors } from "../theme/colors";
 import { typefaces } from "../theme/typography";
-
 
 export type Props = Record<string, never>;
 
 // ---------------------------------------------------------------------------
-// Shared layout primitives
+// Constants
 // ---------------------------------------------------------------------------
 
-function DashboardSection({
-  children,
-  style,
-  fillVariant = "default",
-  contentStyle,
-}: {
-  children: ReactNode;
-  style?: ViewStyle | ViewStyle[];
-  fillVariant?: "default" | "softBlue" | "comparisonBlue";
-  contentStyle?: ViewStyle | ViewStyle[];
-}) {
-  return (
-    <Panel style={[styles.sectionPanel, style]}>
-      {fillVariant === "softBlue" ? (
-        <LinearGradient
-          colors={[colors.backgroundSoft, "#74819B", "#5D6983", colors.backgroundBottom]}
-          locations={[0, 0.48, 0.82, 1]}
-          start={{ x: 0.5, y: 0 }}
-          end={{ x: 0.5, y: 1 }}
-          style={styles.sectionFill}
-        />
-      ) : fillVariant === "comparisonBlue" ? (
-        <LinearGradient
-          colors={[colors.backgroundSoft, "#74819B", "#70536A"]}
-          locations={[0, 0.38, 1]}
-          start={{ x: 0.5, y: 0 }}
-          end={{ x: 0.5, y: 1 }}
-          style={styles.sectionFill}
-        />
-      ) : (
-        <SecondarySurfaceFill />
-      )}
-      <View style={[styles.sectionContent, contentStyle]}>{children}</View>
-    </Panel>
-  );
-}
+// Color swatches — same static palette as HiddenGemsScreen (Eli's pattern)
+const rowBackdropColors = ["#B86A72", "#8B9BC0", "#8B5E7A", "#627F8A", "#C28C5E", "#7A7EB0"];
 
-function SectionTitle({
-  title,
-  subtitle,
-  darkText = false,
-}: {
-  title: string;
-  subtitle?: string;
-  darkText?: boolean;
-}) {
-  return (
-    <View style={styles.sectionTitleWrap}>
-      <Text style={[styles.sectionTitle, darkText ? styles.darkSectionTitle : null]}>{title}</Text>
-      {subtitle ? (
-        <Text style={[styles.sectionSubtitle, darkText ? styles.darkSectionSubtitle : null]}>{subtitle}</Text>
-      ) : null}
-    </View>
-  );
-}
+const HERO_GRADIENT = ["#1a0a2e", "#0f0e17", "#1a1030"] as const;
+const HERO_GRADIENT_LOCATIONS = [0, 0.45, 1] as const;
 
-function SectionLabel({ label }: { label: string }) {
-  return (
-    <View style={styles.sectionLabelWrap}>
-      <Text style={styles.sectionLabel}>{label}</Text>
-    </View>
-  );
-}
+const ISOLATION_COLORS: Record<string, string> = {
+  high: "#f87171",
+  mid: "#fb923c",
+  low: "#4ade80",
+};
+
+const GLOBAL_AVG_ISOLATION = 56;
+
+// Left accent bar colors for KPI cards
+const KPI_BAR = {
+  purple: colors.accent,
+  blue: "#63b3ed",
+  red: "#f87171",
+  green: "#4ade80",
+};
 
 // ---------------------------------------------------------------------------
-// KPI Cards
+// Navigation helper (web only — avoids touching App.tsx)
 // ---------------------------------------------------------------------------
 
-function KpiBadge({ label, variant }: { label: string; variant: "danger" | "warning" | "success" }) {
-  const bg =
-    variant === "danger"
-      ? "rgba(248,113,113,0.18)"
-      : variant === "warning"
-      ? "rgba(251,146,60,0.18)"
-      : "rgba(74,222,128,0.18)";
-  const textColor =
-    variant === "danger" ? "#f87171" : variant === "warning" ? "#fb923c" : "#4ade80";
-  return (
-    <View style={[styles.kpiBadge, { backgroundColor: bg }]}>
-      <Text style={[styles.kpiBadgeText, { color: textColor }]}>{label}</Text>
-    </View>
-  );
-}
-
-function KpiOverlapRateCard({
-  data,
-  trendDirection,
-}: {
-  data: ApiOverlapRate;
-  trendDirection: "up" | "down" | "flat";
-}) {
-  return (
-    <DashboardSection style={styles.kpiCard}>
-      <Text style={styles.kpiCardLabel}>Global Overlap Rate</Text>
-      <View style={styles.kpiHeadlineRow}>
-        <Text style={styles.kpiHeadlineNumber}>{Math.round(data.overlapPct)}%</Text>
-      </View>
-      <Text style={styles.kpiCardBody}>of charting songs{"\n"}appear in 2+ countries</Text>
-      <KpiBadge
-        label={trendDirection === "down" ? "▼ siloed market" : "▲ growing overlap"}
-        variant={trendDirection === "down" ? "danger" : "success"}
-      />
-      <Text style={styles.kpiExplainer}>
-        Only {Math.round(data.overlapPct)}% of the {(data.totalUniqueSongs / 1000).toFixed(0)}k unique charting
-        songs in this dataset appeared in more than one country's charts. The remaining{" "}
-        {100 - Math.round(data.overlapPct)}% never crossed a single border — music markets are far more
-        siloed than global streaming access would suggest.
-      </Text>
-    </DashboardSection>
-  );
-}
-
-function KpiDiscoveryGapCard({ data }: { data: ApiDiscoveryGap }) {
-  return (
-    <DashboardSection style={styles.kpiCard}>
-      <Text style={styles.kpiCardLabel}>Avg Discovery Gap</Text>
-      <View style={styles.kpiHeadlineRow}>
-        <Text style={styles.kpiHeadlineNumber}>{data.avgGapDays}</Text>
-        <Text style={styles.kpiHeadlineUnit}> days</Text>
-      </View>
-      <Text style={styles.kpiCardBody}>before a song crosses{"\n"}its first border</Text>
-      <View style={styles.kpiMedianRow}>
-        <Text style={styles.kpiMedianText}>median: {data.medianGapDays} days</Text>
-      </View>
-      <Text style={styles.kpiExplainer}>
-        When a song first charts somewhere, it takes an average of {data.avgGapDays} days before it
-        appears in a second country. The median of {data.medianGapDays} days reveals the story —
-        most crossovers happen fast, but a long tail of slow-traveling songs pulls the mean up significantly.
-      </Text>
-    </DashboardSection>
-  );
-}
-
-function KpiIsolationCard({ data }: { data: ApiIsolationLeader }) {
-  return (
-    <DashboardSection style={styles.kpiCard}>
-      <Text style={styles.kpiCardLabel}>Most Isolated Region</Text>
-      <Text style={styles.kpiIsolationName}>{data.countryName}</Text>
-      <Text style={styles.kpiCardBody}>{Math.round(data.isolationScore)}% locally unique{"\n"}chart songs</Text>
-      <KpiBadge label="highest isolation score" variant="danger" />
-      <Text style={styles.kpiExplainer}>
-        {Math.round(data.isolationScore)}% of songs that charted in {data.countryName} appeared nowhere else
-        in the dataset. This is the highest isolation score of any qualifying country — meaning{" "}
-        {data.countryName}'s chart is the least connected to global music trends out of all 73 markets tracked.
-      </Text>
-    </DashboardSection>
-  );
-}
-
-function KpiPeakReachCard({ data }: { data: ApiPeakReach }) {
-  const peakDateObj = data.peakDate ? new Date(data.peakDate) : null;
-  const year = peakDateObj ? peakDateObj.getFullYear() : null;
-  const month = peakDateObj
-    ? peakDateObj.toLocaleString("default", { month: "short" })
-    : null;
-
-  return (
-    <DashboardSection style={styles.kpiCard}>
-      <Text style={styles.kpiCardLabel}>Peak Cross-Regional Reach</Text>
-      <View style={styles.kpiHeadlineRow}>
-        <Text style={styles.kpiHeadlineNumber}>{data.peakCountryCount}</Text>
-        <Text style={styles.kpiHeadlineUnit}> countries</Text>
-      </View>
-      <Text style={styles.kpiCardBody}>simultaneous chart{"\n"}presence</Text>
-      <View style={styles.kpiVinylMini}>
-        <View style={styles.kpiVinylAlbumArt}>
-          <View style={styles.kpiVinylRecord} />
-        </View>
-        <View style={styles.kpiVinylInfo}>
-          <Text style={styles.kpiVinylTitle} numberOfLines={1}>{data.songTitle}</Text>
-          <Text style={styles.kpiVinylArtist} numberOfLines={1}>{data.artistName}</Text>
-        </View>
-        {month && year ? (
-          <View style={styles.kpiVinylDateBadge}>
-            <Text style={styles.kpiVinylDateText}>{month}{"\n"}{year}</Text>
-          </View>
-        ) : null}
-      </View>
-      <Text style={styles.kpiExplainer}>
-        The ceiling of the discovery gap: {data.songTitle} by {data.artistName} charted simultaneously
-        in {data.peakCountryCount} countries at once. When the average song only reaches{" "}
-        ~4 countries total, a song hitting {data.peakCountryCount} makes the gap between outliers and
-        the norm impossible to ignore.
-      </Text>
-    </DashboardSection>
-  );
+function navigateTo(path: string) {
+  if (typeof window !== "undefined") {
+    window.location.href = path;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -257,71 +95,376 @@ const tooltipStyle = {
 const tooltipLabelStyle = { color: colors.textStrong };
 const tooltipItemStyle = { color: colors.text };
 const tickStyle = { fill: colors.text, fontSize: 11, opacity: 0.7 };
-const smallTickStyle = { fill: colors.text, fontSize: 10, opacity: 0.7 };
 
 // ---------------------------------------------------------------------------
-// Chart: Global Overlap Rate Over Time (Recharts Line)
+// Country Selector
+// ---------------------------------------------------------------------------
+
+function CountrySelector({
+  data,
+  selectedCountry,
+  onSelect,
+  onClear,
+}: {
+  data: ApiIsolationEntry[];
+  selectedCountry: ApiIsolationEntry | null;
+  onSelect: (entry: ApiIsolationEntry) => void;
+  onClear: () => void;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const tierLabel = (entry: ApiIsolationEntry) => {
+    if (entry.isolationScore > 65) return "highly isolated — most of your charts stay local";
+    if (entry.isolationScore >= 40) return "moderately isolated — some crossover, a lot still stays home";
+    return "well connected — your market overlaps heavily with global trends";
+  };
+
+  const rank = selectedCountry
+    ? data.findIndex((e) => e.isoCode === selectedCountry.isoCode) + 1
+    : null;
+
+  return (
+    <View style={styles.countrySelectorWrap}>
+      <Pressable
+        style={styles.countrySelectorPill}
+        onPress={() => setIsOpen((v) => !v)}
+      >
+        <Text style={styles.countrySelectorText}>
+          {selectedCountry
+            ? `Viewing: ${selectedCountry.countryName}`
+            : "See where your country fits into this story"}
+        </Text>
+        <Text style={styles.countrySelectorChevron}>{isOpen ? "▲" : "▼"}</Text>
+      </Pressable>
+
+      {isOpen ? (
+        <View
+          style={[
+            styles.countryDropdown,
+            Platform.OS === "web"
+              ? ({ overflowY: "scroll", scrollbarWidth: "none" } as any)
+              : null,
+          ]}
+        >
+          {data.map((entry) => (
+            <Pressable
+              key={entry.isoCode}
+              style={[
+                styles.countryDropdownItem,
+                selectedCountry?.isoCode === entry.isoCode
+                  ? styles.countryDropdownItemSelected
+                  : null,
+              ]}
+              onPress={() => {
+                onSelect(entry);
+                setIsOpen(false);
+              }}
+            >
+              <Text style={styles.countryDropdownName}>{entry.countryName}</Text>
+              <Text style={styles.countryDropdownScore}>
+                {Math.round(entry.isolationScore)}%
+              </Text>
+            </Pressable>
+          ))}
+        </View>
+      ) : null}
+
+      {selectedCountry ? (
+        <View style={styles.countryBanner}>
+          <View style={styles.countryBannerLeft}>
+            <View style={styles.countryBannerDot} />
+            <Text style={styles.countryBannerText}>
+              <Text style={styles.countryBannerName}>{selectedCountry.countryName}</Text>
+              {" "}has an isolation score of{" "}
+              <Text style={styles.countryBannerName}>
+                {Math.round(selectedCountry.isolationScore)}%
+              </Text>
+              {" — "}{tierLabel(selectedCountry)}.
+              {rank ? ` It's ranked #${rank} of ${data.length} countries in this dataset.` : ""}
+            </Text>
+          </View>
+          <Pressable onPress={onClear} style={styles.countryBannerClear}>
+            <Text style={styles.countryBannerClearText}>✕ clear</Text>
+          </Pressable>
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Chapter layout primitives
+// ---------------------------------------------------------------------------
+
+function ChapterLabel({ num, title }: { num: number; title: string }) {
+  return (
+    <View style={styles.chapterLabelRow}>
+      <View style={styles.chapterCircle}>
+        <Text style={styles.chapterNumber}>{num}</Text>
+      </View>
+      <Text style={styles.chapterTitle}>{title}</Text>
+    </View>
+  );
+}
+
+function PullStat({
+  number,
+  unit,
+  context,
+}: {
+  number: string;
+  unit?: string;
+  context: string;
+}) {
+  return (
+    <View style={styles.pullStat}>
+      <View style={styles.pullStatDisplay}>
+        <Text style={styles.pullStatNumber}>{number}</Text>
+        {unit ? <Text style={styles.pullStatUnit}>{unit}</Text> : null}
+      </View>
+      <Text style={styles.pullStatContext}>{context}</Text>
+    </View>
+  );
+}
+
+function ArgumentText({ children }: { children: ReactNode }) {
+  return <Text style={styles.argument}>{children}</Text>;
+}
+
+function CtaButton({
+  label,
+  primary,
+  onPress,
+}: {
+  label: string;
+  primary?: boolean;
+  onPress: () => void;
+}) {
+  const [hovered, setHovered] = useState(false);
+  return (
+    <Pressable
+      onPress={onPress}
+      style={[
+        styles.ctaButton,
+        primary ? styles.ctaButtonPrimary : styles.ctaButtonSecondary,
+        hovered ? styles.ctaButtonHovered : null,
+      ]}
+      {...(Platform.OS === "web"
+        ? ({
+            onMouseEnter: () => setHovered(true),
+            onMouseLeave: () => setHovered(false),
+          } as any)
+        : {})}
+    >
+      <Text
+        style={[
+          styles.ctaButtonText,
+          primary ? styles.ctaButtonTextPrimary : styles.ctaButtonTextSecondary,
+        ]}
+      >
+        {label}
+      </Text>
+    </Pressable>
+  );
+}
+
+function CtaRow({ children }: { children: ReactNode }) {
+  return <View style={styles.ctaRow}>{children}</View>;
+}
+
+function WarningTag({ type, label }: { type: "orange" | "blue"; label: string }) {
+  return (
+    <View
+      style={[
+        styles.warningTag,
+        type === "orange" ? styles.warningTagOrange : styles.warningTagBlue,
+      ]}
+    >
+      <Text
+        style={[
+          styles.warningTagText,
+          { color: type === "orange" ? "#fb923c" : "#63b3ed" },
+        ]}
+      >
+        {label}
+      </Text>
+    </View>
+  );
+}
+
+function ChapterCard({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <View style={styles.chapterCard}>
+      <Text style={styles.chapterCardLabel}>{label}</Text>
+      {children}
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// KPI Flip Cards — left accent bar + content layout
+// ---------------------------------------------------------------------------
+
+function KpiCard({
+  barColor,
+  front,
+  back,
+}: {
+  barColor: string;
+  front: ReactNode;
+  back: ReactNode;
+}) {
+  const [flipped, setFlipped] = useState(false);
+  return (
+    <Pressable
+      style={[
+        styles.kpiCard,
+        flipped ? styles.kpiCardFlipped : null,
+        Platform.OS === "web"
+          ? ({ transition: "background-color 0.2s ease, border-color 0.2s ease" } as any)
+          : null,
+      ]}
+      onPress={() => setFlipped((v) => !v)}
+    >
+      <View style={[styles.kpiAccentBar, { backgroundColor: barColor }]} />
+      <View style={styles.kpiContent}>
+        {flipped ? back : (
+          <View>
+            {front}
+            <Text style={styles.kpiFlipHint}>flip ↻</Text>
+          </View>
+        )}
+      </View>
+    </Pressable>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Custom bar shapes — DS1/DS2 visual treatment
+// ---------------------------------------------------------------------------
+
+const TrendBar = (props: any) => {
+  const { x, y, width, height, payload } = props;
+  if (payload.isGap) {
+    const cx = x + width / 2;
+    return (
+      <g>
+        <line
+          x1={cx} y1={y - 180} x2={cx} y2={y}
+          stroke="#fb923c" strokeDasharray="4 3" strokeWidth={1.5}
+        />
+      </g>
+    );
+  }
+  if (!height || height <= 0) return <g />;
+  const isPost = payload.periodYear >= 2023;
+  return (
+    <g>
+      <rect
+        x={x + 1} y={y} width={Math.max(width - 2, 0)} height={height}
+        fill={colors.accent} fillOpacity={isPost ? 0.25 : 0.65} rx={2} ry={2}
+      />
+      {isPost ? (
+        <rect
+          x={x + 1} y={y} width={Math.max(width - 2, 0)} height={height}
+          fill="none" stroke={colors.accent} strokeDasharray="4 2" strokeWidth={1.5} rx={2} ry={2}
+        />
+      ) : null}
+    </g>
+  );
+};
+
+const ReachBar = (props: any) => {
+  const { x, y, width, height, payload } = props;
+  if (payload.isGap) {
+    const cx = x + width / 2;
+    return (
+      <g>
+        <line
+          x1={cx} y1={y - 180} x2={cx} y2={y}
+          stroke="#fb923c" strokeDasharray="4 3" strokeWidth={1.5}
+        />
+      </g>
+    );
+  }
+  if (!height || height <= 0) return <g />;
+  const isPost = payload.periodYear >= 2023;
+  return (
+    <g>
+      <rect
+        x={x + 1} y={y} width={Math.max(width - 2, 0)} height={height}
+        fill="#4ade80" fillOpacity={isPost ? 0.25 : 0.65} rx={2} ry={2}
+      />
+      {isPost ? (
+        <rect
+          x={x + 1} y={y} width={Math.max(width - 2, 0)} height={height}
+          fill="none" stroke="#4ade80" strokeDasharray="4 2" strokeWidth={1.5} rx={2} ry={2}
+        />
+      ) : null}
+    </g>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Chart: Chapter 3 — Global Overlap Trend
 // ---------------------------------------------------------------------------
 
 function OverlapTrendChart({ data }: { data: ApiTrendPoint[] }) {
-  const chartData = data.map((p) => ({
-    periodLabel: p.periodLabel,
-    overlapPct: p.isGap ? null : p.overlapPct,
-    isGap: p.isGap,
-  }));
+  const ds1 = data.filter((p) => !p.isGap && p.periodYear <= 2021);
+  const ds2 = data.filter((p) => !p.isGap && p.periodYear >= 2023);
+  const gapEntry: ApiTrendPoint = {
+    periodYear: 2022, periodLabel: "gap", periodMonth: null,
+    overlapPct: 0, avgCountries: 0, totalUniqueSongs: 0, songsIn2Plus: 0, isGap: true,
+  };
+  const chartData = [...ds1, gapEntry, ...ds2];
 
-  const gapPoints = data.filter((p) => p.isGap);
-  const firstGapLabel = gapPoints[0]?.periodLabel;
-  const lastGapLabel = gapPoints[gapPoints.length - 1]?.periodLabel;
+  const CustomXTick = ({ x, y, payload }: any) => {
+    if (payload.value === 2022) {
+      return (
+        <text x={x} y={y + 12} textAnchor="middle" fill="#fb923c" fontSize={9} fontFamily={typefaces.body}>
+          gap
+        </text>
+      );
+    }
+    const is2023 = payload.value === 2023;
+    return (
+      <text
+        x={x} y={y + 12} textAnchor="middle"
+        fill={is2023 ? "#fb923c" : "rgba(169,176,209,0.7)"}
+        fontSize={11} fontFamily={typefaces.body}
+      >
+        {payload.value}{is2023 ? "*" : ""}
+      </text>
+    );
+  };
 
   return (
-    <View style={styles.lineChartShell}>
+    <View style={styles.chartShell}>
       <View style={styles.chartContainer}>
         <ResponsiveContainer width="100%" height="100%">
-          <LineChart data={chartData} margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
+          <BarChart data={chartData} margin={{ top: 8, right: 12, left: 0, bottom: 0 }}>
             <CartesianGrid strokeDasharray="3 3" stroke="rgba(117,130,160,0.15)" vertical={false} />
-            <XAxis dataKey="periodLabel" tick={tickStyle} axisLine={false} tickLine={false} />
+            <XAxis dataKey="periodYear" tick={<CustomXTick />} axisLine={false} tickLine={false} />
             <YAxis
               tickFormatter={(v) => `${v}%`}
-              tick={tickStyle}
-              axisLine={false}
-              tickLine={false}
-              width={36}
+              tick={tickStyle} axisLine={false} tickLine={false} width={36}
             />
             <Tooltip
-              formatter={(value) =>
-                value !== null ? [`${value}%`, "Overlap rate"] : ["—", "No data"]
+              formatter={(value: any) =>
+                value && value > 0 ? [`${value}%`, "Overlap rate"] : ["—", "No data"]
               }
               contentStyle={tooltipStyle}
               labelStyle={tooltipLabelStyle}
               itemStyle={tooltipItemStyle}
             />
-            {firstGapLabel && lastGapLabel ? (
-              <ReferenceArea
-                x1={firstGapLabel}
-                x2={lastGapLabel}
-                fill="rgba(129,140,248,0.07)"
-                stroke="rgba(129,140,248,0.3)"
-                strokeDasharray="3 3"
-                label={{ value: "data gap", fill: "#818cf8", fontSize: 10 }}
-              />
-            ) : null}
-            <Line
-              type="monotone"
-              dataKey="overlapPct"
-              stroke={colors.accent}
-              strokeWidth={2}
-              dot={{ r: 5, fill: colors.accent, stroke: colors.background, strokeWidth: 2 }}
-              activeDot={{ r: 7 }}
-              connectNulls={false}
-            />
-          </LineChart>
+            <Bar dataKey="overlapPct" shape={<TrendBar />} />
+          </BarChart>
         </ResponsiveContainer>
       </View>
       <View style={styles.chartLegendRow}>
         <View style={styles.chartLegendItem}>
-          <View style={[styles.chartLegendSwatch, { backgroundColor: colors.accent }]} />
-          <Text style={styles.chartLegendText}>Overlap rate %</Text>
+          <View style={[styles.chartLegendSwatch, { backgroundColor: colors.accent, opacity: 0.65 }]} />
+          <Text style={styles.chartLegendText}>2017–2021 (Top 200 + Viral 50)</Text>
         </View>
         <View style={styles.chartLegendItem}>
           <View
@@ -330,125 +473,123 @@ function OverlapTrendChart({ data }: { data: ApiTrendPoint[] }) {
               {
                 backgroundColor: "transparent",
                 borderWidth: 1,
-                borderColor: "#818cf8",
+                borderColor: colors.accent,
                 borderStyle: "dashed" as any,
               },
             ]}
           />
-          <Text style={styles.chartLegendText}>Data gap (22 months)</Text>
+          <Text style={styles.chartLegendText}>2023–2025 (Top 50 only — dimmed)</Text>
         </View>
+        <Text style={[styles.chartLegendText, { color: "#fb923c" }]}>
+          * 2023 = Oct–Dec only
+        </Text>
       </View>
     </View>
   );
 }
 
 // ---------------------------------------------------------------------------
-// Chart: Regional Isolation Scores (Recharts horizontal Bar)
+// Chart: Chapter 2 — Isolation Bar Chart
 // ---------------------------------------------------------------------------
 
-const ISOLATION_COLORS: Record<string, string> = {
-  high: "#f87171",
-  mid: "#fb923c",
-  low: "#4ade80",
-};
+function IsolationBarChart({
+  data,
+  selectedCountry,
+}: {
+  data: ApiIsolationEntry[];
+  selectedCountry: ApiIsolationEntry | null;
+}) {
+  const chartHeight = Math.max(data.length * 28 + 40, 240);
 
-function IsolationBarChart({ data }: { data: ApiIsolationEntry[] }) {
-  const chartHeight = Math.max(data.length * 38 + 40, 240);
+  const CustomYTick = ({ x, y, payload }: any) => {
+    const isSelected = selectedCountry && payload.value === selectedCountry.countryName;
+    return (
+      <g>
+        <text
+          x={x} y={y} dy={4} textAnchor="end"
+          fill={isSelected ? colors.accent : "rgba(169,176,209,0.85)"}
+          fontSize={11} fontWeight={isSelected ? "500" : "400"} fontFamily={typefaces.body}
+        >
+          {payload.value}
+        </text>
+        {isSelected ? (
+          <>
+            <rect x={x + 4} y={y - 7} width={24} height={14} rx={7} fill="rgba(117,82,107,0.18)" />
+            <text
+              x={x + 16} y={y + 3} textAnchor="middle"
+              fill={colors.accent} fontSize={8} fontWeight="600" fontFamily={typefaces.body}
+            >
+              you
+            </text>
+          </>
+        ) : null}
+      </g>
+    );
+  };
 
   return (
     <View style={styles.isolationChartShell}>
-      <View style={{ height: chartHeight }}>
-        <ResponsiveContainer width="100%" height="100%">
-          <BarChart
-            data={data}
-            layout="vertical"
-            margin={{ top: 4, right: 48, left: 8, bottom: 4 }}
-          >
-            <XAxis
-              type="number"
-              domain={[0, 100]}
-              tickFormatter={(v) => `${v}%`}
-              tick={tickStyle}
-              axisLine={false}
-              tickLine={false}
-            />
-            <YAxis
-              type="category"
-              dataKey="countryName"
-              width={90}
-              tick={{ fill: colors.text, fontSize: 12, opacity: 0.85 }}
-              axisLine={false}
-              tickLine={false}
-            />
-            <Tooltip
-              formatter={(value) => [`${value}%`, "Isolation score"]}
-              contentStyle={tooltipStyle}
-              labelStyle={tooltipLabelStyle}
-              itemStyle={tooltipItemStyle}
-            />
-            <Bar dataKey="isolationScore" radius={[0, 4, 4, 0]} barSize={16}>
-              {data.map((entry, index) => (
-                <Cell
-                  key={`cell-${index}`}
-                  fill={ISOLATION_COLORS[entry.isolationTier] ?? ISOLATION_COLORS.mid}
-                  fillOpacity={0.85}
-                />
-              ))}
-            </Bar>
-          </BarChart>
-        </ResponsiveContainer>
+      <View
+        style={[
+          styles.isolationScrollContainer,
+          Platform.OS === "web"
+            ? ({ overflowY: "scroll", scrollbarWidth: "none" } as any)
+            : null,
+        ]}
+      >
+        <View style={{ height: chartHeight }}>
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={data} layout="vertical" margin={{ top: 4, right: 48, left: 8, bottom: 4 }}>
+              <XAxis
+                type="number" domain={[0, 100]}
+                tickFormatter={(v) => `${v}%`}
+                tick={tickStyle} axisLine={false} tickLine={false}
+              />
+              <YAxis
+                type="category" dataKey="countryName" width={100}
+                tick={<CustomYTick />} axisLine={false} tickLine={false}
+              />
+              <Tooltip
+                formatter={(value) => [`${value}%`, "Isolation score"]}
+                contentStyle={tooltipStyle}
+                labelStyle={tooltipLabelStyle}
+                itemStyle={tooltipItemStyle}
+              />
+              <ReferenceLine x={GLOBAL_AVG_ISOLATION} stroke="rgba(255,255,255,0.15)" strokeWidth={1} />
+              <Bar dataKey="isolationScore" radius={[0, 4, 4, 0]} barSize={16}>
+                {data.map((entry, index) => {
+                  const isSelected = selectedCountry?.isoCode === entry.isoCode;
+                  return (
+                    <Cell
+                      key={`cell-${index}`}
+                      fill={ISOLATION_COLORS[entry.isolationTier] ?? ISOLATION_COLORS.mid}
+                      fillOpacity={0.85}
+                      stroke={isSelected ? "rgba(117,82,107,0.65)" : "none"}
+                      strokeWidth={isSelected ? 2 : 0}
+                    />
+                  );
+                })}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        </View>
       </View>
       <View style={styles.chartLegendRow}>
         <View style={styles.chartLegendItem}>
           <View style={[styles.chartLegendSwatch, { backgroundColor: "#f87171" }]} />
-          <Text style={styles.chartLegendText}>High isolation</Text>
+          <Text style={styles.chartLegendText}>High isolation ({">"} 65%)</Text>
         </View>
         <View style={styles.chartLegendItem}>
           <View style={[styles.chartLegendSwatch, { backgroundColor: "#fb923c" }]} />
-          <Text style={styles.chartLegendText}>Mid</Text>
+          <Text style={styles.chartLegendText}>Mid (40–65%)</Text>
         </View>
         <View style={styles.chartLegendItem}>
           <View style={[styles.chartLegendSwatch, { backgroundColor: "#4ade80" }]} />
-          <Text style={styles.chartLegendText}>Low isolation</Text>
+          <Text style={styles.chartLegendText}>Low ({"<"} 40%)</Text>
         </View>
-      </View>
-    </View>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Chart: Discovery Gap Distribution (Recharts vertical Bar)
-// ---------------------------------------------------------------------------
-
-function GapDistributionChart({ data }: { data: ApiGapBucket[] }) {
-  return (
-    <View style={styles.lineChartShell}>
-      <View style={styles.chartContainer}>
-        <ResponsiveContainer width="100%" height="100%">
-          <BarChart data={data} margin={{ top: 8, right: 10, left: 0, bottom: 0 }}>
-            <CartesianGrid strokeDasharray="3 3" stroke="rgba(117,130,160,0.15)" vertical={false} />
-            <XAxis dataKey="bucketLabel" tick={smallTickStyle} axisLine={false} tickLine={false} />
-            <YAxis
-              tickFormatter={(v) => (v >= 1000 ? `${(v / 1000).toFixed(0)}k` : String(v))}
-              tick={tickStyle}
-              axisLine={false}
-              tickLine={false}
-              width={36}
-            />
-            <Tooltip
-              formatter={(value) => [Number(value).toLocaleString(), "Songs"]}
-              contentStyle={tooltipStyle}
-              labelStyle={tooltipLabelStyle}
-              itemStyle={tooltipItemStyle}
-            />
-            <Bar dataKey="songCount" fill="#818cf8" fillOpacity={0.72} radius={[4, 4, 0, 0]} />
-          </BarChart>
-        </ResponsiveContainer>
-      </View>
-      <View style={styles.chartLegendRow}>
         <View style={styles.chartLegendItem}>
-          <View style={[styles.chartLegendSwatch, { backgroundColor: "#818cf8", opacity: 0.7 }]} />
-          <Text style={styles.chartLegendText}>Songs by gap length (days)</Text>
+          <View style={{ width: 1, height: 14, backgroundColor: "rgba(255,255,255,0.15)" }} />
+          <Text style={styles.chartLegendText}>global avg (56%)</Text>
         </View>
       </View>
     </View>
@@ -456,87 +597,169 @@ function GapDistributionChart({ data }: { data: ApiGapBucket[] }) {
 }
 
 // ---------------------------------------------------------------------------
-// Chart: Global Reach Over Time (Recharts vertical Bar)
+// Chart: Chapter 4 — Global Reach Over Time
 // ---------------------------------------------------------------------------
 
 function GlobalReachChart({ data }: { data: ApiTrendPoint[] }) {
-  const nonGapData = data.filter((p) => !p.isGap);
+  const ds1 = data.filter((p) => !p.isGap && p.periodYear <= 2021);
+  const ds2 = data.filter((p) => !p.isGap && p.periodYear >= 2023);
+  const gapEntry: ApiTrendPoint = {
+    periodYear: 2022, periodLabel: "gap", periodMonth: null,
+    overlapPct: 0, avgCountries: 0, totalUniqueSongs: 0, songsIn2Plus: 0, isGap: true,
+  };
+  const chartData = [...ds1, gapEntry, ...ds2];
 
   const CustomXTick = ({ x, y, payload }: any) => {
-    const isPartial = payload.value === 2023;
+    if (payload.value === 2022) {
+      return (
+        <text x={x} y={y + 12} textAnchor="middle" fill="#fb923c" fontSize={9} fontFamily={typefaces.body}>
+          gap
+        </text>
+      );
+    }
+    const is2023 = payload.value === 2023;
     return (
       <text
-        x={x}
-        y={y + 10}
-        textAnchor="middle"
-        fill={isPartial ? "#fb923c" : "rgba(117,130,160,0.7)"}
-        fontSize={11}
-        fontFamily={typefaces.body}
+        x={x} y={y + 12} textAnchor="middle"
+        fill={is2023 ? "#fb923c" : "rgba(169,176,209,0.7)"}
+        fontSize={11} fontFamily={typefaces.body}
       >
-        {payload.value}{isPartial ? "*" : ""}
+        {payload.value}{is2023 ? "*" : ""}
       </text>
     );
   };
 
   return (
-    <View style={styles.lineChartShell}>
+    <View style={styles.chartShell}>
       <View style={styles.chartContainer}>
         <ResponsiveContainer width="100%" height="100%">
-          <BarChart data={nonGapData} margin={{ top: 8, right: 10, left: 0, bottom: 0 }}>
+          <BarChart data={chartData} margin={{ top: 8, right: 10, left: 0, bottom: 0 }}>
             <CartesianGrid strokeDasharray="3 3" stroke="rgba(117,130,160,0.15)" vertical={false} />
-            <XAxis
-              dataKey="periodYear"
-              tick={<CustomXTick />}
-              axisLine={false}
-              tickLine={false}
-            />
+            <XAxis dataKey="periodYear" tick={<CustomXTick />} axisLine={false} tickLine={false} />
             <YAxis
               tickFormatter={(v) => Number(v).toFixed(1)}
-              tick={tickStyle}
-              axisLine={false}
-              tickLine={false}
-              width={36}
+              tick={tickStyle} axisLine={false} tickLine={false} width={36}
             />
             <Tooltip
-              formatter={(value) => [Number(value).toFixed(2), "Avg countries"]}
+              formatter={(value: any) =>
+                value && value > 0 ? [Number(value).toFixed(2), "Avg countries"] : ["—", "No data"]
+              }
               contentStyle={tooltipStyle}
               labelStyle={tooltipLabelStyle}
               itemStyle={tooltipItemStyle}
-              labelFormatter={(label) =>
-                label === 2023 ? `${label} (Oct–Dec only)` : `${label}`
-              }
+              labelFormatter={(label) => label === 2023 ? `${label} (Oct–Dec only)` : `${label}`}
             />
-            <Bar dataKey="avgCountries" fill="#34d399" fillOpacity={0.75} radius={[4, 4, 0, 0]}>
-              {nonGapData.map((entry) => (
-                <Cell
-                  key={entry.periodYear}
-                  fill="#34d399"
-                  fillOpacity={entry.periodYear === 2023 ? 0.45 : 0.75}
-                />
-              ))}
-            </Bar>
+            <Bar dataKey="avgCountries" shape={<ReachBar />} />
           </BarChart>
         </ResponsiveContainer>
       </View>
       <View style={styles.chartLegendRow}>
         <View style={styles.chartLegendItem}>
-          <View style={[styles.chartLegendSwatch, { backgroundColor: "#34d399", opacity: 0.75 }]} />
-          <Text style={styles.chartLegendText}>Avg countries per song</Text>
+          <View style={[styles.chartLegendSwatch, { backgroundColor: "#4ade80", opacity: 0.65 }]} />
+          <Text style={styles.chartLegendText}>2017–2021</Text>
         </View>
         <View style={styles.chartLegendItem}>
-          <View style={[styles.chartLegendSwatch, { backgroundColor: "#34d399", opacity: 0.45 }]} />
-          <Text style={styles.chartLegendText}>Partial year (Oct–Dec only)</Text>
+          <View
+            style={[
+              styles.chartLegendSwatch,
+              {
+                backgroundColor: "transparent",
+                borderWidth: 1,
+                borderColor: "#4ade80",
+                borderStyle: "dashed" as any,
+              },
+            ]}
+          />
+          <Text style={styles.chartLegendText}>2023–2025 (Top 50 only — dimmed)</Text>
         </View>
+        <Text style={[styles.chartLegendText, { color: "#fb923c" }]}>
+          * 2023 = Oct–Dec only
+        </Text>
       </View>
-      <Text style={styles.chartFootnote}>
-        * 2023 reflects Oct–Dec data only. DS2 years (2023–2025) use Top 50 charts vs DS1's Top 200 — averages are not directly comparable across the gap.
-      </Text>
     </View>
   );
 }
 
 // ---------------------------------------------------------------------------
-// Main screen — fetches all dashboard data on mount
+// About This Data (collapsible)
+// ---------------------------------------------------------------------------
+
+const ABOUT_ENTRIES = [
+  {
+    icon: "!",
+    iconType: "orange" as const,
+    title: "22-month data gap (Dec 2021–Oct 2023)",
+    body: "No data exists for this period. Trend lines are broken, not interpolated.",
+  },
+  {
+    icon: "!",
+    iconType: "orange" as const,
+    title: "2023 data covers Oct 17–Dec 31 only",
+    body: "Heavily Q4-weighted. Affects Hidden Gems, Country Profile, and any chart scoped to 2023.",
+  },
+  {
+    icon: "!",
+    iconType: "orange" as const,
+    title: "Known limitation — Viral 50 and Top 200 treated as equivalent",
+    body: "Discovery gap times and overlap rates include Viral 50 entries, which spread simultaneously by design rather than through organic discovery. A chart-type-separated view is planned for a future iteration.",
+  },
+  {
+    icon: "i",
+    iconType: "blue" as const,
+    title: "Chart scope differs between time periods",
+    body: "2017–2021 data draws from Top 200 + Viral 50. 2023–2025 data draws from Top 50 only. Values are not directly comparable across the gap.",
+  },
+  {
+    icon: "i",
+    iconType: "blue" as const,
+    title: "Discovery gap reflects first crossings only",
+    body: "Mean (38d) and median (4d) diverge because crossover is bimodal. Songs that never crossed any border are excluded.",
+  },
+];
+
+const ICON_COLORS: Record<string, string> = {
+  orange: "#fb923c",
+  blue: "#63b3ed",
+};
+
+function AboutThisData() {
+  const [open, setOpen] = useState(false);
+  return (
+    <View style={styles.aboutSection}>
+      <Pressable style={styles.aboutToggleRow} onPress={() => setOpen((v) => !v)}>
+        <Text style={styles.aboutToggleLabel}>
+          About this data — sources, limitations & methodology
+        </Text>
+        <Text style={styles.aboutChevron}>{open ? "▲" : "▼"}</Text>
+      </Pressable>
+      {open ? (
+        <View style={styles.aboutEntries}>
+          {ABOUT_ENTRIES.map((entry, i) => (
+            <View key={i} style={styles.aboutEntry}>
+              <View
+                style={[
+                  styles.aboutIconWrap,
+                  { backgroundColor: `${ICON_COLORS[entry.iconType]}22` },
+                ]}
+              >
+                <Text style={[styles.aboutIconText, { color: ICON_COLORS[entry.iconType] }]}>
+                  {entry.icon}
+                </Text>
+              </View>
+              <View style={styles.aboutEntryContent}>
+                <Text style={styles.aboutEntryTitle}>{entry.title}</Text>
+                <Text style={styles.aboutEntryBody}>{entry.body}</Text>
+              </View>
+            </View>
+          ))}
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main screen content
 // ---------------------------------------------------------------------------
 
 function DashboardScreenContent() {
@@ -546,9 +769,9 @@ function DashboardScreenContent() {
   const [peakReach, setPeakReach] = useState<ApiPeakReach | null>(null);
   const [trendData, setTrendData] = useState<ApiTrendPoint[]>([]);
   const [isolationRanking, setIsolationRanking] = useState<ApiIsolationEntry[]>([]);
-  const [gapDistribution, setGapDistribution] = useState<ApiGapBucket[]>([]);
   const [loading, setLoading] = useState(true);
   const [fetchError, setFetchError] = useState<string | null>(null);
+  const [selectedCountry, setSelectedCountry] = useState<ApiIsolationEntry | null>(null);
 
   useEffect(() => {
     const start = "2017-01-01";
@@ -560,16 +783,14 @@ function DashboardScreenContent() {
       loadPeakReach(start, end),
       loadOverlapTrend(start, end),
       loadIsolationRanking(start, end),
-      loadGapDistribution(start, end),
     ])
-      .then(([rate, gap, leader, reach, trend, ranking, distribution]) => {
+      .then(([rate, gap, leader, reach, trend, ranking]) => {
         setOverlapRate(rate);
         setDiscoveryGap(gap);
         setIsolationLeader(leader);
         setPeakReach(reach);
         setTrendData(trend);
         setIsolationRanking(ranking);
-        setGapDistribution(distribution);
         setLoading(false);
       })
       .catch((err: unknown) => {
@@ -578,16 +799,73 @@ function DashboardScreenContent() {
       });
   }, []);
 
-  const trendDirection = useMemo((): "up" | "down" | "flat" => {
+  // All pull-stat values derived from API data
+  const notCrossingPct = useMemo(
+    () => (overlapRate ? Math.round(100 - overlapRate.overlapPct) : null),
+    [overlapRate]
+  );
+
+  const isolationSpread = useMemo(() => {
+    if (isolationRanking.length < 2) return null;
+    const scores = isolationRanking.map((e) => e.isolationScore);
+    return Math.round(Math.max(...scores) - Math.min(...scores));
+  }, [isolationRanking]);
+
+  const overlapChange = useMemo(() => {
     const nonGap = trendData.filter((p) => !p.isGap && p.overlapPct > 0);
-    if (nonGap.length < 2) return "flat";
-    const last = nonGap[nonGap.length - 1].overlapPct;
-    const prev = nonGap[nonGap.length - 2].overlapPct;
-    if (last > prev) return "up";
-    if (last < prev) return "down";
-    return "flat";
+    const pt2017 = nonGap.find((p) => p.periodYear === 2017);
+    const pt2021 = nonGap.find((p) => p.periodYear === 2021);
+    if (!pt2017 || !pt2021) return null;
+    return Math.round(pt2021.overlapPct - pt2017.overlapPct);
   }, [trendData]);
 
+  // Card 3 personalization
+  const isolationCardScore = selectedCountry
+    ? Math.round(selectedCountry.isolationScore)
+    : isolationLeader
+    ? Math.round(isolationLeader.isolationScore)
+    : null;
+  const isolationCardName =
+    selectedCountry?.countryName ?? isolationLeader?.countryName ?? "";
+  const isolationCardTierLabel = selectedCountry
+    ? selectedCountry.isolationScore > 65
+      ? "highly isolated market"
+      : selectedCountry.isolationScore >= 40
+      ? "moderately isolated"
+      : "well connected"
+    : "most isolated market";
+  const isolationCardBarColor = selectedCountry
+    ? selectedCountry.isolationScore > 65
+      ? KPI_BAR.red
+      : selectedCountry.isolationScore >= 40
+      ? "#fb923c"
+      : KPI_BAR.green
+    : KPI_BAR.red;
+
+  // Personalized CTA labels
+  const countryLabel = selectedCountry?.countryName ?? null;
+  const countryParam = selectedCountry
+    ? `?country=${encodeURIComponent(selectedCountry.isoCode)}`
+    : "";
+  const gemLabel = countryLabel
+    ? `Find ${countryLabel}'s hidden gems →`
+    : "Find hidden gems →";
+  const globeLabel = countryLabel
+    ? `See ${countryLabel} on the globe →`
+    : "Explore these gaps on the globe →";
+  const missingLabel = countryLabel
+    ? `Find what ${countryLabel} is missing →`
+    : "Find what your country is missing →";
+
+  // Peak song display date
+  const peakDateStr = peakReach?.peakDate
+    ? (() => {
+        const d = new Date(peakReach.peakDate);
+        return `peak ${d.toLocaleString("default", { month: "short" })} ${d.getFullYear()}`;
+      })()
+    : null;
+
+  // Scrollbar state
   const pageScrollRef = useRef<ScrollView>(null);
   const pageTrackRef = useRef<View>(null);
   const [pageViewportHeight, setPageViewportHeight] = useState(0);
@@ -604,7 +882,8 @@ function DashboardScreenContent() {
       : pageTrackHeight
     : 0;
   const pageThumbTop = pageHasOverflow
-    ? (pageScrollY / (pageContentHeight - pageViewportHeight)) * (pageViewportHeight - pageThumbHeight)
+    ? (pageScrollY / (pageContentHeight - pageViewportHeight)) *
+      (pageViewportHeight - pageThumbHeight)
     : 0;
 
   const handlePageScroll = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
@@ -630,7 +909,8 @@ function DashboardScreenContent() {
   };
 
   useEffect(() => {
-    if (Platform.OS !== "web" || !isDraggingPageScrollbar || typeof document === "undefined") return;
+    if (Platform.OS !== "web" || !isDraggingPageScrollbar || typeof document === "undefined")
+      return;
     const previousUserSelect = document.body.style.userSelect;
     const handleMove = (event: MouseEvent) => {
       event.preventDefault();
@@ -645,7 +925,14 @@ function DashboardScreenContent() {
       document.removeEventListener("mousemove", handleMove);
       document.removeEventListener("mouseup", handleUp);
     };
-  }, [isDraggingPageScrollbar, pageHasOverflow, pageThumbHeight, pageTrackHeight, pageContentHeight, pageViewportHeight]);
+  }, [
+    isDraggingPageScrollbar,
+    pageHasOverflow,
+    pageThumbHeight,
+    pageTrackHeight,
+    pageContentHeight,
+    pageViewportHeight,
+  ]);
 
   if (loading || fetchError) {
     return (
@@ -653,7 +940,7 @@ function DashboardScreenContent() {
         <View style={styles.pageScrollFrame}>
           <View style={styles.statusShell}>
             <Text style={[styles.statusText, fetchError ? styles.statusError : null]}>
-              {fetchError ?? "Loading dashboard data…"}
+              {fetchError ?? "Loading…"}
             </Text>
           </View>
         </View>
@@ -674,123 +961,452 @@ function DashboardScreenContent() {
           onScroll={handlePageScroll}
           scrollEventThrottle={16}
         >
-          {/* —— Page header —— */}
-          <DiscoveryBlurb
-            heading="Global Overlap Dashboard"
-            body="This dashboard is the analytical answer to the Discovery Gap question: which globally trending artists and songs are missing from local markets, and how do those patterns change over time? Every number here is derived from 28 million chart entries across 73 countries spanning 2017–2021 and 2023–2025. The 22-month data gap between datasets is marked clearly wherever it appears in trend charts."
-          />
-
-          {/* —— KPI section —— */}
-          <SectionLabel label="KEY PERFORMANCE INDICATORS" />
-
-          <View style={styles.kpiRow}>
-            {overlapRate ? (
-              <KpiOverlapRateCard data={overlapRate} trendDirection={trendDirection} />
-            ) : null}
-            {discoveryGap ? <KpiDiscoveryGapCard data={discoveryGap} /> : null}
-            {isolationLeader ? <KpiIsolationCard data={isolationLeader} /> : null}
-            {peakReach ? <KpiPeakReachCard data={peakReach} /> : null}
+          {/* ── Hero ── */}
+          <View style={styles.heroWrap}>
+            <LinearGradient
+              colors={HERO_GRADIENT}
+              locations={HERO_GRADIENT_LOCATIONS}
+              start={{ x: 0.15, y: 0 }}
+              end={{ x: 0.85, y: 1 }}
+              style={StyleSheet.absoluteFillObject}
+            />
+            <View style={styles.contentInner}>
+              <View style={styles.heroContent}>
+                <Text style={styles.heroOverline}>The discovery gap — a data story</Text>
+                <View style={styles.heroTitleRow}>
+                  <Text style={styles.heroH1}>
+                    {"Most music never leaves "}
+                    <Text style={styles.heroH1Accent}>home.</Text>
+                  </Text>
+                  <GemIcon size={30} style={styles.heroGemIcon} />
+                </View>
+                <Text style={styles.heroBody}>
+                  A song can be charting in 30 countries and completely unknown in yours.
+                  This isn't a taste difference — it's a structural gap in how music travels.
+                </Text>
+                <CountrySelector
+                  data={isolationRanking}
+                  selectedCountry={selectedCountry}
+                  onSelect={setSelectedCountry}
+                  onClear={() => setSelectedCountry(null)}
+                />
+                <View style={styles.scrollHint}>
+                  <View style={styles.scrollHintLine} />
+                  <Text style={styles.scrollHintText}>scroll to explore</Text>
+                </View>
+              </View>
+            </View>
           </View>
 
-          {/* —— Trend analysis section —— */}
-          <SectionLabel label="TREND ANALYSIS" />
+          {/* ══ Chapter 1: The gap exists (base dark) ══ */}
+          <View style={styles.chapterWrap}>
+            <View style={styles.contentInner}>
+              <ChapterLabel num={1} title="THE GAP EXISTS" />
+              <View style={styles.chapterTwoCol}>
+                <View style={styles.chapterLeft}>
+                  {notCrossingPct !== null ? (
+                    <PullStat
+                      number={String(notCrossingPct)}
+                      unit="%"
+                      context="of all charting songs never appeared in a second country's charts."
+                    />
+                  ) : null}
+                </View>
+                <View style={styles.chapterRight}>
+                  {notCrossingPct !== null && overlapRate ? (
+                    <ArgumentText>
+                      Out of every 100 songs that charted anywhere in the world between
+                      2017 and 2025,{" "}
+                      <Text style={styles.argBold}>{notCrossingPct} stayed home.</Text> They
+                      charted, they disappeared, and no other market ever heard of them. The
+                      remaining{" "}
+                      <Text style={styles.argBold}>
+                        {Math.round(overlapRate.overlapPct)} crossed at least one border
+                      </Text>{" "}
+                      — and a handful crossed dozens.
+                    </ArgumentText>
+                  ) : null}
+                  <CtaRow>
+                    <CtaButton
+                      label={globeLabel}
+                      primary
+                      onPress={() => navigateTo(`/discovery${countryParam}`)}
+                    />
+                    <CtaButton
+                      label={gemLabel}
+                      onPress={() => navigateTo(`/hidden-gems${countryParam}`)}
+                    />
+                  </CtaRow>
+                </View>
+              </View>
 
-          {/* Row 1: Overlap trend + Isolation ranking */}
-          <View style={styles.chartRow}>
-            <DashboardSection style={styles.chartCardWide}>
-              <SectionTitle
-                title="Global Overlap Rate Over Time"
-                subtitle="% of charting songs appearing in 2+ countries — annual, 2017–2025"
-              />
-              <Text style={styles.chartExplainer}>
-                This line tracks what share of the global charting song pool was crossing borders in any
-                given year. A rising line means music markets are becoming more connected; a falling line
-                means they're pulling apart. The 22-month data gap (Dec 2021 – Oct 2023) is shaded — do
-                not read continuity across that region.
-              </Text>
-              {trendData.length > 0 ? <OverlapTrendChart data={trendData} /> : null}
-            </DashboardSection>
+              {/* KPI flip cards — full-width 4-column grid */}
+              <View style={styles.kpiGrid}>
+                {overlapRate ? (
+                  <KpiCard
+                    barColor={KPI_BAR.purple}
+                    front={
+                      <View style={styles.kpiFront}>
+                        <Text style={styles.kpiLabel}>Global Overlap Rate</Text>
+                        <Text style={styles.kpiNumber}>{Math.round(overlapRate.overlapPct)}%</Text>
+                        <Text style={styles.kpiSublabel}>songs reached 2+ countries</Text>
+                      </View>
+                    }
+                    back={
+                      <View style={styles.kpiBack}>
+                        <Text style={styles.kpiBackTitle}>What this means</Text>
+                        <Text style={styles.kpiBackBody}>
+                          {Math.round(100 - overlapRate.overlapPct)}% of charting music stayed in
+                          exactly one country. The {Math.round(overlapRate.overlapPct)}% that
+                          crossed is what this app is built to help you find.
+                        </Text>
+                        <Pressable onPress={() => navigateTo("/discovery")}>
+                          <Text style={styles.kpiCta}>Explore globe →</Text>
+                        </Pressable>
+                      </View>
+                    }
+                  />
+                ) : null}
 
-            <DashboardSection style={styles.chartCardNarrow}>
-              <SectionTitle
-                title="Regional Isolation Scores"
-                subtitle="Countries ranked by % locally unique chart songs"
-              />
-              <Text style={styles.chartExplainer}>
-                A country's isolation score = the share of its charting songs that appeared nowhere else.
-                High scores (red) mean a market that barely intersects with global trends. Low scores
-                (green) mean a market whose charts closely mirror what's popular everywhere.
-              </Text>
-              {isolationRanking.length > 0 ? <IsolationBarChart data={isolationRanking} /> : null}
-            </DashboardSection>
+                {discoveryGap ? (
+                  <KpiCard
+                    barColor={KPI_BAR.blue}
+                    front={
+                      <View style={styles.kpiFront}>
+                        <Text style={styles.kpiLabel}>Discovery Gap</Text>
+                        <Text style={styles.kpiNumber}>{discoveryGap.medianGapDays}d</Text>
+                        <Text style={styles.kpiSublabel}>median to cross a border</Text>
+                        <Text style={styles.kpiSecondary}>
+                          mean: {discoveryGap.avgGapDays} days
+                        </Text>
+                      </View>
+                    }
+                    back={
+                      <View style={styles.kpiBack}>
+                        <Text style={styles.kpiBackTitle}>Why two numbers?</Text>
+                        <Text style={styles.kpiBackBody}>
+                          Most crossovers happen within days. A long tail of slow-movers pulls
+                          the mean to {discoveryGap.avgGapDays}. The median is the real signal.
+                        </Text>
+                      </View>
+                    }
+                  />
+                ) : null}
+
+                {isolationCardScore !== null ? (
+                  <KpiCard
+                    barColor={isolationCardBarColor}
+                    front={
+                      <View style={styles.kpiFront}>
+                        <Text style={styles.kpiLabel}>
+                          {selectedCountry ? "Your Country" : "Most Isolated Market"}
+                        </Text>
+                        <Text style={styles.kpiNumber}>{isolationCardScore}%</Text>
+                        <Text style={styles.kpiSublabel}>
+                          {isolationCardName} — {isolationCardTierLabel}
+                        </Text>
+                      </View>
+                    }
+                    back={
+                      <View style={styles.kpiBack}>
+                        <Text style={styles.kpiBackTitle}>
+                          {selectedCountry ? "Your country in context" : "Isolation explained"}
+                        </Text>
+                        <Text style={styles.kpiBackBody}>
+                          {selectedCountry
+                            ? selectedCountry.isolationScore > 65
+                              ? `${selectedCountry.countryName} has an isolation score of ${Math.round(selectedCountry.isolationScore)}%. Most of its chart stays local — it has some of the most to discover.`
+                              : selectedCountry.isolationScore >= 40
+                              ? `${selectedCountry.countryName} has an isolation score of ${Math.round(selectedCountry.isolationScore)}%. Some global crossover, but still plenty of undiscovered music.`
+                              : `${selectedCountry.countryName} has an isolation score of ${Math.round(selectedCountry.isolationScore)}%. Its charts overlap heavily with global trends.`
+                            : isolationLeader
+                            ? `${Math.round(isolationLeader.isolationScore)}% of songs charting in ${isolationLeader.countryName} appeared nowhere else. These are the markets with the most to discover.`
+                            : ""}
+                        </Text>
+                        <Pressable onPress={() => navigateTo(`/hidden-gems${countryParam}`)}>
+                          <Text style={styles.kpiCta}>{gemLabel}</Text>
+                        </Pressable>
+                      </View>
+                    }
+                  />
+                ) : null}
+
+                {peakReach ? (
+                  <KpiCard
+                    barColor={KPI_BAR.green}
+                    front={
+                      <View style={styles.kpiFront}>
+                        <Text style={styles.kpiLabel}>Peak Cross-Regional Reach</Text>
+                        <Text style={styles.kpiNumber}>{peakReach.peakCountryCount}</Text>
+                        <Text style={styles.kpiSublabel}>countries at once — peak reach</Text>
+                      </View>
+                    }
+                    back={
+                      <View style={styles.kpiBack}>
+                        <Text style={styles.kpiBackTitle}>The ceiling</Text>
+                        <Text style={styles.kpiBackBody}>
+                          {peakReach.songTitle} by {peakReach.artistName} charted in{" "}
+                          {peakReach.peakCountryCount} countries simultaneously. The average
+                          song reaches 3.
+                        </Text>
+                        <Pressable onPress={() => navigateTo("/discovery")}>
+                          <Text style={styles.kpiCta}>Explore globe →</Text>
+                        </Pressable>
+                      </View>
+                    }
+                  />
+                ) : null}
+              </View>
+            </View>
           </View>
 
-          {/* Row 2: Gap distribution + Global reach */}
-          <View style={styles.chartRow}>
-            <DashboardSection style={styles.chartCardHalf}>
-              <SectionTitle
-                title="Discovery Gap Distribution"
-                subtitle="How many days until songs cross their first border"
-              />
-              <Text style={styles.chartExplainer}>
-                Each bar shows how many songs took that long to appear in a second country after their
-                debut chart entry. Most songs that cross a border do so within the first week — the 0-7 
-                day bucket reflects how quickly streaming-era music spreads when it gains momentum, and 
-                is partly driven by Viral 50 chart entries which capture simultaneous cross-market momentum 
-                by design. The average of 38 days is pulled higher by a long tail of songs that took months 
-                to travel or barely reached a second market. The gap between the median (4 days) and mean
-                (38 days) is itself a finding: crossover is either fast or it doesn't happen. Songs in the 
-                "90d+" bucket either took a very long time to travel or only barely made it to one other market
-                before dropping off entirely.
-              </Text>
-              {gapDistribution.length > 0 ? <GapDistributionChart data={gapDistribution} /> : null}
-            </DashboardSection>
-
-            <DashboardSection style={styles.chartCardHalf}>
-              <SectionTitle
-                title="Global Reach Over Time"
-                subtitle="Avg countries per charting song — annual, 2017–2025"
-              />
-              <Text style={styles.chartExplainer}>
-                On average, how many countries did a charting song appear in that year? This is the
-                macro view of the Discovery Gap: if the number stays low, most music stays local
-                regardless of global streaming access.{"\n\n"}
-                Two important caveats: DS1 years (2017–2021) draw from the Top 200 and Viral 50
-                charts across 70+ countries, while DS2 years (2023–2025) draw from a Top 50 chart
-                only — the smaller chart pool naturally produces lower averages and is not directly
-                comparable. Additionally, 2023 reflects only Oct–Dec data, so its bar represents
-                a partial year. Gap year 2022 is omitted entirely rather than shown as zero.
-              </Text>
-              {trendData.length > 0 ? <GlobalReachChart data={trendData} /> : null}
-            </DashboardSection>
+          {/* ══ Chapter 2: The gap is geographic (elevated) ══ */}
+          <View style={[styles.chapterWrap, styles.chapterElevated]}>
+            <View style={styles.contentInner}>
+              <ChapterLabel num={2} title="THE GAP IS GEOGRAPHIC" />
+              <View style={styles.chapterTwoCol}>
+                <View style={styles.chapterLeft}>
+                  {isolationSpread !== null ? (
+                    <PullStat
+                      number={String(isolationSpread)}
+                      unit="pts"
+                      context="difference between the most and least isolated market in this dataset."
+                    />
+                  ) : null}
+                </View>
+                <View style={styles.chapterRight}>
+                  <ArgumentText>
+                    The gap isn't evenly distributed. Some markets are deeply wired into global
+                    trends. Others are almost entirely self-contained.{" "}
+                    <Text style={styles.argBold}>
+                      Where your country falls determines how much music you're missing.
+                    </Text>
+                  </ArgumentText>
+                  <CtaRow>
+                    <CtaButton
+                      label={
+                        countryLabel
+                          ? `See ${countryLabel} on the globe →`
+                          : "See this on the globe →"
+                      }
+                      primary
+                      onPress={() => navigateTo(`/discovery${countryParam}`)}
+                    />
+                    <CtaButton
+                      label="Compare two countries →"
+                      onPress={() => navigateTo("/compare")}
+                    />
+                  </CtaRow>
+                </View>
+              </View>
+              {isolationRanking.length > 0 ? (
+                <ChapterCard label="ISOLATION SCORES BY COUNTRY">
+                  <IsolationBarChart
+                    data={isolationRanking}
+                    selectedCountry={selectedCountry}
+                  />
+                </ChapterCard>
+              ) : null}
+            </View>
           </View>
 
-          {/* —— Methodology note —— */}
-          <DashboardSection style={styles.methodologyCard}>
-            <SectionTitle title="About This Data" />
-            <Text style={styles.methodologyBody}>
-              All metrics on this dashboard are derived from two Kaggle datasets: Spotify Historical
-              Charts (2017–2021) covering the Top 200 and Viral 50 across 70+ countries, and Top Spotify
-              Songs in 73 Countries (2023–2025) covering daily Top 50 charts. Combined, these datasets
-              represent approximately 28 million chart entries.
-            </Text>
-            <Text style={styles.methodologyBody}>
-              <Text style={styles.methodologyBold}>Popularity metrics cannot be compared across datasets.</Text>
-              {" "}Dataset 1 uses raw stream counts; Dataset 2 uses Spotify's proprietary 0–100 popularity
-              score. These are stored separately and never merged.
-            </Text>
-            <Text style={styles.methodologyBody}>
-              <Text style={styles.methodologyBold}>The 22-month data gap (Dec 2021 – Oct 2023)</Text>
-              {" "}is a known limitation. No data exists for this period. Trend lines are broken — not
-              interpolated — across this gap, and every time-series visualization on this page marks it
-              explicitly.
-            </Text>
-            <Text style={styles.methodologyBody}>
-              KPI calculations run in pre-computed SQL summary tables server-side and are never derived
-              live from the raw 28M-row fact table. This ensures response times remain fast regardless
-              of filter state.
-            </Text>
-          </DashboardSection>
+          {/* ══ Chapter 3: Measurable over time (base dark) ══ */}
+          <View style={styles.chapterWrap}>
+            <View style={styles.contentInner}>
+              <ChapterLabel num={3} title="THE GAP IS MEASURABLE OVER TIME" />
+              <View style={styles.chapterTwoCol}>
+                <View style={styles.chapterLeft}>
+                  {overlapChange !== null ? (
+                    <PullStat
+                      number={`+${overlapChange}`}
+                      unit="pts"
+                      context="increase in global overlap from 2017 to 2021 — then a 22-month silence."
+                    />
+                  ) : null}
+                </View>
+                <View style={styles.chapterRight}>
+                  <ArgumentText>
+                    Global overlap was{" "}
+                    <Text style={styles.argBold}>improving through 2021.</Text> Then the data
+                    stops. When it resumes in late 2023, the picture looks different —{" "}
+                    <Text style={styles.argBold}>but that may be the data, not reality.</Text>
+                  </ArgumentText>
+                  <View style={styles.warningTagRow}>
+                    <WarningTag
+                      type="orange"
+                      label="⚠ 22-month gap — broken, not interpolated"
+                    />
+                    <WarningTag
+                      type="blue"
+                      label="i 2017–2021 data vs 2023–2025 data uses different chart pools"
+                    />
+                  </View>
+                </View>
+              </View>
+              {trendData.length > 0 ? (
+                <>
+                  <ChapterCard label="GLOBAL OVERLAP RATE — 2017–2025">
+                    <OverlapTrendChart data={trendData} />
+                  </ChapterCard>
+                  <Text style={styles.pullQuote}>
+                    The dashed bars use a smaller chart pool. A visual dip after the gap
+                    doesn't mean music borders got worse — it partly means we're counting
+                    fewer songs per country.
+                  </Text>
+                </>
+              ) : null}
+            </View>
+          </View>
+
+          {/* ══ Chapter 4: The ceiling (elevated) ══ */}
+          <View style={[styles.chapterWrap, styles.chapterElevated]}>
+            <View style={styles.contentInner}>
+              <ChapterLabel num={4} title="THE CEILING" />
+              <View style={styles.chapterTwoCol}>
+                <View style={styles.chapterLeft}>
+                  {peakReach ? (
+                    <PullStat
+                      number={String(peakReach.peakCountryCount)}
+                      context="countries at once. The most connected a song has ever been in this dataset."
+                    />
+                  ) : null}
+                </View>
+                <View style={styles.chapterRight}>
+                  {peakReach ? (
+                    <>
+                      <ArgumentText>
+                        The average charting song reaches{" "}
+                        <Text style={styles.argBold}>3 countries.</Text> The record is{" "}
+                        {peakReach.peakCountryCount}. Between those two numbers is{" "}
+                        <Text style={styles.argBold}>
+                          every song trending somewhere right now that hasn't reached you yet.
+                        </Text>
+                      </ArgumentText>
+                      <View style={styles.songRefCard}>
+                        <View
+                          style={[
+                            styles.songRefSwatch,
+                            { backgroundColor: rowBackdropColors[0] },
+                          ]}
+                        />
+                        <View style={styles.songRefInfo}>
+                          <Text style={styles.songRefTitle}>{peakReach.songTitle}</Text>
+                          <Text style={styles.songRefArtist}>
+                            {peakReach.artistName}
+                            {peakDateStr ? ` · ${peakDateStr}` : ""}
+                          </Text>
+                        </View>
+                        <View style={styles.songRefCount}>
+                          <Text style={styles.songRefNumber}>{peakReach.peakCountryCount}</Text>
+                          <Text style={styles.songRefCountLabel}>countries at once</Text>
+                        </View>
+                      </View>
+                      <View style={styles.warningTagRow}>
+                        <WarningTag type="orange" label="⚠ 2023 = Oct–Dec only" />
+                        <WarningTag type="blue" label="i 2023–2025 uses Top 50 charts only" />
+                      </View>
+                      <CtaRow>
+                        <CtaButton
+                          label={missingLabel}
+                          primary
+                          onPress={() => navigateTo(`/hidden-gems${countryParam}`)}
+                        />
+                        <CtaButton
+                          label="Explore on the globe →"
+                          onPress={() => navigateTo("/discovery")}
+                        />
+                      </CtaRow>
+                    </>
+                  ) : null}
+                </View>
+              </View>
+              {trendData.length > 0 ? (
+                <ChapterCard label="AVERAGE COUNTRIES PER SONG — 2017–2025">
+                  <GlobalReachChart data={trendData} />
+                </ChapterCard>
+              ) : null}
+            </View>
+          </View>
+
+          {/* ══ Conclusion ══ */}
+          <View style={styles.conclusionWrap}>
+            <LinearGradient
+              colors={HERO_GRADIENT}
+              locations={HERO_GRADIENT_LOCATIONS}
+              start={{ x: 0.15, y: 0 }}
+              end={{ x: 0.85, y: 1 }}
+              style={StyleSheet.absoluteFillObject}
+            />
+            <View style={styles.contentInner}>
+              <View style={styles.conclusionTwoCol}>
+                <View style={styles.conclusionLeft}>
+                  <Text style={styles.conclusionHeadline}>
+                    {"The gap is real. The music is "}
+                    <Text style={styles.conclusionAccent}>out there.</Text>
+                  </Text>
+                  <Text style={styles.conclusionBody}>
+                    {notCrossingPct !== null ? `${notCrossingPct}%` : "—"} of charting songs
+                    never crossed a single border. The ones that did spread fast — most within
+                    days. A handful reached{" "}
+                    {peakReach ? peakReach.peakCountryCount : "—"} countries at once.
+                    Everything in between is waiting to be discovered.
+                  </Text>
+                  <View style={styles.conclusionCtas}>
+                    <CtaButton
+                      label={missingLabel}
+                      primary
+                      onPress={() => navigateTo(`/hidden-gems${countryParam}`)}
+                    />
+                    <CtaButton
+                      label="Explore on the globe →"
+                      onPress={() => navigateTo("/discovery")}
+                    />
+                  </View>
+                </View>
+                <View style={styles.conclusionRight}>
+                  <View style={styles.statGrid}>
+                    <View style={styles.statCard}>
+                      <Text style={styles.statNumber}>
+                        {notCrossingPct !== null ? `${notCrossingPct}%` : "—"}
+                      </Text>
+                      <Text style={styles.statLabel}>
+                        of music never leaves its home market
+                      </Text>
+                    </View>
+                    <View style={styles.statCard}>
+                      <Text style={styles.statNumber}>
+                        {discoveryGap ? `${discoveryGap.medianGapDays}d` : "—"}
+                      </Text>
+                      <Text style={styles.statLabel}>median time to cross a border</Text>
+                    </View>
+                    <View style={styles.statCard}>
+                      <Text style={styles.statNumber}>
+                        {peakReach ? peakReach.peakCountryCount : "—"}
+                      </Text>
+                      <Text style={styles.statLabel}>
+                        countries — the ceiling one song ever reached
+                      </Text>
+                    </View>
+                    <View style={styles.statCard}>
+                      <Text style={styles.statNumber}>
+                        {isolationLeader
+                          ? `${Math.round(isolationLeader.isolationScore)}%`
+                          : "—"}
+                      </Text>
+                      <Text style={styles.statLabel}>
+                        isolation — the most self-contained market
+                      </Text>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+
+          {/* ── About This Data ── */}
+          <View style={styles.contentInner}>
+            <AboutThisData />
+          </View>
         </ScrollView>
 
         {pageScrollbarVisible ? (
@@ -799,8 +1415,12 @@ function DashboardScreenContent() {
             style={styles.pageScrollbarTrack}
             onStartShouldSetResponder={() => true}
             onMoveShouldSetResponder={() => true}
-            onResponderGrant={(event) => scrollPageToTrackLocation(event.nativeEvent.locationY)}
-            onResponderMove={(event) => scrollPageToTrackLocation(event.nativeEvent.locationY)}
+            onResponderGrant={(event) =>
+              scrollPageToTrackLocation(event.nativeEvent.locationY)
+            }
+            onResponderMove={(event) =>
+              scrollPageToTrackLocation(event.nativeEvent.locationY)
+            }
             {...(Platform.OS === "web"
               ? ({
                   onMouseDown: (event: any) => {
@@ -843,14 +1463,10 @@ const styles = StyleSheet.create({
   scrollView: {
     flex: 1,
     ...(Platform.OS === "web"
-      ? ({
-          overflowY: "scroll",
-          scrollbarWidth: "none",
-        } as ViewStyle)
+      ? ({ overflowY: "scroll", scrollbarWidth: "none" } as ViewStyle)
       : null),
   },
   scrollContent: {
-    gap: 20,
     paddingBottom: 32,
     paddingRight: 18,
   },
@@ -872,254 +1488,537 @@ const styles = StyleSheet.create({
     backgroundColor: colors.scrollbarThumb,
   },
 
-  // —— Section primitives ——
-  sectionPanel: {
-    backgroundColor: "transparent",
-    padding: 0,
-    overflow: "hidden",
-  },
-  sectionFill: {
-    ...StyleSheet.absoluteFillObject,
-  },
-  sectionContent: {
-    padding: 18,
-    gap: 14,
-  },
-  sectionTitleWrap: {
-    gap: 5,
-  },
-  sectionTitle: {
-    color: colors.textStrong,
-    fontFamily: typefaces.display,
-    fontSize: 20,
-    lineHeight: 24,
-  },
-  darkSectionTitle: {
-    color: "rgba(15,16,21,0.92)",
-  },
-  sectionSubtitle: {
-    color: colors.text,
-    fontFamily: typefaces.body,
-    fontSize: 13,
-    lineHeight: 18,
-  },
-  darkSectionSubtitle: {
-    color: "rgba(15,16,21,0.8)",
+  // —— Max-width content inner ——
+  contentInner: {
+    maxWidth: 960,
+    alignSelf: "center",
+    width: "100%",
+    paddingHorizontal: 28,
   },
 
-  // —— Section label ——
-  sectionLabelWrap: {
-    paddingHorizontal: 2,
+  // —— Hero ——
+  heroWrap: {
+    overflow: "hidden",
+    paddingTop: 72,
+    paddingBottom: 60,
   },
-  sectionLabel: {
+  heroContent: {
+    alignItems: "center",
+    gap: 20,
+  },
+  heroOverline: {
     color: colors.text,
     fontFamily: typefaces.body,
     fontSize: 11,
-    lineHeight: 14,
-    letterSpacing: 1.4,
+    letterSpacing: 2,
     textTransform: "uppercase" as any,
-    opacity: 0.7,
+    opacity: 0.35,
   },
-
-  // —— KPI cards ——
-  kpiRow: {
+  heroTitleRow: {
     flexDirection: "row",
-    gap: 12,
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 10,
     flexWrap: "wrap",
   },
-  kpiCard: {
-    flex: 1,
-    minWidth: 200,
-    maxWidth: 320,
+  heroH1: {
+    color: colors.textStrong,
+    fontFamily: typefaces.display,
+    fontSize: 42,
+    fontWeight: "700",
+    letterSpacing: -0.5,
+    textAlign: "center",
+    lineHeight: 48,
   },
-  kpiCardLabel: {
+  heroH1Accent: {
+    color: colors.accent,
+  },
+  heroGemIcon: {
+    opacity: 0.8,
+  },
+  heroBody: {
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 15,
+    lineHeight: 24,
+    opacity: 0.65,
+    maxWidth: 500,
+    textAlign: "center",
+  },
+  scrollHint: {
+    alignItems: "center",
+    gap: 6,
+    marginTop: 4,
+    opacity: 0.3,
+  },
+  scrollHintLine: {
+    width: 1,
+    height: 20,
+    backgroundColor: "rgba(255,255,255,0.4)",
+  },
+  scrollHintText: {
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 11,
+  },
+
+  // —— Country selector ——
+  countrySelectorWrap: {
+    alignSelf: "center",
+    width: "100%",
+    maxWidth: 420,
+    gap: 8,
+  },
+  countrySelectorPill: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderRadius: 999,
+    borderWidth: 0.5,
+    borderColor: "rgba(117,82,107,0.5)",
+    backgroundColor: "rgba(255,255,255,0.04)",
+  },
+  countrySelectorText: {
+    flex: 1,
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 14,
+  },
+  countrySelectorChevron: {
+    color: colors.text,
+    fontSize: 11,
+    opacity: 0.6,
+  },
+  countryDropdown: {
+    borderRadius: 12,
+    borderWidth: 0.5,
+    borderColor: "rgba(117,82,107,0.3)",
+    backgroundColor: colors.backgroundRaised,
+    maxHeight: 200,
+    overflow: "hidden",
+  },
+  countryDropdownItem: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderBottomWidth: 0.5,
+    borderBottomColor: "rgba(117,130,160,0.1)",
+  },
+  countryDropdownItemSelected: {
+    backgroundColor: "rgba(117,82,107,0.15)",
+  },
+  countryDropdownName: {
+    flex: 1,
+    color: colors.textStrong,
+    fontFamily: typefaces.body,
+    fontSize: 13,
+  },
+  countryDropdownScore: {
     color: colors.text,
     fontFamily: typefaces.body,
     fontSize: 12,
-    lineHeight: 16,
-    opacity: 0.72,
+    opacity: 0.7,
   },
-  kpiHeadlineRow: {
+  countryBanner: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    borderRadius: 12,
+    borderWidth: 0.5,
+    borderColor: "rgba(117,82,107,0.4)",
+    backgroundColor: "rgba(117,82,107,0.08)",
+    gap: 10,
+  },
+  countryBannerLeft: {
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: 8,
+  },
+  countryBannerDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: colors.accent,
+    marginTop: 5,
+  },
+  countryBannerText: {
+    flex: 1,
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 13,
+    lineHeight: 19,
+  },
+  countryBannerName: {
+    color: colors.accent,
+    fontWeight: "500",
+  },
+  countryBannerClear: {
+    paddingLeft: 8,
+  },
+  countryBannerClearText: {
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 12,
+    opacity: 0.6,
+  },
+
+  // —— Chapter ——
+  chapterWrap: {
+    paddingVertical: 56,
+  },
+  chapterElevated: {
+    backgroundColor: "rgba(255,255,255,0.015)",
+  },
+  chapterLabelRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    marginBottom: 28,
+  },
+  chapterCircle: {
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: "rgba(117,82,107,0.6)",
+    backgroundColor: "rgba(117,82,107,0.08)",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  chapterNumber: {
+    color: colors.accent,
+    fontFamily: typefaces.body,
+    fontSize: 12,
+    fontWeight: "700",
+  },
+  chapterTitle: {
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 12,
+    letterSpacing: 1.4,
+    textTransform: "uppercase" as any,
+    fontWeight: "500",
+    opacity: 0.75,
+  },
+
+  // —— Two-column layout ——
+  chapterTwoCol: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 28,
+    marginBottom: 32,
+    alignItems: "flex-start",
+  },
+  chapterLeft: {
+    minWidth: 180,
+    maxWidth: 220,
+    flex: 0,
+  },
+  chapterRight: {
+    flex: 1,
+    minWidth: 260,
+    gap: 16,
+  },
+
+  // —— Pull stat (poster-scale typography) ——
+  pullStat: {
+    gap: 8,
+  },
+  pullStatDisplay: {
     flexDirection: "row",
     alignItems: "baseline",
     flexWrap: "wrap",
   },
-  kpiHeadlineNumber: {
-    color: colors.textStrong,
+  pullStatNumber: {
+    color: colors.accent,
     fontFamily: typefaces.display,
-    fontSize: 52,
-    lineHeight: 56,
+    fontSize: 108,
+    fontWeight: "700",
+    letterSpacing: -4,
+    lineHeight: 108,
   },
-  kpiHeadlineUnit: {
-    color: colors.text,
+  pullStatUnit: {
+    color: colors.accent,
     fontFamily: typefaces.display,
-    fontSize: 22,
-    lineHeight: 28,
+    fontSize: 64,
+    fontWeight: "700",
+    letterSpacing: -2,
+    lineHeight: 72,
     marginLeft: 2,
   },
-  kpiIsolationName: {
-    color: colors.textStrong,
-    fontFamily: typefaces.display,
-    fontSize: 36,
-    lineHeight: 40,
-  },
-  kpiCardBody: {
+  pullStatContext: {
     color: colors.text,
     fontFamily: typefaces.body,
-    fontSize: 13,
-    lineHeight: 18,
-  },
-  kpiBadge: {
-    alignSelf: "flex-start",
-    borderRadius: 999,
-    paddingHorizontal: 10,
-    paddingVertical: 4,
-  },
-  kpiBadgeText: {
-    fontFamily: typefaces.body,
-    fontSize: 12,
-    lineHeight: 16,
-    fontWeight: "600",
-  },
-  kpiMedianRow: {
-    borderRadius: 999,
-    borderWidth: 1,
-    borderColor: colors.border,
-    alignSelf: "flex-start",
-    paddingHorizontal: 10,
-    paddingVertical: 4,
-  },
-  kpiMedianText: {
-    color: colors.textStrong,
-    fontFamily: typefaces.body,
-    fontSize: 12,
-    lineHeight: 16,
-  },
-  kpiExplainer: {
-    color: colors.text,
-    fontFamily: typefaces.body,
-    fontSize: 12,
-    lineHeight: 17,
-    opacity: 0.75,
-    borderTopWidth: 1,
-    borderTopColor: "rgba(117,130,160,0.2)",
-    paddingTop: 10,
-    marginTop: 2,
-  },
-
-  // —— KPI Vinyl mini ——
-  kpiVinylMini: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 10,
-    borderRadius: 12,
-    borderWidth: 1,
-    borderColor: colors.border,
-    backgroundColor: "rgba(22,26,38,0.4)",
-    padding: 10,
-  },
-  kpiVinylAlbumArt: {
-    width: 40,
-    height: 40,
-    borderRadius: 8,
-    backgroundColor: "rgba(108,119,142,0.3)",
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  kpiVinylRecord: {
-    width: 20,
-    height: 20,
-    borderRadius: 10,
-    backgroundColor: "rgba(15,16,21,0.8)",
-    borderWidth: 4,
-    borderColor: "rgba(108,119,142,0.5)",
-  },
-  kpiVinylInfo: {
-    flex: 1,
-    gap: 2,
-  },
-  kpiVinylTitle: {
-    color: colors.textStrong,
-    fontFamily: typefaces.display,
     fontSize: 14,
-    lineHeight: 17,
+    lineHeight: 21,
+    maxWidth: 220,
+    opacity: 0.45,
+    marginTop: 4,
   },
-  kpiVinylArtist: {
+
+  // —— Argument text ——
+  argument: {
     color: colors.text,
     fontFamily: typefaces.body,
-    fontSize: 12,
-    lineHeight: 15,
-    opacity: 0.8,
+    fontSize: 15,
+    lineHeight: 26,
   },
-  kpiVinylDateBadge: {
-    backgroundColor: colors.accent,
-    borderRadius: 6,
-    paddingHorizontal: 6,
-    paddingVertical: 4,
+  argBold: {
+    color: colors.textStrong,
+    fontWeight: "500",
+  },
+
+  // —— CTA row ——
+  ctaRow: {
+    flexDirection: "row",
+    gap: 12,
+    flexWrap: "wrap",
     alignItems: "center",
   },
-  kpiVinylDateText: {
-    color: colors.textStrong,
-    fontFamily: typefaces.body,
-    fontSize: 10,
-    lineHeight: 13,
-    textAlign: "center",
-    fontWeight: "700",
+  ctaButton: {
+    paddingVertical: 10,
+    paddingHorizontal: 18,
+    borderRadius: 999,
+    borderWidth: 1,
   },
-
-  // —— Chart rows ——
-  chartRow: {
-    flexDirection: "row",
-    gap: 16,
-    flexWrap: "wrap",
-    alignItems: "stretch",
+  ctaButtonPrimary: {
+    borderColor: "rgba(117,82,107,0.6)",
+    backgroundColor: "rgba(117,82,107,0.12)",
   },
-  chartCardWide: {
-    flex: 1.3,
-    minWidth: 380,
-    minHeight: 440,
+  ctaButtonSecondary: {
+    borderColor: "rgba(117,130,160,0.25)",
+    backgroundColor: "transparent",
   },
-  chartCardNarrow: {
-    flex: 0.9,
-    minWidth: 300,
-    minHeight: 440,
+  ctaButtonHovered: {
+    backgroundColor: "rgba(117,82,107,0.08)",
   },
-  chartCardHalf: {
-    flex: 1,
-    minWidth: 320,
-    minHeight: 400,
-  },
-
-  // —— Recharts wrapper ——
-  chartContainer: {
-    height: 220,
-  },
-
-  // —— Explainer text in chart cards ——
-  chartExplainer: {
-    color: colors.text,
+  ctaButtonText: {
     fontFamily: typefaces.body,
     fontSize: 13,
-    lineHeight: 18,
+    fontWeight: "500",
+  },
+  ctaButtonTextPrimary: {
+    color: colors.accent,
+  },
+  ctaButtonTextSecondary: {
+    color: colors.text,
     opacity: 0.75,
   },
-  
-  // —— Footnote text in chart cards ——
-  chartFootnote: {
-    color: colors.text,
+
+  // —— Warning tags ——
+  warningTagRow: {
+    flexDirection: "row",
+    gap: 8,
+    flexWrap: "wrap",
+  },
+  warningTag: {
+    borderRadius: 999,
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderWidth: 1,
+  },
+  warningTagOrange: {
+    backgroundColor: "rgba(251,146,60,0.12)",
+    borderColor: "rgba(251,146,60,0.35)",
+  },
+  warningTagBlue: {
+    backgroundColor: "rgba(99,179,237,0.12)",
+    borderColor: "rgba(99,179,237,0.35)",
+  },
+  warningTagText: {
     fontFamily: typefaces.body,
     fontSize: 11,
     lineHeight: 15,
-    opacity: 0.55,
-    paddingTop: 6,
   },
 
-  // —— Legend ——
+  // —— Chapter card (chart wrapper) ——
+  chapterCard: {
+    backgroundColor: "rgba(255,255,255,0.04)",
+    borderWidth: 0.5,
+    borderColor: "rgba(255,255,255,0.08)",
+    borderRadius: 12,
+    padding: 20,
+    gap: 12,
+  },
+  chapterCardLabel: {
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 12,
+    letterSpacing: 0.8,
+    textTransform: "uppercase" as any,
+    opacity: 0.25,
+  },
+
+  // —— Pull quote (after trend chart) ——
+  pullQuote: {
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 13,
+    lineHeight: 20,
+    fontStyle: "italic",
+    opacity: 0.35,
+    borderLeftWidth: 2,
+    borderLeftColor: "rgba(117,82,107,0.25)",
+    paddingLeft: 12,
+    marginTop: 12,
+  },
+
+  // —— KPI flip cards ——
+  kpiGrid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 10,
+  },
+  kpiCard: {
+    flex: 1,
+    minWidth: 180,
+    flexDirection: "row",
+    backgroundColor: "rgba(255,255,255,0.04)",
+    borderWidth: 0.5,
+    borderColor: "rgba(255,255,255,0.08)",
+    borderRadius: 10,
+    minHeight: 80,
+    overflow: "hidden",
+    cursor: "pointer" as any,
+  },
+  kpiCardFlipped: {
+    backgroundColor: "rgba(117,82,107,0.08)",
+    borderColor: "rgba(117,82,107,0.25)",
+  },
+  kpiAccentBar: {
+    width: 3,
+    alignSelf: "stretch",
+  },
+  kpiContent: {
+    flex: 1,
+    padding: 12,
+  },
+  kpiFront: {
+    gap: 4,
+  },
+  kpiBack: {
+    gap: 8,
+  },
+  kpiLabel: {
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 11,
+    opacity: 0.6,
+  },
+  kpiNumber: {
+    color: colors.textStrong,
+    fontFamily: typefaces.display,
+    fontSize: 28,
+    fontWeight: "700",
+    lineHeight: 32,
+  },
+  kpiSublabel: {
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 12,
+    lineHeight: 16,
+  },
+  kpiSecondary: {
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 10,
+    opacity: 0.5,
+  },
+  kpiFlipHint: {
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 10,
+    opacity: 0.35,
+    textAlign: "right",
+    marginTop: 6,
+  },
+  kpiBackTitle: {
+    color: colors.textStrong,
+    fontFamily: typefaces.display,
+    fontSize: 13,
+    fontWeight: "600",
+  },
+  kpiBackBody: {
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 12,
+    lineHeight: 17,
+    opacity: 0.75,
+  },
+  kpiCta: {
+    color: colors.accent,
+    fontFamily: typefaces.body,
+    fontSize: 12,
+    fontWeight: "500",
+  },
+
+  // —— Song reference card (Chapter 4) ——
+  songRefCard: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    padding: 12,
+    borderRadius: 10,
+    borderWidth: 0.5,
+    borderColor: "rgba(255,255,255,0.08)",
+    backgroundColor: "rgba(255,255,255,0.04)",
+  },
+  songRefSwatch: {
+    width: 36,
+    height: 36,
+    borderRadius: 6,
+  },
+  songRefInfo: {
+    flex: 1,
+    gap: 2,
+  },
+  songRefTitle: {
+    color: colors.textStrong,
+    fontFamily: typefaces.body,
+    fontSize: 13,
+    fontWeight: "500",
+  },
+  songRefArtist: {
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 11,
+    opacity: 0.7,
+  },
+  songRefCount: {
+    alignItems: "flex-end",
+    gap: 1,
+  },
+  songRefNumber: {
+    color: colors.accent,
+    fontFamily: typefaces.display,
+    fontSize: 24,
+    fontWeight: "700",
+    lineHeight: 26,
+  },
+  songRefCountLabel: {
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 10,
+    opacity: 0.6,
+  },
+
+  // —— Chart shared ——
+  chartShell: {
+    gap: 10,
+  },
+  chartContainer: {
+    height: 220,
+  },
   chartLegendRow: {
     flexDirection: "row",
-    gap: 16,
+    gap: 14,
     flexWrap: "wrap",
     paddingTop: 4,
+    alignItems: "center",
   },
   chartLegendItem: {
     flexDirection: "row",
@@ -1134,41 +2033,164 @@ const styles = StyleSheet.create({
   chartLegendText: {
     color: colors.text,
     fontFamily: typefaces.body,
-    fontSize: 12,
-    lineHeight: 16,
-    opacity: 0.8,
+    fontSize: 11,
+    lineHeight: 15,
+    opacity: 0.6,
   },
 
-  // —— Line/bar chart shell ——
-  lineChartShell: {
-    flex: 1,
-    minHeight: 240,
-    flexDirection: "column",
-    gap: 8,
-  },
+  // —— Isolation chart ——
   isolationChartShell: {
-    flex: 1,
     gap: 8,
   },
-
-  // —— Methodology note ——
-  methodologyCard: {
-    marginTop: 4,
+  isolationScrollContainer: {
+    maxHeight: 400,
+    overflow: "hidden",
   },
-  methodologyBody: {
+
+  // —— Conclusion ——
+  conclusionWrap: {
+    overflow: "hidden",
+    paddingVertical: 64,
+  },
+  conclusionTwoCol: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 48,
+    alignItems: "flex-start",
+  },
+  conclusionLeft: {
+    flex: 1,
+    minWidth: 260,
+    gap: 20,
+  },
+  conclusionRight: {
+    minWidth: 240,
+    flex: 0,
+  },
+  conclusionHeadline: {
+    color: colors.textStrong,
+    fontFamily: typefaces.display,
+    fontSize: 28,
+    fontWeight: "700",
+    lineHeight: 36,
+    letterSpacing: -0.3,
+  },
+  conclusionAccent: {
+    color: colors.accent,
+  },
+  conclusionBody: {
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 15,
+    lineHeight: 24,
+    opacity: 0.75,
+  },
+  conclusionCtas: {
+    flexDirection: "row",
+    gap: 12,
+    flexWrap: "wrap",
+  },
+
+  // —— Stat grid (conclusion) ——
+  statGrid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 10,
+  },
+  statCard: {
+    flex: 1,
+    minWidth: 110,
+    backgroundColor: "rgba(255,255,255,0.04)",
+    borderWidth: 0.5,
+    borderColor: "rgba(255,255,255,0.08)",
+    borderRadius: 10,
+    padding: 14,
+    gap: 4,
+  },
+  statNumber: {
+    color: colors.accent,
+    fontFamily: typefaces.display,
+    fontSize: 32,
+    fontWeight: "700",
+    lineHeight: 36,
+  },
+  statLabel: {
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 11,
+    lineHeight: 15,
+    opacity: 0.65,
+  },
+
+  // —— About This Data ——
+  aboutSection: {
+    paddingTop: 24,
+    paddingBottom: 48,
+    gap: 4,
+  },
+  aboutToggleRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingVertical: 8,
+    cursor: "pointer" as any,
+  },
+  aboutToggleLabel: {
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 14,
+    opacity: 0.75,
+  },
+  aboutChevron: {
+    color: colors.text,
+    fontSize: 11,
+    opacity: 0.5,
+  },
+  aboutEntries: {
+    gap: 0,
+    marginTop: 8,
+  },
+  aboutEntry: {
+    flexDirection: "row",
+    gap: 12,
+    paddingVertical: 14,
+    borderBottomWidth: 0.5,
+    borderBottomColor: "rgba(117,130,160,0.12)",
+    alignItems: "flex-start",
+  },
+  aboutIconWrap: {
+    width: 22,
+    height: 22,
+    borderRadius: 11,
+    alignItems: "center",
+    justifyContent: "center",
+    marginTop: 1,
+  },
+  aboutIconText: {
+    fontFamily: typefaces.body,
+    fontSize: 11,
+    fontWeight: "700",
+  },
+  aboutEntryContent: {
+    flex: 1,
+    gap: 3,
+  },
+  aboutEntryTitle: {
+    color: colors.textStrong,
+    fontFamily: typefaces.body,
+    fontSize: 13,
+    fontWeight: "500",
+    lineHeight: 18,
+  },
+  aboutEntryBody: {
     color: colors.text,
     fontFamily: typefaces.body,
     fontSize: 13,
-    lineHeight: 19,
-    opacity: 0.75,
-  },
-  methodologyBold: {
-    color: colors.textStrong,
-    fontWeight: "600",
-    opacity: 1,
+    lineHeight: 18,
+    opacity: 0.7,
   },
 
-  // —— Loading / error state ——
+  // —— Loading / error ——
   statusShell: {
     flex: 1,
     alignItems: "center",


### PR DESCRIPTION
## Summary

Three categories of changes: a major dashboard rewrite with full API data hookup and narrative
redesign, backend reliability improvements, and QA documentation for two newly identified
data quality findings.

---

## Files Changed

| File | Change |
|------|--------|
| `hidden-gem-music-app/src/screens/DashboardScreen.web.tsx` | Full rewrite — live API data, new narrative layout |
| `backend/Capstone.Api/Infrastructure/Repositories/SqlServerRepository.cs` | Increased command timeout to 120s |
| `backend/Capstone.API/SQL Scripts/read/sp_GetDiscoverPageInfo.sql` | Performance fix — sargable date range + removed bad ISO filter |
| `Documents/.../adr-discovery-gap-data-quality.md` | Issue 4 added — Viral 50 / Top 200 conflation analysis |
| `Documents/.../qa-findings-log-2026-04-29.md` | Issue 4 entry added |
| `Documents/.../dashboard-about-this-data-copy.md` | Known limitation copy updated |

---

## Dashboard Rewrite — `DashboardScreen.web.tsx`

Complete rewrite of the dashboard from a static placeholder to a live, API-driven narrative
screen. Previous version used mock data and a generic layout. New version:

- Fetches all metrics from the dashboard API on mount (`loadOverlapRate`, `loadOverlapTrend`,
  `loadDiscoveryGap`, `loadIsolationLeader`, `loadIsolationRanking`, `loadPeakReach`)
- Organized into a four-chapter narrative structure ("Music Borders" framing)
- Includes recharts visualizations (overlap trend line, discovery gap distribution histogram,
  isolation ranking bar chart)
- KPI flip cards for hero stats with 108px pull-quote numbers
- All values sourced from API — no mock data dependencies remain in this screen
- Props interface changed to `Record<string, never>` — screen is fully self-contained

**Note for reviewers:** `App.tsx` was updated separately to remove stale props
(`year`, `metrics`, `countries`) previously passed to this screen.

---

## Backend — `SqlServerRepository.cs`

Added `command.CommandTimeout = 120` to all three `GetDataAsync` / `GetDataSetsAsync`
overloads. The default 30-second timeout was causing `sp_GetDiscoverPageInfo` to fail
under load on larger datasets.

---

## SQL — `sp_GetDiscoverPageInfo`

Two fixes:

- **Performance:** Replaced `YEAR(ce.snapshot_date) = @Year` with a sargable date range
  (`snapshot_date >= DATEFROMPARTS(@Year, 1, 1) AND snapshot_date < DATEFROMPARTS(@Year + 1, 1, 1)`).
  The original predicate caused a full table scan on `ChartEntry` — this allows SQL Server
  to use an index on `snapshot_date`.
- **Filter:** Removed `AND LEN(LTRIM(RTRIM(c.iso_code))) = 2` which was incorrectly
  excluding valid countries with whitespace in their ISO code column.

> **Note:** Re-run this SP in SSMS against your local database to apply the performance fix.

---

## Documentation

### Issue 4 — Viral 50 / Top 200 Chart Type Conflation

Identified during dashboard design review. All SPs are functioning correctly — this is a
measurement design concern, not a logic bug. Key implications:

- Discovery Gap mean (38d) / median (4d) are compressed by Viral 50 simultaneous-spread events
- Global Overlap Rate (26%) is inflated by sharing behavior rather than adoption
- Peak Cross-Regional Reach (70 countries — *abcdefu*) is almost certainly a Viral 50 result
- DS1 average countries per song (2.9–3.2) is pulled upward throughout

No SP changes made. Decision: document prominently and flag for future iteration.
Recommended future fix is a `@ChartTypeFilter` parameter on the gap SPs (WHERE clause
only, no repopulation required). See ADR for full SQL pattern.
Working on quick fix solutions

---

## Known Open Issues

- `YearSelector.tsx` is hardcoded to `mockData.availableYears` (1975–2021) — cannot
  navigate to 2023–2025. Pre-existing, out of scope for this PR.
- Issue 4 future fixes (chart type filter, UI toggle) are documented in the ADR but
  not currently implemented.
