### PR TITLE
92-Cross Check Error Handling

### DIFF
--- a/Documents/QA-log.md
+++ b/Documents/QA-log.md
@@ -1,0 +1,33 @@
+# QA Log
+## HiddenGemMusic Capstone
+
+---
+
+## 2026-05-13 — Backend Error Handling
+
+**Scope:** All 7 controllers
+
+### What I noticed
+
+While reviewing the AR 2023 `OperationCanceledException` error in the backend logs, I checked error handling across all controllers and found it was completely inconsistent — some had none at all.
+
+### What was wrong
+
+| Controller | Problem |
+|---|---|
+| `DashboardController` | No try-catch, no logger — all 7 endpoints unprotected |
+| `GlobeController` | No try-catch, no logger |
+| `MetadataController` | No try-catch, no logger |
+| `HiddenGemsController` | No try-catch, no logger, takes `CancellationToken` but never handled it |
+| `CountryController` | Had SqlException + Exception on all endpoints but was missing `OperationCanceledException` on 3 of 4 endpoints |
+
+`ComparisonController` and `DiscoveryController` were already fine.
+
+### What was fixed
+
+All controllers now consistently catch:
+- `SqlException` → 503 with a user-facing message + error log
+- `OperationCanceledException` (where a `CancellationToken` is in scope) → silent `EmptyResult()`, no log — this is normal client disconnection behavior, not an error
+- `Exception` → 500 with a user-facing message + error log
+
+Logger was injected into the four controllers that were missing it.

--- a/Documents/QA-log.md
+++ b/Documents/QA-log.md
@@ -31,3 +31,45 @@ All controllers now consistently catch:
 - `Exception` → 500 with a user-facing message + error log
 
 Logger was injected into the four controllers that were missing it.
+
+---
+
+## 2026-05-13 — CancellationToken Propagation
+
+**Scope:** All controllers, interfaces, repositories, and the SQL data layer
+
+### What I noticed
+
+While fixing controller error handling, I found that `CancellationToken` was being dropped before it ever reached the database. Controllers accepted the token and passed it to repositories, but `IDataRepository.GetDataAsync` / `GetDataSetsAsync` had no token parameter at all — so cancellation stopped at the repository boundary. SQL commands ran to completion even after the client disconnected.
+
+Additionally, even in repositories that already declared a token (CountryRepository, HiddenGemsRepository), some individual `_db` call sites weren't passing it through.
+
+### What was wrong
+
+| Layer | Problem |
+|---|---|
+| `IDataRepository` | No `CancellationToken` on any of the 3 methods — token could never reach SQL |
+| `SqlServerRepository` | `OpenAsync`, `ExecuteReaderAsync`, `ReadAsync`, `IsDBNullAsync`, `NextResultAsync` all called without a token |
+| `IGlobeRepository`, `IMetadataRepository` | No token on their methods |
+| `IComparisonRepository` | No token on either method |
+| `IDashboardRepository` | No token on any of the 7 methods |
+| `CountryRepository` | Token declared on public methods but dropped when calling `_db` — 5 call sites affected |
+| `HiddenGemsRepository` | Token declared but dropped at the `_db.GetDataAsync` call |
+| `DashboardController`, `GlobeController`, `MetadataController`, `ComparisonController`, `DiscoveryController` | No `CancellationToken` parameter on any endpoint — token was never in scope to begin with |
+
+### What was fixed
+
+- Added `CancellationToken cancellationToken = default` to all 3 `IDataRepository` methods
+- Updated `SqlServerRepository` to pass the token to every async DB call
+- Updated `MySqlRepository` signatures to match the interface
+- Added token to `IGlobeRepository`, `IMetadataRepository`, `IComparisonRepository`, and all 7 methods on `IDashboardRepository`
+- Updated all repository implementations to accept and pass the token to `_db` calls
+- Added `CancellationToken` parameter to all controller endpoints that were missing it — ASP.NET Core automatically binds this from `HttpContext.RequestAborted`
+- Added `OperationCanceledException` catch to all newly-updated controller endpoints
+- Threaded token through `DiscoveryController` to both its repo calls
+
+Token now flows end to end: browser cancels → ASP.NET cancels token → controller → repository → `_db` → SQL command interrupted.
+
+### Why it matters
+
+Without this, every cancelled request still held a live SQL connection open until the query finished. On fast queries this is invisible. On slow scans — like the genre sampling that caused the AR 2023 error — the server kept doing work and holding resources for a client that was already gone. With the fix, the database command is interrupted immediately when the client disconnects, freeing the connection and thread right away.

--- a/Documents/QA-log.md
+++ b/Documents/QA-log.md
@@ -73,3 +73,59 @@ Token now flows end to end: browser cancels → ASP.NET cancels token → contro
 ### Why it matters
 
 Without this, every cancelled request still held a live SQL connection open until the query finished. On fast queries this is invisible. On slow scans — like the genre sampling that caused the AR 2023 error — the server kept doing work and holding resources for a client that was already gone. With the fix, the database command is interrupted immediately when the client disconnects, freeing the connection and thread right away.
+
+---
+
+## 2026-05-13 — Model Nullability Audit
+
+**Scope:** All 20 model files across Dashboard, Comparison, Country, Globe, HiddenGems, and Shared folders
+
+### What I noticed
+
+Audited all models against their source stored procedures to check whether non-nullable value-type properties could actually receive NULL from the database.
+
+### What was wrong
+
+| Model | Property | Was | Should Be | Reason |
+|---|---|---|---|---|
+| `GlobalTrendPoint` | `OverlapPct` | `decimal` | `decimal?` | Gap rows in `sp_GetGlobalOverlapTrend` return NULL for all metric columns — Recharts uses `IsGap` to skip rendering these points |
+| `GlobalTrendPoint` | `AvgCountries` | `decimal` | `decimal?` | Same — gap row |
+| `GlobalTrendPoint` | `TotalUniqueSongs` | `int` | `int?` | Same — gap row |
+| `GlobalTrendPoint` | `SongsIn2Plus` | `int` | `int?` | Same — gap row |
+| `PeakReachKpi` | `PeakDate` | `DateOnly` | `DateOnly?` | `AsDateOnly` returned `DateOnly.MinValue` for NULL, masking missing dates instead of surfacing them |
+
+### What was fixed
+
+- Made 4 metric properties on `GlobalTrendPoint` nullable (`decimal?` / `int?`)
+- Made `PeakDate` on `PeakReachKpi` nullable (`DateOnly?`)
+- Updated `DashboardRepository` mapping for `GlobalTrendPoint` to call `AsNullableDecimal` and `AsNullableInt`
+- Updated `DashboardRepository` mapping for `PeakReachKpi` to call `AsNullableDateOnly`
+- Added `AsNullableDecimal` and `AsNullableDateOnly` private helper methods to `DashboardRepository`
+- Removed the old non-nullable `AsDateOnly` helper (no longer used)
+
+### All other models — no issues found
+
+All remaining non-nullable value-type properties (`int` counts, `decimal` percentages, `double` lat/long, chart ranks) are backed by columns that are structurally guaranteed non-null by their SPs or are aggregates that always produce a value.
+
+---
+
+## How to Test (Branch: `67-cross-check-interfaces-controllers-against-sps`)
+
+### Error handling
+
+1. Start the API and make a valid request to any endpoint (e.g. `GET /api/dashboard/overlap-rate?start=2017-01-01&end=2021-12-31`)
+2. Navigate away immediately / cancel the request — the server log should produce **no error entry** (silent `EmptyResult`, not a stack trace)
+3. To verify 503: temporarily take the DB offline and hit any endpoint — should return `503` with the user-facing message, not a 500 or unhandled exception page
+4. Sanity check: every controller action is wrapped in try-catch — no unprotected endpoints
+
+### CancellationToken propagation
+
+1. Open SQL Server Activity Monitor or query `sys.dm_exec_requests` before and after a cancelled request
+2. Hit a slow endpoint (Hidden Gems with a large dataset, or genre sampling on a country not yet cached) and navigate away immediately
+3. The in-flight SQL session should disappear from `dm_exec_requests` promptly — previously it would run to completion regardless of client disconnect
+
+### Model nullability
+
+1. Call `GET /api/dashboard/overlap-trend?start=2017-01-01&end=2024-12-31` — the response should include rows where `overlapPct`, `avgCountries`, `totalUniqueSongs`, and `songsIn2Plus` are `null` (not `0`) when `isGap` is `true`
+2. Verify the dashboard gap region renders as a dashed line, not a flat zero line through the data gap
+3. Call `GET /api/dashboard/peak-reach?start=2017-01-01&end=2024-12-31` — `peakDate` should be `null` if the SP returns NULL, not `"0001-01-01"`

--- a/backend/Capstone.API/Controllers/ComparisonController.cs
+++ b/backend/Capstone.API/Controllers/ComparisonController.cs
@@ -41,7 +41,8 @@ namespace Capstone.API.Controllers
         public async Task<IActionResult> GetCountryComparison(
             [FromQuery] string countryA,
             [FromQuery] string countryB,
-            [FromQuery] int year = 2021)
+            [FromQuery] int year = 2021,
+            CancellationToken cancellationToken = default)
         {
             if (!TryValidateInputs(countryA, countryB, year, out var validationError))
                 return BadRequest(new { message = validationError });
@@ -51,7 +52,8 @@ namespace Capstone.API.Controllers
                 var result = await _repo.GetCountryComparisonAsync(
                     countryA.ToUpperInvariant(),
                     countryB.ToUpperInvariant(),
-                    year);
+                    year,
+                    cancellationToken);
 
                 if (result == null)
                     return NotFound();
@@ -67,6 +69,10 @@ namespace Capstone.API.Controllers
                     countryB,
                     year);
                 return StatusCode(503, new { message = "Database temporarily unavailable while retrieving country comparison data." });
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                return new EmptyResult();
             }
             catch (Exception ex)
             {
@@ -91,7 +97,8 @@ namespace Capstone.API.Controllers
         public async Task<IActionResult> GetComparisonHiddenGems(
             [FromQuery] string countryA,
             [FromQuery] string countryB,
-            [FromQuery] int year = 2021)
+            [FromQuery] int year = 2021,
+            CancellationToken cancellationToken = default)
         {
             if (!TryValidateInputs(countryA, countryB, year, out var validationError))
                 return BadRequest(new { message = validationError });
@@ -101,7 +108,8 @@ namespace Capstone.API.Controllers
                 var result = await _repo.GetComparisonHiddenGemsAsync(
                     countryA.ToUpperInvariant(),
                     countryB.ToUpperInvariant(),
-                    year);
+                    year,
+                    cancellationToken);
                 return Ok(result);
             }
             catch (SqlException ex)
@@ -113,6 +121,10 @@ namespace Capstone.API.Controllers
                     countryB,
                     year);
                 return StatusCode(503, new { message = "Database temporarily unavailable while retrieving comparison hidden gems data." });
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                return new EmptyResult();
             }
             catch (Exception ex)
             {

--- a/backend/Capstone.API/Controllers/CountryController.cs
+++ b/backend/Capstone.API/Controllers/CountryController.cs
@@ -70,6 +70,10 @@ namespace Capstone.API.Controllers
                 _logger.LogError(ex, "SQL error getting country profile for {CountryCode} year {Year}", code, year);
                 return StatusCode(503, new { message = "Database temporarily unavailable while retrieving country profile data." });
             }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                return new EmptyResult();
+            }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error getting country profile for {CountryCode} year {Year}", code, year);
@@ -102,6 +106,10 @@ namespace Capstone.API.Controllers
             {
                 _logger.LogError(ex, "SQL error getting hidden gems preview for {CountryCode} year {Year}", code, year);
                 return StatusCode(503, new { message = "Database temporarily unavailable while retrieving hidden gems preview data." });
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                return new EmptyResult();
             }
             catch (Exception ex)
             {
@@ -155,6 +163,10 @@ namespace Capstone.API.Controllers
             {
                 _logger.LogError(ex, "SQL error getting country songs for {CountryCode} year {Year} listType {ListType}", code, year, listType);
                 return StatusCode(503, new { message = "Database temporarily unavailable while retrieving country songs data." });
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                return new EmptyResult();
             }
             catch (Exception ex)
             {

--- a/backend/Capstone.API/Controllers/DashboardController.cs
+++ b/backend/Capstone.API/Controllers/DashboardController.cs
@@ -31,11 +31,12 @@ namespace Capstone.API.Controllers
         [HttpGet("overlap-rate")]
         public async Task<IActionResult> GetOverlapRate(
             [FromQuery] DateOnly start,
-            [FromQuery] DateOnly end)
+            [FromQuery] DateOnly end,
+            CancellationToken cancellationToken = default)
         {
             try
             {
-                var result = await _repo.GetOverlapRateAsync(start, end);
+                var result = await _repo.GetOverlapRateAsync(start, end, cancellationToken);
                 if (result == null)
                     return NotFound();
 
@@ -45,6 +46,10 @@ namespace Capstone.API.Controllers
             {
                 _logger.LogError(ex, "SQL error getting overlap rate for {Start} to {End}", start, end);
                 return StatusCode(503, new { message = "Database temporarily unavailable while retrieving global overlap rate data." });
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                return new EmptyResult();
             }
             catch (Exception ex)
             {
@@ -62,11 +67,12 @@ namespace Capstone.API.Controllers
         public async Task<IActionResult> GetDiscoveryGap(
             [FromQuery] DateOnly start,
             [FromQuery] DateOnly end,
-            [FromQuery] int minCountries = 2)
+            [FromQuery] int minCountries = 2,
+            CancellationToken cancellationToken = default)
         {
             try
             {
-                var result = await _repo.GetDiscoveryGapAsync(start, end, minCountries);
+                var result = await _repo.GetDiscoveryGapAsync(start, end, minCountries, cancellationToken);
                 if (result == null)
                     return NotFound();
 
@@ -76,6 +82,10 @@ namespace Capstone.API.Controllers
             {
                 _logger.LogError(ex, "SQL error getting discovery gap for {Start} to {End}", start, end);
                 return StatusCode(503, new { message = "Database temporarily unavailable while retrieving discovery gap data." });
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                return new EmptyResult();
             }
             catch (Exception ex)
             {
@@ -92,17 +102,22 @@ namespace Capstone.API.Controllers
         [HttpGet("gap-distribution")]
         public async Task<IActionResult> GetGapDistribution(
             [FromQuery] DateOnly start,
-            [FromQuery] DateOnly end)
+            [FromQuery] DateOnly end,
+            CancellationToken cancellationToken = default)
         {
             try
             {
-                var result = await _repo.GetGapDistributionAsync(start, end);
+                var result = await _repo.GetGapDistributionAsync(start, end, cancellationToken);
                 return Ok(result);
             }
             catch (SqlException ex)
             {
                 _logger.LogError(ex, "SQL error getting gap distribution for {Start} to {End}", start, end);
                 return StatusCode(503, new { message = "Database temporarily unavailable while retrieving discovery gap distribution data." });
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                return new EmptyResult();
             }
             catch (Exception ex)
             {
@@ -118,11 +133,12 @@ namespace Capstone.API.Controllers
         [HttpGet("isolation-leader")]
         public async Task<IActionResult> GetIsolationLeader(
             [FromQuery] DateOnly start,
-            [FromQuery] DateOnly end)
+            [FromQuery] DateOnly end,
+            CancellationToken cancellationToken = default)
         {
             try
             {
-                var result = await _repo.GetIsolationLeaderAsync(start, end);
+                var result = await _repo.GetIsolationLeaderAsync(start, end, cancellationToken);
                 if (result == null)
                     return NotFound();
 
@@ -132,6 +148,10 @@ namespace Capstone.API.Controllers
             {
                 _logger.LogError(ex, "SQL error getting isolation leader for {Start} to {End}", start, end);
                 return StatusCode(503, new { message = "Database temporarily unavailable while retrieving isolation leader data." });
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                return new EmptyResult();
             }
             catch (Exception ex)
             {
@@ -148,17 +168,22 @@ namespace Capstone.API.Controllers
         [HttpGet("isolation-ranking")]
         public async Task<IActionResult> GetIsolationRanking(
             [FromQuery] DateOnly start,
-            [FromQuery] DateOnly end)
+            [FromQuery] DateOnly end,
+            CancellationToken cancellationToken = default)
         {
             try
             {
-                var result = await _repo.GetIsolationRankingAsync(start, end);
+                var result = await _repo.GetIsolationRankingAsync(start, end, cancellationToken);
                 return Ok(result);
             }
             catch (SqlException ex)
             {
                 _logger.LogError(ex, "SQL error getting isolation ranking for {Start} to {End}", start, end);
                 return StatusCode(503, new { message = "Database temporarily unavailable while retrieving isolation ranking data." });
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                return new EmptyResult();
             }
             catch (Exception ex)
             {
@@ -175,11 +200,12 @@ namespace Capstone.API.Controllers
         [HttpGet("peak-reach")]
         public async Task<IActionResult> GetPeakReach(
             [FromQuery] DateOnly start,
-            [FromQuery] DateOnly end)
+            [FromQuery] DateOnly end,
+            CancellationToken cancellationToken = default)
         {
             try
             {
-                var result = await _repo.GetPeakReachAsync(start, end);
+                var result = await _repo.GetPeakReachAsync(start, end, cancellationToken);
                 if (result == null)
                     return NotFound();
 
@@ -189,6 +215,10 @@ namespace Capstone.API.Controllers
             {
                 _logger.LogError(ex, "SQL error getting peak reach for {Start} to {End}", start, end);
                 return StatusCode(503, new { message = "Database temporarily unavailable while retrieving peak reach data." });
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                return new EmptyResult();
             }
             catch (Exception ex)
             {
@@ -205,17 +235,22 @@ namespace Capstone.API.Controllers
         [HttpGet("overlap-trend")]
         public async Task<IActionResult> GetOverlapTrend(
             [FromQuery] DateOnly start,
-            [FromQuery] DateOnly end)
+            [FromQuery] DateOnly end,
+            CancellationToken cancellationToken = default)
         {
             try
             {
-                var result = await _repo.GetOverlapTrendAsync(start, end);
+                var result = await _repo.GetOverlapTrendAsync(start, end, cancellationToken);
                 return Ok(result);
             }
             catch (SqlException ex)
             {
                 _logger.LogError(ex, "SQL error getting overlap trend for {Start} to {End}", start, end);
                 return StatusCode(503, new { message = "Database temporarily unavailable while retrieving global overlap trend data." });
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                return new EmptyResult();
             }
             catch (Exception ex)
             {

--- a/backend/Capstone.API/Controllers/DashboardController.cs
+++ b/backend/Capstone.API/Controllers/DashboardController.cs
@@ -1,5 +1,6 @@
 using Capstone.API.Infrastructure.Interfaces;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Data.SqlClient;
 
 namespace Capstone.API.Controllers
 {
@@ -12,13 +13,15 @@ namespace Capstone.API.Controllers
     public class DashboardController : ControllerBase
     {
         private readonly IDashboardRepository _repo;
+        private readonly ILogger<DashboardController> _logger;
 
         /// <summary>
         /// Initializes a new instance of DashboardController.
         /// </summary>
-        public DashboardController(IDashboardRepository repo)
+        public DashboardController(IDashboardRepository repo, ILogger<DashboardController> logger)
         {
             _repo = repo;
+            _logger = logger;
         }
 
         /// <summary>
@@ -30,11 +33,24 @@ namespace Capstone.API.Controllers
             [FromQuery] DateOnly start,
             [FromQuery] DateOnly end)
         {
-            var result = await _repo.GetOverlapRateAsync(start, end);
-            if (result == null)
-                return NotFound();
+            try
+            {
+                var result = await _repo.GetOverlapRateAsync(start, end);
+                if (result == null)
+                    return NotFound();
 
-            return Ok(result);
+                return Ok(result);
+            }
+            catch (SqlException ex)
+            {
+                _logger.LogError(ex, "SQL error getting overlap rate for {Start} to {End}", start, end);
+                return StatusCode(503, new { message = "Database temporarily unavailable while retrieving global overlap rate data." });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error getting overlap rate for {Start} to {End}", start, end);
+                return StatusCode(500, new { message = "An unexpected error occurred while retrieving global overlap rate data." });
+            }
         }
 
         /// <summary>
@@ -48,11 +64,24 @@ namespace Capstone.API.Controllers
             [FromQuery] DateOnly end,
             [FromQuery] int minCountries = 2)
         {
-            var result = await _repo.GetDiscoveryGapAsync(start, end, minCountries);
-            if (result == null)
-                return NotFound();
+            try
+            {
+                var result = await _repo.GetDiscoveryGapAsync(start, end, minCountries);
+                if (result == null)
+                    return NotFound();
 
-            return Ok(result);
+                return Ok(result);
+            }
+            catch (SqlException ex)
+            {
+                _logger.LogError(ex, "SQL error getting discovery gap for {Start} to {End}", start, end);
+                return StatusCode(503, new { message = "Database temporarily unavailable while retrieving discovery gap data." });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error getting discovery gap for {Start} to {End}", start, end);
+                return StatusCode(500, new { message = "An unexpected error occurred while retrieving discovery gap data." });
+            }
         }
 
         /// <summary>
@@ -65,8 +94,21 @@ namespace Capstone.API.Controllers
             [FromQuery] DateOnly start,
             [FromQuery] DateOnly end)
         {
-            var result = await _repo.GetGapDistributionAsync(start, end);
-            return Ok(result);
+            try
+            {
+                var result = await _repo.GetGapDistributionAsync(start, end);
+                return Ok(result);
+            }
+            catch (SqlException ex)
+            {
+                _logger.LogError(ex, "SQL error getting gap distribution for {Start} to {End}", start, end);
+                return StatusCode(503, new { message = "Database temporarily unavailable while retrieving discovery gap distribution data." });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error getting gap distribution for {Start} to {End}", start, end);
+                return StatusCode(500, new { message = "An unexpected error occurred while retrieving discovery gap distribution data." });
+            }
         }
 
         /// <summary>
@@ -78,11 +120,24 @@ namespace Capstone.API.Controllers
             [FromQuery] DateOnly start,
             [FromQuery] DateOnly end)
         {
-            var result = await _repo.GetIsolationLeaderAsync(start, end);
-            if (result == null)
-                return NotFound();
+            try
+            {
+                var result = await _repo.GetIsolationLeaderAsync(start, end);
+                if (result == null)
+                    return NotFound();
 
-            return Ok(result);
+                return Ok(result);
+            }
+            catch (SqlException ex)
+            {
+                _logger.LogError(ex, "SQL error getting isolation leader for {Start} to {End}", start, end);
+                return StatusCode(503, new { message = "Database temporarily unavailable while retrieving isolation leader data." });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error getting isolation leader for {Start} to {End}", start, end);
+                return StatusCode(500, new { message = "An unexpected error occurred while retrieving isolation leader data." });
+            }
         }
 
         /// <summary>
@@ -95,8 +150,21 @@ namespace Capstone.API.Controllers
             [FromQuery] DateOnly start,
             [FromQuery] DateOnly end)
         {
-            var result = await _repo.GetIsolationRankingAsync(start, end);
-            return Ok(result);
+            try
+            {
+                var result = await _repo.GetIsolationRankingAsync(start, end);
+                return Ok(result);
+            }
+            catch (SqlException ex)
+            {
+                _logger.LogError(ex, "SQL error getting isolation ranking for {Start} to {End}", start, end);
+                return StatusCode(503, new { message = "Database temporarily unavailable while retrieving isolation ranking data." });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error getting isolation ranking for {Start} to {End}", start, end);
+                return StatusCode(500, new { message = "An unexpected error occurred while retrieving isolation ranking data." });
+            }
         }
 
         /// <summary>
@@ -109,11 +177,24 @@ namespace Capstone.API.Controllers
             [FromQuery] DateOnly start,
             [FromQuery] DateOnly end)
         {
-            var result = await _repo.GetPeakReachAsync(start, end);
-            if (result == null)
-                return NotFound();
+            try
+            {
+                var result = await _repo.GetPeakReachAsync(start, end);
+                if (result == null)
+                    return NotFound();
 
-            return Ok(result);
+                return Ok(result);
+            }
+            catch (SqlException ex)
+            {
+                _logger.LogError(ex, "SQL error getting peak reach for {Start} to {End}", start, end);
+                return StatusCode(503, new { message = "Database temporarily unavailable while retrieving peak reach data." });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error getting peak reach for {Start} to {End}", start, end);
+                return StatusCode(500, new { message = "An unexpected error occurred while retrieving peak reach data." });
+            }
         }
 
         /// <summary>
@@ -126,8 +207,21 @@ namespace Capstone.API.Controllers
             [FromQuery] DateOnly start,
             [FromQuery] DateOnly end)
         {
-            var result = await _repo.GetOverlapTrendAsync(start, end);
-            return Ok(result);
+            try
+            {
+                var result = await _repo.GetOverlapTrendAsync(start, end);
+                return Ok(result);
+            }
+            catch (SqlException ex)
+            {
+                _logger.LogError(ex, "SQL error getting overlap trend for {Start} to {End}", start, end);
+                return StatusCode(503, new { message = "Database temporarily unavailable while retrieving global overlap trend data." });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error getting overlap trend for {Start} to {End}", start, end);
+                return StatusCode(500, new { message = "An unexpected error occurred while retrieving global overlap trend data." });
+            }
         }
     }
 }

--- a/backend/Capstone.API/Controllers/DiscoveryController.cs
+++ b/backend/Capstone.API/Controllers/DiscoveryController.cs
@@ -31,23 +31,27 @@ namespace Capstone.API.Controllers
         /// GET /api/discovery/countries?year={year}
         /// </summary>
         [HttpGet("countries")]
-        public async Task<IActionResult> GetDiscoveryCountries([FromQuery] int year = 2021)
+        public async Task<IActionResult> GetDiscoveryCountries([FromQuery] int year = 2021, CancellationToken cancellationToken = default)
         {
             try
             {
-                var availableYears = (await _metadataRepo.GetAvailableYearsAsync()).ToHashSet();
+                var availableYears = (await _metadataRepo.GetAvailableYearsAsync(cancellationToken)).ToHashSet();
                 if (!availableYears.Contains(year))
                 {
                     return BadRequest(new { message = $"Year {year} is unavailable in this dataset." });
                 }
 
-                var result = await _repo.GetGlobeSummaryAsync(year);
+                var result = await _repo.GetGlobeSummaryAsync(year, cancellationToken);
                 return Ok(result);
             }
             catch (SqlException ex)
             {
                 _logger.LogError(ex, "SQL error getting discovery countries for year {Year}", year);
                 return StatusCode(503, new { message = "Database temporarily unavailable while retrieving discovery countries data." });
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                return new EmptyResult();
             }
             catch (Exception ex)
             {

--- a/backend/Capstone.API/Controllers/GlobeController.cs
+++ b/backend/Capstone.API/Controllers/GlobeController.cs
@@ -29,17 +29,21 @@ namespace Capstone.API.Controllers
         /// </summary>
         /// <param name="year">The chart year to display. Defaults to 2021 (last year of Dataset 1).</param>
         [HttpGet]
-        public async Task<IActionResult> GetGlobeSummary([FromQuery] int year = 2021)
+        public async Task<IActionResult> GetGlobeSummary([FromQuery] int year = 2021, CancellationToken cancellationToken = default)
         {
             try
             {
-                var result = await _repo.GetGlobeSummaryAsync(year);
+                var result = await _repo.GetGlobeSummaryAsync(year, cancellationToken);
                 return Ok(result);
             }
             catch (SqlException ex)
             {
                 _logger.LogError(ex, "SQL error getting globe summary for year {Year}", year);
                 return StatusCode(503, new { message = "Database temporarily unavailable while retrieving globe data." });
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                return new EmptyResult();
             }
             catch (Exception ex)
             {

--- a/backend/Capstone.API/Controllers/GlobeController.cs
+++ b/backend/Capstone.API/Controllers/GlobeController.cs
@@ -1,5 +1,6 @@
 using Capstone.API.Infrastructure.Interfaces;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Data.SqlClient;
 
 namespace Capstone.API.Controllers
 {
@@ -11,13 +12,15 @@ namespace Capstone.API.Controllers
     public class GlobeController : ControllerBase
     {
         private readonly IGlobeRepository _repo;
+        private readonly ILogger<GlobeController> _logger;
 
         /// <summary>
         /// Initializes a new instance of GlobeController.
         /// </summary>
-        public GlobeController(IGlobeRepository repo)
+        public GlobeController(IGlobeRepository repo, ILogger<GlobeController> logger)
         {
             _repo = repo;
+            _logger = logger;
         }
 
         /// <summary>
@@ -28,8 +31,21 @@ namespace Capstone.API.Controllers
         [HttpGet]
         public async Task<IActionResult> GetGlobeSummary([FromQuery] int year = 2021)
         {
-            var result = await _repo.GetGlobeSummaryAsync(year);
-            return Ok(result);
+            try
+            {
+                var result = await _repo.GetGlobeSummaryAsync(year);
+                return Ok(result);
+            }
+            catch (SqlException ex)
+            {
+                _logger.LogError(ex, "SQL error getting globe summary for year {Year}", year);
+                return StatusCode(503, new { message = "Database temporarily unavailable while retrieving globe data." });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error getting globe summary for year {Year}", year);
+                return StatusCode(500, new { message = "An unexpected error occurred while retrieving globe data." });
+            }
         }
     }
 }

--- a/backend/Capstone.API/Controllers/HiddenGemsController.cs
+++ b/backend/Capstone.API/Controllers/HiddenGemsController.cs
@@ -1,5 +1,6 @@
 using Capstone.API.Infrastructure.Interfaces;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Data.SqlClient;
 
 namespace Capstone.API.Controllers
 {
@@ -11,13 +12,15 @@ namespace Capstone.API.Controllers
     public class HiddenGemsController : ControllerBase
     {
         private readonly IHiddenGemsRepository _repo;
+        private readonly ILogger<HiddenGemsController> _logger;
 
         /// <summary>
         /// Initializes a new instance of HiddenGemsController.
         /// </summary>
-        public HiddenGemsController(IHiddenGemsRepository repo)
+        public HiddenGemsController(IHiddenGemsRepository repo, ILogger<HiddenGemsController> logger)
         {
             _repo = repo;
+            _logger = logger;
         }
 
         /// <summary>
@@ -42,8 +45,25 @@ namespace Capstone.API.Controllers
             if (page < 1) page = 1;
             if (pageSize < 1 || pageSize > 100) pageSize = 25;
 
-            var result = await _repo.GetHiddenGemsAsync(code.ToUpper(), year, minCountries, page, pageSize, cancellationToken);
-            return Ok(result);
+            try
+            {
+                var result = await _repo.GetHiddenGemsAsync(code.ToUpper(), year, minCountries, page, pageSize, cancellationToken);
+                return Ok(result);
+            }
+            catch (SqlException ex)
+            {
+                _logger.LogError(ex, "SQL error getting hidden gems for {CountryCode} year {Year}", code, year);
+                return StatusCode(503, new { message = "Database temporarily unavailable while retrieving hidden gems data." });
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                return new EmptyResult();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error getting hidden gems for {CountryCode} year {Year}", code, year);
+                return StatusCode(500, new { message = "An unexpected error occurred while retrieving hidden gems data." });
+            }
         }
     }
 }

--- a/backend/Capstone.API/Controllers/MetadataController.cs
+++ b/backend/Capstone.API/Controllers/MetadataController.cs
@@ -1,5 +1,6 @@
 using Capstone.API.Infrastructure.Interfaces;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Data.SqlClient;
 
 namespace Capstone.API.Controllers
 {
@@ -11,13 +12,15 @@ namespace Capstone.API.Controllers
     public class MetadataController : ControllerBase
     {
         private readonly IMetadataRepository _repo;
+        private readonly ILogger<MetadataController> _logger;
 
         /// <summary>
         /// Initializes a new instance of MetadataController.
         /// </summary>
-        public MetadataController(IMetadataRepository repo)
+        public MetadataController(IMetadataRepository repo, ILogger<MetadataController> logger)
         {
             _repo = repo;
+            _logger = logger;
         }
 
         /// <summary>
@@ -27,8 +30,21 @@ namespace Capstone.API.Controllers
         [HttpGet("years")]
         public async Task<IActionResult> GetAvailableYears()
         {
-            var years = await _repo.GetAvailableYearsAsync();
-            return Ok(years);
+            try
+            {
+                var years = await _repo.GetAvailableYearsAsync();
+                return Ok(years);
+            }
+            catch (SqlException ex)
+            {
+                _logger.LogError(ex, "SQL error getting available years");
+                return StatusCode(503, new { message = "Database temporarily unavailable while retrieving available years." });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error getting available years");
+                return StatusCode(500, new { message = "An unexpected error occurred while retrieving available years." });
+            }
         }
     }
 }

--- a/backend/Capstone.API/Controllers/MetadataController.cs
+++ b/backend/Capstone.API/Controllers/MetadataController.cs
@@ -28,17 +28,21 @@ namespace Capstone.API.Controllers
         /// GET /api/metadata/years
         /// </summary>
         [HttpGet("years")]
-        public async Task<IActionResult> GetAvailableYears()
+        public async Task<IActionResult> GetAvailableYears(CancellationToken cancellationToken = default)
         {
             try
             {
-                var years = await _repo.GetAvailableYearsAsync();
+                var years = await _repo.GetAvailableYearsAsync(cancellationToken);
                 return Ok(years);
             }
             catch (SqlException ex)
             {
                 _logger.LogError(ex, "SQL error getting available years");
                 return StatusCode(503, new { message = "Database temporarily unavailable while retrieving available years." });
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                return new EmptyResult();
             }
             catch (Exception ex)
             {

--- a/backend/Capstone.API/Infrastructure/Interfaces/IComparisonRepository.cs
+++ b/backend/Capstone.API/Infrastructure/Interfaces/IComparisonRepository.cs
@@ -14,7 +14,7 @@ namespace Capstone.API.Infrastructure.Interfaces
         /// <param name="countryCodeA">2-letter ISO code for Country A.</param>
         /// <param name="countryCodeB">2-letter ISO code for Country B.</param>
         /// <param name="year">The chart year to filter by.</param>
-        Task<ComparisonResult?> GetCountryComparisonAsync(string countryCodeA, string countryCodeB, int year);
+        Task<ComparisonResult?> GetCountryComparisonAsync(string countryCodeA, string countryCodeB, int year, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Returns songs trending in surrounding regions that are absent from both compared countries.
@@ -23,6 +23,6 @@ namespace Capstone.API.Infrastructure.Interfaces
         /// <param name="countryCodeA">2-letter ISO code for Country A.</param>
         /// <param name="countryCodeB">2-letter ISO code for Country B.</param>
         /// <param name="year">The chart year to filter by.</param>
-        Task<IEnumerable<ComparisonHiddenGem>> GetComparisonHiddenGemsAsync(string countryCodeA, string countryCodeB, int year);
+        Task<IEnumerable<ComparisonHiddenGem>> GetComparisonHiddenGemsAsync(string countryCodeA, string countryCodeB, int year, CancellationToken cancellationToken = default);
     }
 }

--- a/backend/Capstone.API/Infrastructure/Interfaces/IDashboardRepository.cs
+++ b/backend/Capstone.API/Infrastructure/Interfaces/IDashboardRepository.cs
@@ -11,44 +11,44 @@ namespace Capstone.API.Infrastructure.Interfaces
         /// Returns KPI 1 — the percentage of charting songs that appeared in 2+ countries.
         /// Calls sp_GetGlobalOverlapRate.
         /// </summary>
-        Task<GlobalOverlapRateKpi?> GetOverlapRateAsync(DateOnly start, DateOnly end);
+        Task<GlobalOverlapRateKpi?> GetOverlapRateAsync(DateOnly start, DateOnly end, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Returns KPI 2 — average and median days before a song crosses into a second country.
         /// Calls sp_GetAverageDiscoveryGap.
         /// </summary>
         /// <param name="minCountries">Minimum countries a song must chart in to be included. Default is 2.</param>
-        Task<DiscoveryGapKpi?> GetDiscoveryGapAsync(DateOnly start, DateOnly end, int minCountries = 2);
+        Task<DiscoveryGapKpi?> GetDiscoveryGapAsync(DateOnly start, DateOnly end, int minCountries = 2, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Returns pre-bucketed histogram data for the Discovery Gap Distribution chart.
         /// Calls sp_GetDiscoveryGapDistribution. Buckets are computed in the DB, never in JavaScript.
         /// </summary>
-        Task<IEnumerable<DiscoveryGapBucket>> GetGapDistributionAsync(DateOnly start, DateOnly end);
+        Task<IEnumerable<DiscoveryGapBucket>> GetGapDistributionAsync(DateOnly start, DateOnly end, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Returns KPI 3 — the single most globally isolated country for the stat card.
         /// Calls sp_GetIsolationLeader.
         /// </summary>
-        Task<IsolationLeaderKpi?> GetIsolationLeaderAsync(DateOnly start, DateOnly end);
+        Task<IsolationLeaderKpi?> GetIsolationLeaderAsync(DateOnly start, DateOnly end, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Returns the full ranked isolation list for the Regional Isolation Scores bar chart.
         /// Calls sp_GetIsolationRanking. Fetched separately from the KPI card so both can load independently.
         /// </summary>
-        Task<IEnumerable<IsolationRankingEntry>> GetIsolationRankingAsync(DateOnly start, DateOnly end);
+        Task<IEnumerable<IsolationRankingEntry>> GetIsolationRankingAsync(DateOnly start, DateOnly end, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Returns KPI 4 — the song with the highest simultaneous cross-regional chart presence.
         /// Calls sp_GetPeakCrossRegionalReach.
         /// </summary>
-        Task<PeakReachKpi?> GetPeakReachAsync(DateOnly start, DateOnly end);
+        Task<PeakReachKpi?> GetPeakReachAsync(DateOnly start, DateOnly end, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Returns one data point per year (or month) for the Global Overlap trend and Reach charts.
         /// Includes IsGap to drive the 22-month data gap visual marker in Recharts.
         /// Calls sp_GetGlobalOverlapTrend.
         /// </summary>
-        Task<IEnumerable<GlobalTrendPoint>> GetOverlapTrendAsync(DateOnly start, DateOnly end);
+        Task<IEnumerable<GlobalTrendPoint>> GetOverlapTrendAsync(DateOnly start, DateOnly end, CancellationToken cancellationToken = default);
     }
 }

--- a/backend/Capstone.API/Infrastructure/Interfaces/IDataRepository.cs
+++ b/backend/Capstone.API/Infrastructure/Interfaces/IDataRepository.cs
@@ -9,23 +9,26 @@ namespace Capstone.API.Infrastructure.Interfaces
         /// Executes a stored procedure without parameters and returns the results.
         /// </summary>
         /// <param name="storedProc">The name of the stored procedure to execute.</param>
+        /// <param name="cancellationToken">Token to cancel the database operation.</param>
         /// <returns>A collection of rows where each row is represented as a dictionary of column names to values.</returns>
-        Task<IEnumerable<IDictionary<string, object?>>> GetDataAsync(string storedProc);
+        Task<IEnumerable<IDictionary<string, object?>>> GetDataAsync(string storedProc, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Executes a stored procedure with parameters and returns the results.
         /// </summary>
         /// <param name="storedProc">The name of the stored procedure to execute.</param>
         /// <param name="parameters">A dictionary of parameter names and values to pass to the stored procedure.</param>
+        /// <param name="cancellationToken">Token to cancel the database operation.</param>
         /// <returns>A collection of rows where each row is represented as a dictionary of column names to values.</returns>
-        Task<IEnumerable<IDictionary<string, object?>>> GetDataAsync(string storedProc, IDictionary<string, object?> parameters);
+        Task<IEnumerable<IDictionary<string, object?>>> GetDataAsync(string storedProc, IDictionary<string, object?> parameters, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Executes a stored procedure with parameters and returns multiple result sets.
         /// </summary>
         /// <param name="storedProc">The name of the stored procedure to execute.</param>
         /// <param name="parameters">A dictionary of parameter names and values to pass to the stored procedure.</param>
+        /// <param name="cancellationToken">Token to cancel the database operation.</param>
         /// <returns>A list of result sets, where each result set is a collection of rows.</returns>
-        Task<List<List<IDictionary<string, object?>>>> GetDataSetsAsync(string storedProc, IDictionary<string, object?> parameters);
+        Task<List<List<IDictionary<string, object?>>>> GetDataSetsAsync(string storedProc, IDictionary<string, object?> parameters, CancellationToken cancellationToken = default);
     }
 }

--- a/backend/Capstone.API/Infrastructure/Interfaces/IGlobeRepository.cs
+++ b/backend/Capstone.API/Infrastructure/Interfaces/IGlobeRepository.cs
@@ -12,6 +12,6 @@ namespace Capstone.API.Infrastructure.Interfaces
         /// Calls sp_GetGlobeSummary.
         /// </summary>
         /// <param name="year">The chart year to filter by.</param>
-        Task<IEnumerable<CountryGlobeSummary>> GetGlobeSummaryAsync(int year);
+        Task<IEnumerable<CountryGlobeSummary>> GetGlobeSummaryAsync(int year, CancellationToken cancellationToken = default);
     }
 }

--- a/backend/Capstone.API/Infrastructure/Interfaces/IMetadataRepository.cs
+++ b/backend/Capstone.API/Infrastructure/Interfaces/IMetadataRepository.cs
@@ -9,6 +9,6 @@ namespace Capstone.API.Infrastructure.Interfaces
         /// Returns the list of available chart years present in the dataset.
         /// Calls sp_GetAvailableYears.
         /// </summary>
-        Task<IEnumerable<int>> GetAvailableYearsAsync();
+        Task<IEnumerable<int>> GetAvailableYearsAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/backend/Capstone.API/Infrastructure/Repositories/ComparisonRepository.cs
+++ b/backend/Capstone.API/Infrastructure/Repositories/ComparisonRepository.cs
@@ -23,14 +23,14 @@ namespace Capstone.API.Infrastructure.Repositories
 
         /// <inheritdoc/>
         public async Task<ComparisonResult?> GetCountryComparisonAsync(
-            string countryCodeA, string countryCodeB, int year)
+            string countryCodeA, string countryCodeB, int year, CancellationToken cancellationToken = default)
         {
             var sets = await _db.GetDataSetsAsync("sp_GetCountryComparison", new Dictionary<string, object?>
             {
                 { "@CountryCodeA", countryCodeA },
                 { "@CountryCodeB", countryCodeB },
                 { "@Year", year }
-            });
+            }, cancellationToken);
 
             if (sets.Count < 2 || sets[0].Count == 0 || sets[1].Count == 0)
                 return null;
@@ -55,14 +55,14 @@ namespace Capstone.API.Infrastructure.Repositories
 
         /// <inheritdoc/>
         public async Task<IEnumerable<ComparisonHiddenGem>> GetComparisonHiddenGemsAsync(
-            string countryCodeA, string countryCodeB, int year)
+            string countryCodeA, string countryCodeB, int year, CancellationToken cancellationToken = default)
         {
             var rows = await _db.GetDataAsync("sp_GetComparisonHiddenGems", new Dictionary<string, object?>
             {
                 { "@CountryCodeA", countryCodeA },
                 { "@CountryCodeB", countryCodeB },
                 { "@Year", year }
-            });
+            }, cancellationToken);
 
             return rows.Select(MapComparisonHiddenGem);
         }

--- a/backend/Capstone.API/Infrastructure/Repositories/CountryRepository.cs
+++ b/backend/Capstone.API/Infrastructure/Repositories/CountryRepository.cs
@@ -36,7 +36,7 @@ namespace Capstone.API.Infrastructure.Repositories
             {
                 { "@CountryCode", countryCode },
                 { "@Year", year }
-            });
+            }, cancellationToken);
 
             if (sets.Count == 0 || sets[0].Count == 0)
                 return null;
@@ -76,7 +76,7 @@ namespace Capstone.API.Infrastructure.Repositories
                 { "@CountryCode", countryCode },
                 { "@Year", year },
                 { "@Limit", rawLimit }
-            });
+            }, cancellationToken);
 
             var results = new List<CountryHiddenGemPreviewItem>();
             var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -132,7 +132,7 @@ namespace Capstone.API.Infrastructure.Repositories
                     { "@ListType", listType },
                     { "@Offset", scanOffset },
                     { "@PageSize", RawSongBatchSize }
-                })).ToList();
+                }, cancellationToken)).ToList();
 
                 if (scanRows.Count == 0)
                 {
@@ -326,7 +326,7 @@ namespace Capstone.API.Infrastructure.Repositories
                         { "@ListType", listType },
                         { "@Offset", scanOffset },
                         { "@PageSize", RawSongBatchSize }
-                    })).ToList();
+                    }, cancellationToken)).ToList();
 
                     if (rows.Count == 0)
                     {
@@ -387,7 +387,7 @@ namespace Capstone.API.Infrastructure.Repositories
                         { "@ListType", listType },
                         { "@Offset", scanOffset },
                         { "@PageSize", RawSongBatchSize }
-                    })).ToList();
+                    }, cancellationToken)).ToList();
 
                     if (rows.Count == 0)
                     {

--- a/backend/Capstone.API/Infrastructure/Repositories/DashboardRepository.cs
+++ b/backend/Capstone.API/Infrastructure/Repositories/DashboardRepository.cs
@@ -109,7 +109,7 @@ namespace Capstone.API.Infrastructure.Repositories
                 PeakCountryCount = AsInt(row, "peak_country_count"),
                 SongTitle = AsString(row, "song_title"),
                 ArtistName = AsString(row, "artist_name"),
-                PeakDate = AsDateOnly(row, "peak_date")
+                PeakDate = AsNullableDateOnly(row, "peak_date")
             };
         }
 
@@ -123,10 +123,10 @@ namespace Capstone.API.Infrastructure.Repositories
                 PeriodLabel = AsString(row, "period_label"),
                 PeriodYear = AsInt(row, "period_year"),
                 PeriodMonth = AsNullableInt(row, "period_month"),
-                OverlapPct = AsDecimal(row, "overlap_pct"),
-                AvgCountries = AsDecimal(row, "avg_countries"),
-                TotalUniqueSongs = AsInt(row, "total_unique_songs"),
-                SongsIn2Plus = AsInt(row, "songs_in_2plus"),
+                OverlapPct = AsNullableDecimal(row, "overlap_pct"),
+                AvgCountries = AsNullableDecimal(row, "avg_countries"),
+                TotalUniqueSongs = AsNullableInt(row, "total_unique_songs"),
+                SongsIn2Plus = AsNullableInt(row, "songs_in_2plus"),
                 IsGap = AsBool(row, "is_gap")
             });
         }
@@ -153,10 +153,13 @@ namespace Capstone.API.Infrastructure.Repositories
         private static decimal AsDecimal(IDictionary<string, object?> row, string key)
             => row.TryGetValue(key, out var v) && v != null ? Convert.ToDecimal(v) : 0m;
 
+        private static decimal? AsNullableDecimal(IDictionary<string, object?> row, string key)
+            => row.TryGetValue(key, out var v) && v != null ? Convert.ToDecimal(v) : null;
+
         private static bool AsBool(IDictionary<string, object?> row, string key)
             => row.TryGetValue(key, out var v) && v != null && Convert.ToBoolean(v);
 
-        private static DateOnly AsDateOnly(IDictionary<string, object?> row, string key)
-            => row.TryGetValue(key, out var v) && v is DateTime dt ? DateOnly.FromDateTime(dt) : DateOnly.MinValue;
+        private static DateOnly? AsNullableDateOnly(IDictionary<string, object?> row, string key)
+            => row.TryGetValue(key, out var v) && v is DateTime dt ? DateOnly.FromDateTime(dt) : null;
     }
 }

--- a/backend/Capstone.API/Infrastructure/Repositories/DashboardRepository.cs
+++ b/backend/Capstone.API/Infrastructure/Repositories/DashboardRepository.cs
@@ -20,9 +20,9 @@ namespace Capstone.API.Infrastructure.Repositories
         }
 
         /// <inheritdoc/>
-        public async Task<GlobalOverlapRateKpi?> GetOverlapRateAsync(DateOnly start, DateOnly end)
+        public async Task<GlobalOverlapRateKpi?> GetOverlapRateAsync(DateOnly start, DateOnly end, CancellationToken cancellationToken = default)
         {
-            var rows = await _db.GetDataAsync("sp_GetGlobalOverlapRate", DateRange(start, end));
+            var rows = await _db.GetDataAsync("sp_GetGlobalOverlapRate", DateRange(start, end), cancellationToken);
             var row = rows.FirstOrDefault();
             if (row == null) return null;
 
@@ -35,14 +35,14 @@ namespace Capstone.API.Infrastructure.Repositories
         }
 
         /// <inheritdoc/>
-        public async Task<DiscoveryGapKpi?> GetDiscoveryGapAsync(DateOnly start, DateOnly end, int minCountries = 2)
+        public async Task<DiscoveryGapKpi?> GetDiscoveryGapAsync(DateOnly start, DateOnly end, int minCountries = 2, CancellationToken cancellationToken = default)
         {
             var rows = await _db.GetDataAsync("sp_GetAverageDiscoveryGap", new Dictionary<string, object?>
             {
                 { "@DateStart", start.ToDateTime(TimeOnly.MinValue) },
                 { "@DateEnd", end.ToDateTime(TimeOnly.MinValue) },
                 { "@MinCountries", minCountries }
-            });
+            }, cancellationToken);
 
             var row = rows.FirstOrDefault();
             if (row == null) return null;
@@ -56,9 +56,9 @@ namespace Capstone.API.Infrastructure.Repositories
         }
 
         /// <inheritdoc/>
-        public async Task<IEnumerable<DiscoveryGapBucket>> GetGapDistributionAsync(DateOnly start, DateOnly end)
+        public async Task<IEnumerable<DiscoveryGapBucket>> GetGapDistributionAsync(DateOnly start, DateOnly end, CancellationToken cancellationToken = default)
         {
-            var rows = await _db.GetDataAsync("sp_GetDiscoveryGapDistribution", DateRange(start, end));
+            var rows = await _db.GetDataAsync("sp_GetDiscoveryGapDistribution", DateRange(start, end), cancellationToken);
 
             return rows.Select(row => new DiscoveryGapBucket
             {
@@ -69,9 +69,9 @@ namespace Capstone.API.Infrastructure.Repositories
         }
 
         /// <inheritdoc/>
-        public async Task<IsolationLeaderKpi?> GetIsolationLeaderAsync(DateOnly start, DateOnly end)
+        public async Task<IsolationLeaderKpi?> GetIsolationLeaderAsync(DateOnly start, DateOnly end, CancellationToken cancellationToken = default)
         {
-            var rows = await _db.GetDataAsync("sp_GetIsolationLeader", DateRange(start, end));
+            var rows = await _db.GetDataAsync("sp_GetIsolationLeader", DateRange(start, end), cancellationToken);
             var row = rows.FirstOrDefault();
             if (row == null) return null;
 
@@ -84,9 +84,9 @@ namespace Capstone.API.Infrastructure.Repositories
         }
 
         /// <inheritdoc/>
-        public async Task<IEnumerable<IsolationRankingEntry>> GetIsolationRankingAsync(DateOnly start, DateOnly end)
+        public async Task<IEnumerable<IsolationRankingEntry>> GetIsolationRankingAsync(DateOnly start, DateOnly end, CancellationToken cancellationToken = default)
         {
-            var rows = await _db.GetDataAsync("sp_GetIsolationRanking", DateRange(start, end));
+            var rows = await _db.GetDataAsync("sp_GetIsolationRanking", DateRange(start, end), cancellationToken);
 
             return rows.Select(row => new IsolationRankingEntry
             {
@@ -98,9 +98,9 @@ namespace Capstone.API.Infrastructure.Repositories
         }
 
         /// <inheritdoc/>
-        public async Task<PeakReachKpi?> GetPeakReachAsync(DateOnly start, DateOnly end)
+        public async Task<PeakReachKpi?> GetPeakReachAsync(DateOnly start, DateOnly end, CancellationToken cancellationToken = default)
         {
-            var rows = await _db.GetDataAsync("sp_GetPeakCrossRegionalReach", DateRange(start, end));
+            var rows = await _db.GetDataAsync("sp_GetPeakCrossRegionalReach", DateRange(start, end), cancellationToken);
             var row = rows.FirstOrDefault();
             if (row == null) return null;
 
@@ -114,9 +114,9 @@ namespace Capstone.API.Infrastructure.Repositories
         }
 
         /// <inheritdoc/>
-        public async Task<IEnumerable<GlobalTrendPoint>> GetOverlapTrendAsync(DateOnly start, DateOnly end)
+        public async Task<IEnumerable<GlobalTrendPoint>> GetOverlapTrendAsync(DateOnly start, DateOnly end, CancellationToken cancellationToken = default)
         {
-            var rows = await _db.GetDataAsync("sp_GetGlobalOverlapTrend", DateRange(start, end));
+            var rows = await _db.GetDataAsync("sp_GetGlobalOverlapTrend", DateRange(start, end), cancellationToken);
 
             return rows.Select(row => new GlobalTrendPoint
             {

--- a/backend/Capstone.API/Infrastructure/Repositories/GlobeRepository.cs
+++ b/backend/Capstone.API/Infrastructure/Repositories/GlobeRepository.cs
@@ -20,12 +20,12 @@ namespace Capstone.API.Infrastructure.Repositories
         }
 
         /// <inheritdoc/>
-        public async Task<IEnumerable<CountryGlobeSummary>> GetGlobeSummaryAsync(int year)
+        public async Task<IEnumerable<CountryGlobeSummary>> GetGlobeSummaryAsync(int year, CancellationToken cancellationToken = default)
         {
             var rows = await _db.GetDataAsync("sp_GetDiscoverPageInfo", new Dictionary<string, object?>
             {
                 { "@Year", year }
-            });
+            }, cancellationToken);
 
             return rows.Select(MapRow);
         }

--- a/backend/Capstone.API/Infrastructure/Repositories/HiddenGemsRepository.cs
+++ b/backend/Capstone.API/Infrastructure/Repositories/HiddenGemsRepository.cs
@@ -48,7 +48,7 @@ namespace Capstone.API.Infrastructure.Repositories
                     { "@MinCountries", minCountries },
                     { "@Offset", scanOffset },
                     { "@PageSize", rawBatchSize }
-                })).ToList();
+                }, cancellationToken)).ToList();
 
                 if (rows.Count == 0)
                 {

--- a/backend/Capstone.API/Infrastructure/Repositories/MetadataRepository.cs
+++ b/backend/Capstone.API/Infrastructure/Repositories/MetadataRepository.cs
@@ -18,9 +18,9 @@ namespace Capstone.API.Infrastructure.Repositories
         }
 
         /// <inheritdoc/>
-        public async Task<IEnumerable<int>> GetAvailableYearsAsync()
+        public async Task<IEnumerable<int>> GetAvailableYearsAsync(CancellationToken cancellationToken = default)
         {
-            var rows = await _db.GetDataAsync("sp_GetAvailableYears");
+            var rows = await _db.GetDataAsync("sp_GetAvailableYears", cancellationToken);
 
             return rows
                 .Select((row) => RowValueReader.AsIntAny(row, "chart_year"))

--- a/backend/Capstone.API/Infrastructure/Repositories/MySqlRepository.cs
+++ b/backend/Capstone.API/Infrastructure/Repositories/MySqlRepository.cs
@@ -26,7 +26,7 @@ namespace Capstone.API.Infrastructure.Interfaces.Repositories
         /// <param name="storedProc">The name of the stored procedure to execute.</param>
         /// <returns>A collection of rows returned by the stored procedure.</returns>
         /// <exception cref="NotImplementedException">This method is not yet implemented.</exception>
-        public Task<IEnumerable<IDictionary<string, object?>>> GetDataAsync(string storedProc)
+        public Task<IEnumerable<IDictionary<string, object?>>> GetDataAsync(string storedProc, CancellationToken cancellationToken = default)
         {
             return Task.FromException<IEnumerable<IDictionary<string, object?>>>(new NotImplementedException());
         }
@@ -38,7 +38,7 @@ namespace Capstone.API.Infrastructure.Interfaces.Repositories
         /// <param name="parameters">A dictionary of parameter names and values to pass to the stored procedure.</param>
         /// <returns>A collection of rows returned by the stored procedure.</returns>
         /// <exception cref="NotImplementedException">This method is not yet implemented.</exception>
-        public Task<IEnumerable<IDictionary<string, object?>>> GetDataAsync(string storedProc, IDictionary<string, object?> parameters)
+        public Task<IEnumerable<IDictionary<string, object?>>> GetDataAsync(string storedProc, IDictionary<string, object?> parameters, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
         }
@@ -50,7 +50,7 @@ namespace Capstone.API.Infrastructure.Interfaces.Repositories
         /// <param name="parameters">A dictionary of parameter names and values to pass to the stored procedure.</param>
         /// <returns>A list of result sets, where each result set is a collection of rows.</returns>
         /// <exception cref="NotImplementedException">This method is not yet implemented.</exception>
-        public Task<List<List<IDictionary<string, object?>>>> GetDataSetsAsync(string storedProc, IDictionary<string, object?> parameters)
+        public Task<List<List<IDictionary<string, object?>>>> GetDataSetsAsync(string storedProc, IDictionary<string, object?> parameters, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
         }

--- a/backend/Capstone.API/Infrastructure/Repositories/SqlServerRepository.cs
+++ b/backend/Capstone.API/Infrastructure/Repositories/SqlServerRepository.cs
@@ -8,156 +8,158 @@ namespace Capstone.API.Infrastructure.Interfaces.Repositories
     /// SQL Server implementation of the data repository for executing stored procedures.
     /// </summary>
     public class SqlServerRepository : IDataRepository
-{
-    private readonly string _connectionString = string.Empty;
-
-    /// <summary>
-    /// Initializes a new instance of the SqlServerRepository.
-    /// </summary>
-    /// <param name="connectionString">The SQL Server connection string.</param>
-    public SqlServerRepository(string connectionString)
     {
-        _connectionString = connectionString ?? string.Empty;
-    }
+        private readonly string _connectionString = string.Empty;
 
-    /// <summary>
-    /// Executes a stored procedure without parameters and returns the result set.
-    /// </summary>
-    /// <param name="storedProc">The name of the stored procedure to execute.</param>
-    /// <returns>A collection of rows returned by the stored procedure.</returns>
-    public async Task<IEnumerable<IDictionary<string, object?>>> GetDataAsync(string storedProc)
-    {
-        var results = new List<IDictionary<string, object?>>();
-
-        using (var connection = new SqlConnection(_connectionString))
+        /// <summary>
+        /// Initializes a new instance of the SqlServerRepository.
+        /// </summary>
+        /// <param name="connectionString">The SQL Server connection string.</param>
+        public SqlServerRepository(string connectionString)
         {
-            using (var command = new SqlCommand(storedProc, connection))
+            _connectionString = connectionString ?? string.Empty;
+        }
+
+        /// <summary>
+        /// Executes a stored procedure without parameters and returns the result set.
+        /// </summary>
+        /// <param name="storedProc">The name of the stored procedure to execute.</param>
+        /// <param name="cancellationToken">Token to cancel the database operation.</param>
+        /// <returns>A collection of rows returned by the stored procedure.</returns>
+        public async Task<IEnumerable<IDictionary<string, object?>>> GetDataAsync(string storedProc, CancellationToken cancellationToken = default)
+        {
+            var results = new List<IDictionary<string, object?>>();
+
+            using (var connection = new SqlConnection(_connectionString))
             {
-                command.CommandType = CommandType.StoredProcedure;
-                command.CommandTimeout = 120;
-
-                await connection.OpenAsync();
-
-                using (var reader = await command.ExecuteReaderAsync())
+                using (var command = new SqlCommand(storedProc, connection))
                 {
-                    while (await reader.ReadAsync())
+                    command.CommandType = CommandType.StoredProcedure;
+                    command.CommandTimeout = 120;
+
+                    await connection.OpenAsync(cancellationToken);
+
+                    using (var reader = await command.ExecuteReaderAsync(cancellationToken))
                     {
-                        var newRow = new Dictionary<string, object?>();
-                        for (int i = 0; i < reader.FieldCount; i++)
+                        while (await reader.ReadAsync(cancellationToken))
                         {
-                            newRow[reader.GetName(i)] = reader.IsDBNull(i) ? null : reader.GetValue(i);
+                            var newRow = new Dictionary<string, object?>();
+                            for (int i = 0; i < reader.FieldCount; i++)
+                            {
+                                newRow[reader.GetName(i)] = reader.IsDBNull(i) ? null : reader.GetValue(i);
+                            }
+                            results.Add(newRow);
                         }
-                        results.Add(newRow);
                     }
                 }
             }
+
+            return results;
         }
 
-        return results;
-    }
-
-    /// <summary>
-    /// Executes a stored procedure with parameters and returns the result set.
-    /// </summary>
-    /// <param name="storedProc">The name of the stored procedure to execute.</param>
-    /// <param name="parameters">A dictionary of parameter names and values to pass to the stored procedure.</param>
-    /// <returns>A collection of rows returned by the stored procedure.</returns>
-    public async Task<IEnumerable<IDictionary<string, object?>>> GetDataAsync(string storedProc, IDictionary<string, object?>? parameters)
-    {
-        var results = new List<IDictionary<string, object?>>();
-
-        using (var connection = new SqlConnection(_connectionString))
+        /// <summary>
+        /// Executes a stored procedure with parameters and returns the result set.
+        /// </summary>
+        /// <param name="storedProc">The name of the stored procedure to execute.</param>
+        /// <param name="parameters">A dictionary of parameter names and values to pass to the stored procedure.</param>
+        /// <param name="cancellationToken">Token to cancel the database operation.</param>
+        /// <returns>A collection of rows returned by the stored procedure.</returns>
+        public async Task<IEnumerable<IDictionary<string, object?>>> GetDataAsync(string storedProc, IDictionary<string, object?>? parameters, CancellationToken cancellationToken = default)
         {
-            using (var command = new SqlCommand(storedProc, connection))
+            var results = new List<IDictionary<string, object?>>();
+
+            using (var connection = new SqlConnection(_connectionString))
             {
-                command.CommandType = CommandType.StoredProcedure;
-                command.CommandTimeout = 120;
-
-                if (parameters != null)
+                using (var command = new SqlCommand(storedProc, connection))
                 {
-                    foreach (var kvp in parameters)
-                    {
-                        // Ensure parameter name starts with @
-                        var paramName = kvp.Key.StartsWith("@") ? kvp.Key : "@" + kvp.Key;
-                        command.Parameters.AddWithValue(paramName, kvp.Value ?? DBNull.Value);
-                    }
-                }
+                    command.CommandType = CommandType.StoredProcedure;
+                    command.CommandTimeout = 120;
 
-                await connection.OpenAsync();
-
-                using (var reader = await command.ExecuteReaderAsync())
-                {
-                    while (await reader.ReadAsync())
+                    if (parameters != null)
                     {
-                        var row = new Dictionary<string, object?>();
-                        for (int i = 0; i < reader.FieldCount; i++)
+                        foreach (var kvp in parameters)
                         {
-                            var name = reader.GetName(i);
-                            var value = await reader.IsDBNullAsync(i) ? null : reader.GetValue(i);
-                            row[name] = value;
+                            var paramName = kvp.Key.StartsWith("@") ? kvp.Key : "@" + kvp.Key;
+                            command.Parameters.AddWithValue(paramName, kvp.Value ?? DBNull.Value);
                         }
-
-                        results.Add(row);
                     }
-                }
-            }
-        }
 
-        return results;
-    }
+                    await connection.OpenAsync(cancellationToken);
 
-    /// <summary>
-    /// Executes a stored procedure with parameters and returns multiple result sets.
-    /// </summary>
-    /// <param name="storedProc">The name of the stored procedure to execute.</param>
-    /// <param name="parameters">A dictionary of parameter names and values to pass to the stored procedure.</param>
-    /// <returns>A list of result sets, where each result set is a collection of rows.</returns>
-    public async Task<List<List<IDictionary<string, object?>>>> GetDataSetsAsync(string storedProc, IDictionary<string, object?>? parameters)
-    {
-        var dataSets = new List<List<IDictionary<string, object?>>>();
-
-        using (var connection = new SqlConnection(_connectionString))
-        {
-            using (var command = new SqlCommand(storedProc, connection))
-            {
-                command.CommandType = CommandType.StoredProcedure;
-                command.CommandTimeout = 120;
-
-                if (parameters != null)
-                {
-                    foreach (var kvp in parameters)
+                    using (var reader = await command.ExecuteReaderAsync(cancellationToken))
                     {
-                        var paramName = kvp.Key.StartsWith("@") ? kvp.Key : "@" + kvp.Key;
-                        command.Parameters.AddWithValue(paramName, kvp.Value ?? DBNull.Value);
-                    }
-                }
-
-                await connection.OpenAsync();
-
-                using (var reader = await command.ExecuteReaderAsync())
-                {
-                    do
-                    {
-                        var results = new List<IDictionary<string, object?>>();
-                        while (await reader.ReadAsync())
+                        while (await reader.ReadAsync(cancellationToken))
                         {
                             var row = new Dictionary<string, object?>();
                             for (int i = 0; i < reader.FieldCount; i++)
                             {
                                 var name = reader.GetName(i);
-                                var value = await reader.IsDBNullAsync(i) ? null : reader.GetValue(i);
+                                var value = await reader.IsDBNullAsync(i, cancellationToken) ? null : reader.GetValue(i);
                                 row[name] = value;
                             }
+
                             results.Add(row);
                         }
-                        dataSets.Add(results);
                     }
-                    while (await reader.NextResultAsync());
                 }
             }
+
+            return results;
         }
 
-        return dataSets;
+        /// <summary>
+        /// Executes a stored procedure with parameters and returns multiple result sets.
+        /// </summary>
+        /// <param name="storedProc">The name of the stored procedure to execute.</param>
+        /// <param name="parameters">A dictionary of parameter names and values to pass to the stored procedure.</param>
+        /// <param name="cancellationToken">Token to cancel the database operation.</param>
+        /// <returns>A list of result sets, where each result set is a collection of rows.</returns>
+        public async Task<List<List<IDictionary<string, object?>>>> GetDataSetsAsync(string storedProc, IDictionary<string, object?>? parameters, CancellationToken cancellationToken = default)
+        {
+            var dataSets = new List<List<IDictionary<string, object?>>>();
+
+            using (var connection = new SqlConnection(_connectionString))
+            {
+                using (var command = new SqlCommand(storedProc, connection))
+                {
+                    command.CommandType = CommandType.StoredProcedure;
+                    command.CommandTimeout = 120;
+
+                    if (parameters != null)
+                    {
+                        foreach (var kvp in parameters)
+                        {
+                            var paramName = kvp.Key.StartsWith("@") ? kvp.Key : "@" + kvp.Key;
+                            command.Parameters.AddWithValue(paramName, kvp.Value ?? DBNull.Value);
+                        }
+                    }
+
+                    await connection.OpenAsync(cancellationToken);
+
+                    using (var reader = await command.ExecuteReaderAsync(cancellationToken))
+                    {
+                        do
+                        {
+                            var results = new List<IDictionary<string, object?>>();
+                            while (await reader.ReadAsync(cancellationToken))
+                            {
+                                var row = new Dictionary<string, object?>();
+                                for (int i = 0; i < reader.FieldCount; i++)
+                                {
+                                    var name = reader.GetName(i);
+                                    var value = await reader.IsDBNullAsync(i, cancellationToken) ? null : reader.GetValue(i);
+                                    row[name] = value;
+                                }
+                                results.Add(row);
+                            }
+                            dataSets.Add(results);
+                        }
+                        while (await reader.NextResultAsync(cancellationToken));
+                    }
+                }
+            }
+
+            return dataSets;
+        }
     }
-}
 }

--- a/backend/Capstone.API/Models/Dashboard/GlobalTrendPoint.cs
+++ b/backend/Capstone.API/Models/Dashboard/GlobalTrendPoint.cs
@@ -25,23 +25,27 @@ namespace Capstone.API.Models.Dashboard
 
         /// <summary>
         /// Gets or sets the percentage of charting songs that appeared in 2 or more countries for this period.
+        /// Null for gap rows — Recharts uses IsGap to skip rendering these points.
         /// </summary>
-        public decimal OverlapPct { get; set; }
+        public decimal? OverlapPct { get; set; }
 
         /// <summary>
         /// Gets or sets the average number of countries per charting song for this period.
+        /// Null for gap rows.
         /// </summary>
-        public decimal AvgCountries { get; set; }
+        public decimal? AvgCountries { get; set; }
 
         /// <summary>
         /// Gets or sets the total number of unique songs that charted in this period.
+        /// Null for gap rows.
         /// </summary>
-        public int TotalUniqueSongs { get; set; }
+        public int? TotalUniqueSongs { get; set; }
 
         /// <summary>
         /// Gets or sets the number of songs that charted in 2 or more countries in this period.
+        /// Null for gap rows.
         /// </summary>
-        public int SongsIn2Plus { get; set; }
+        public int? SongsIn2Plus { get; set; }
 
         /// <summary>
         /// Gets or sets a flag indicating whether this point falls inside the 22-month data gap (Dec 2021 – Oct 2023).

--- a/backend/Capstone.API/Models/Dashboard/PeakReachKpi.cs
+++ b/backend/Capstone.API/Models/Dashboard/PeakReachKpi.cs
@@ -26,6 +26,6 @@ namespace Capstone.API.Models.Dashboard
         /// <summary>
         /// Gets or sets the date on which peak reach was recorded.
         /// </summary>
-        public DateOnly PeakDate { get; set; }
+        public DateOnly? PeakDate { get; set; }
     }
 }


### PR DESCRIPTION
## Backend Reliability: Error Handling, CancellationToken Propagation, and Model Correctness

**Branch:** `67-cross-check-interfaces-controllers-against-sps`
**Scope:** All 7 controllers · all 5 repository interfaces · all 9 repository implementations · `IDataRepository` / `SqlServerRepository` · 2 Dashboard models

---

### Summary

Three interconnected reliability problems were identified and fixed across the full backend stack: inconsistent error handling in controllers, cancellation tokens that were silently dropped before reaching the database, and nullable type mismatches in dashboard models that masked NULL database values.

---

### 1 — Consistent Error Handling (All 7 Controllers)

**Problem:** Error handling across the API was completely ad-hoc. `DashboardController`, `GlobeController`, and `MetadataController` had no try-catch at all. `HiddenGemsController` had no try-catch and no logger. `CountryController` had SQL and general exception handling but was missing `OperationCanceledException` on 3 of 4 endpoints. `ComparisonController` and `DiscoveryController` were missing `OperationCanceledException`.

**Root cause of the original AR 2023 log error:** `CountryController.GetCountryProfile` had no `OperationCanceledException` handler, so routine client disconnects were caught by the generic `Exception` handler and logged as errors with a full stack trace.

**Fix:** All 7 controllers now consistently catch:
- `SqlException` → `503` with a user-facing message + `LogError`
- `OperationCanceledException` (when `cancellationToken.IsCancellationRequested`) → silent `EmptyResult()`, no log — this is normal browser navigation, not an error
- `Exception` → `500` with a user-facing message + `LogError`

`ILogger<T>` was injected into the four controllers that were missing it (`DashboardController`, `GlobeController`, `MetadataController`, `HiddenGemsController`).

**Files changed:**
- `Controllers/DashboardController.cs` — full rewrite
- `Controllers/GlobeController.cs` — full rewrite
- `Controllers/MetadataController.cs` — full rewrite
- `Controllers/HiddenGemsController.cs` — full rewrite
- `Controllers/ComparisonController.cs` — `OperationCanceledException` added to both endpoints
- `Controllers/DiscoveryController.cs` — `OperationCanceledException` added
- `Controllers/CountryController.cs` — `OperationCanceledException` added to 3 endpoints

---

### 2 — CancellationToken Propagation (End-to-End)

**Problem:** `CancellationToken` was being dropped at the `IDataRepository` boundary. Controllers accepted the token from ASP.NET Core and passed it to repositories, but `IDataRepository.GetDataAsync` / `GetDataSetsAsync` had no token parameter — so the token never reached the SQL layer. Even in `CountryRepository` and `HiddenGemsRepository`, which did declare a token on their public methods, the token was dropped at the `_db.GetDataAsync(...)` call site.

Result: cancelled requests (user navigating away, tab closed) kept live SQL connections open and running until the query finished. On the genre-sampling slow-scan queries this meant the server continued burning a connection and thread for a client that was already gone.

**Fix:** Token is now threaded end-to-end:

| Layer | What changed |
|---|---|
| `IDataRepository` | `CancellationToken cancellationToken = default` added to all 3 methods |
| `SqlServerRepository` | Token passed to `OpenAsync`, `ExecuteReaderAsync`, `ReadAsync`, `IsDBNullAsync`, `NextResultAsync` in all 3 methods |
| `MySqlRepository` | Signatures updated to match the interface (stubs, still throws `NotImplementedException`) |
| `IGlobeRepository`, `IMetadataRepository` | Token added to their one method each |
| `IComparisonRepository` | Token added to both methods |
| `IDashboardRepository` | Token added to all 7 methods |
| `ICountryRepository` | Token already present on all methods |
| `IHiddenGemsRepository` | Token already present |
| `GlobeRepository`, `MetadataRepository` | Token accepted + passed to `_db` |
| `ComparisonRepository` | Token accepted + passed to `_db` at both call sites |
| `DashboardRepository` | Token accepted + passed to `_db` at all 7 call sites |
| `CountryRepository` | Token now passed to `_db` at 5 previously-dropped call sites |
| `HiddenGemsRepository` | Token now passed to `_db` at the batch-fetch call site |
| Controllers (5 of 7) | `CancellationToken` parameter added to all endpoints that were missing it |

Flow is now: browser cancels → ASP.NET cancels token → controller → repository → `_db` → SQL command interrupted.

**Files changed:**
- `Infrastructure/Interfaces/IDataRepository.cs`
- `Infrastructure/Interfaces/IComparisonRepository.cs`
- `Infrastructure/Interfaces/IDashboardRepository.cs`
- `Infrastructure/Interfaces/IGlobeRepository.cs`
- `Infrastructure/Interfaces/IMetadataRepository.cs`
- `Infrastructure/Repositories/SqlServerRepository.cs`
- `Infrastructure/Repositories/MySqlRepository.cs`
- `Infrastructure/Repositories/ComparisonRepository.cs`
- `Infrastructure/Repositories/CountryRepository.cs`
- `Infrastructure/Repositories/DashboardRepository.cs`
- `Infrastructure/Repositories/GlobeRepository.cs`
- `Infrastructure/Repositories/HiddenGemsRepository.cs`
- `Infrastructure/Repositories/MetadataRepository.cs`

---

### 3 — Model Nullability Fixes (Dashboard Models)

**Problem:** Two Dashboard models declared value-type properties as non-nullable even though their source stored procedures can return NULL for those columns.

- `GlobalTrendPoint` — `sp_GetGlobalOverlapTrend` emits synthetic "gap rows" (covering the Dec 2021–Oct 2023 data gap) with `is_gap = 1` and NULL for all four metric columns. The model declared `OverlapPct`, `AvgCountries`, `TotalUniqueSongs`, and `SongsIn2Plus` as non-nullable, so NULL was silently coerced to `0` / `0.0` instead of `null`. Recharts depends on `null` to skip rendering gap points.
- `PeakReachKpi` — `PeakDate` was `DateOnly` (non-nullable). The `AsDateOnly` helper returned `DateOnly.MinValue` for a NULL DB value, masking missing dates instead of surfacing them as `null`.

**Fix:**

| Model | Property | Was | Now |
|---|---|---|---|
| `GlobalTrendPoint` | `OverlapPct` | `decimal` | `decimal?` |
| `GlobalTrendPoint` | `AvgCountries` | `decimal` | `decimal?` |
| `GlobalTrendPoint` | `TotalUniqueSongs` | `int` | `int?` |
| `GlobalTrendPoint` | `SongsIn2Plus` | `int` | `int?` |
| `PeakReachKpi` | `PeakDate` | `DateOnly` | `DateOnly?` |

`DashboardRepository` mappings updated to call `AsNullableDecimal` / `AsNullableInt` / `AsNullableDateOnly`. Two new private helpers added (`AsNullableDecimal`, `AsNullableDateOnly`). The old non-nullable `AsDateOnly` helper removed (no longer used).

**Files changed:**
- `Models/Dashboard/GlobalTrendPoint.cs`
- `Models/Dashboard/PeakReachKpi.cs`
- `Infrastructure/Repositories/DashboardRepository.cs`

---

### How to Test

#### Error handling
1. Start the API and make a valid request to any endpoint (e.g. `GET /api/dashboard/overlap-rate?start=2017-01-01&end=2021-12-31`)
2. Navigate away immediately / cancel the request — the server log should produce **no error entry** (silent `EmptyResult`, not a stack trace)
3. To verify 503: temporarily take the DB offline and hit any endpoint — should return `503` with the user-facing message, not a 500 or unhandled exception
4. Confirm no unprotected endpoints: every controller action is wrapped in try-catch

#### CancellationToken propagation
1. Open SQL Server Activity Monitor or `sys.dm_exec_requests` before and after a cancelled request
2. Hit a slow endpoint (e.g. Hidden Gems with a large dataset, or genre sampling on a new country) and navigate away immediately
3. The in-flight SQL session should disappear from `dm_exec_requests` promptly — previously it would run to completion

#### Model nullability
1. Call `GET /api/dashboard/overlap-trend?start=2017-01-01&end=2024-12-31` — response should include rows where `overlapPct`, `avgCountries`, `totalUniqueSongs`, and `songsIn2Plus` are `null` (not `0`) when `isGap` is `true`
2. Call `GET /api/dashboard/peak-reach?start=2017-01-01&end=2024-12-31` — `peakDate` should be `null` if the SP returns NULL, not `"0001-01-01"`
3. Verify the dashboard gap region renders as a dashed line (not a flat zero line through the gap)
