### PR TITLE
Completed Issue 125 - Various Bugs 

### DIFF
--- a/Documentation/QA-log.md
+++ b/Documentation/QA-log.md
@@ -3,6 +3,70 @@
 
 ---
 
+## 2026-05-15 — Hidden Gems Direct Navigation and Code Review Follow-Up
+
+**Tester:** mp3li / Codex-assisted verification
+**Fix owner:** mp3li / Codex-assisted implementation
+**Scope:** Hidden Gems direct/reload prompt behavior, route header/breadcrumb stability, loading overlays, country filtering, fetch retry behavior, and Welcome navigation reset
+
+### What I noticed
+
+After the Issue 125 branch was reviewed and tested, these remaining risks or regressions needed focus:
+
+- Direct `/hidden-gems` navigation needed to show the country/year selection prompt when there was no confirmed country/year context.
+- In-app navigation to Hidden Gems still needed to skip the prompt and open the intended country/year page.
+- Hidden Gems year changes could temporarily show `Loading country...` in the header and breadcrumb.
+- Returning from Hidden Gems to Country could leave the Country header/breadcrumb stuck on `Loading country...`.
+- A later fallback briefly showed country codes such as `AR` instead of full names such as `Argentina`.
+- Hidden Gems sections needed the same glassy/dimmed loading treatment used elsewhere.
+- The global Hidden Gems loading message used feature-specific copy instead of neutral `Loading...`.
+- General app country filtering was too tightly coupled to `hiddenSongs > 0`.
+- Fetch retry behavior could retry abort/timeout failures and duplicate long waits.
+- Clicking `Welcome` from an active page could show the Welcome modal over that page instead of returning to the normal Welcome state.
+
+### What was fixed
+
+- Added app-owned Hidden Gems prompt logic for direct/reload paths without complete country/year params.
+- Preserved app-driven Hidden Gems handoff behavior for Country and preview-click navigation.
+- Added stable country lookup fallbacks so route titles, headers, and breadcrumbs keep full country names while API country pools reload.
+- Added world-map ISO fallback so API ids like `iso-ar` resolve to `Argentina` rather than flashing `AR`.
+- Added glassy/dimmed `Loading...` veils to the Hidden Gems song list, now-playing panel, and favorite-artists section.
+- Replaced `Loading hidden gems...` with neutral `Loading...`.
+- Split general app-data country filtering from Hidden-Gems-specific hidden-gem availability filtering.
+- Limited fetch retry behavior to likely transient network fetch failures, not aborts or timeouts.
+- Changed Welcome navigation from header/breadcrumb clicks to reset into the normal Welcome-over-Discovery stack.
+
+### How to test
+
+1. Open `/hidden-gems` directly with no country/year params. The country/year intro prompt should appear.
+2. From a Country page, open Hidden Gems. It should go straight to that country's Hidden Gems page.
+3. Refresh after app-driven Hidden Gems handoff. The selected country/year behavior should remain correct.
+4. Change the Hidden Gems year dropdown. Header, document title, and breadcrumb should keep the full country name.
+5. Return from Hidden Gems to Country. Header and breadcrumb should keep the full country name and should not get stuck on `Loading country...`.
+6. Test an API country id route such as `iso-ar` when available. The label should resolve to `Argentina`, not flash `AR`.
+7. Confirm Hidden Gems section loading uses the dimmed/glassy `Loading...` veil.
+8. Confirm Hidden Gems loading text is neutral `Loading...`.
+9. Check Discovery/Country/Comparison country choices are not wrongly removed just because a country has zero hidden gems.
+10. Click `Welcome` from a Country or Hidden Gems page. Welcome should return to the normal Welcome state instead of appearing over the current page.
+
+### Verification
+
+- `npm run typecheck -- --noEmit`
+
+### User runtime confirmation
+
+mp3li confirmed:
+
+- direct Hidden Gems prompt behavior is correct
+- in-app Hidden Gems navigation is correct
+- reload/handoff behavior is correct
+- basic backend data loading is good
+- glassy Hidden Gems loading treatment is correct
+- country names no longer show `Loading country...` or flash country codes
+- Welcome navigation behavior is good
+
+---
+
 ## 2026-05-15 — Project Stabilization Follow-Up
 
 **Tester:** mp3li / Codex-assisted verification

--- a/Documents/mp3li implementation timeline document.txt
+++ b/Documents/mp3li implementation timeline document.txt
@@ -2,6 +2,68 @@ mp3li implementation timeline document
 
 Updated: May 15, 2026
 
+Hidden Gems Direct Navigation, Code Review Fixes, and Documentation Follow-Up (May 15, 2026)
+- Objective:
+  - Complete the Issue 125 follow-up after hands-on review confirmed the Hidden Gems country/year selection prompt now behaves correctly on reload and direct navigation.
+  - Address the code-review findings immediately instead of leaving them as future cleanup.
+  - Preserve the approved Hidden Gems visual direction while removing confusing loading/header/breadcrumb states.
+  - Update the personal timeline and professional documentation so the final branch behavior is traceable.
+
+- Hidden Gems direct-navigation behavior:
+  - Direct `/hidden-gems` navigation now opens the Hidden Gems intro prompt when the route does not have a confirmed country/year context.
+  - In-app navigation from Country pages or hidden-gem previews still opens the intended country/year Hidden Gems page instead of forcing the prompt.
+  - Added a session handoff marker so app-driven Hidden Gems navigation can be distinguished from a fresh direct/reload path.
+  - Kept the prompt country list scoped to countries with real hidden-gem availability.
+
+- Header, breadcrumb, and route-label cleanup:
+  - Fixed the issue where Hidden Gems year changes could make the header and breadcrumb say `Loading country...` even after the page data had loaded.
+  - Fixed the follow-on issue where returning from Hidden Gems to Country could leave the Country header/breadcrumb stuck on `Loading country...`.
+  - Added stable country-name fallback behavior so route/header labels use known country metadata while the selected year's API country pool reloads.
+  - Added ISO/world-map fallback for API ids such as `iso-ar`, so the UI keeps showing `Argentina` instead of briefly flashing `AR`.
+  - Preserved full country names for Country, Hidden Gems, Comparison, document titles, and breadcrumb labels.
+
+- Hidden Gems loading and overlay polish:
+  - Added the same glassy/dimmed `Loading...` veil treatment to the Hidden Gems song list, now-playing panel, and favorite-artists section while they load.
+  - Replaced the app-wide `Loading hidden gems...` message with neutral `Loading...` wording to stay consistent with the rest of the app.
+  - Kept the existing Hidden Gems layout, controls, labels, and section structure intact.
+
+- Code review and optimization fixes:
+  - Split the country filtering helper into general app-data filtering and Hidden-Gems-specific filtering.
+  - General Discovery/Country/Comparison country pools no longer depend on `hiddenSongs > 0`.
+  - Hidden Gems dropdown/prompt choices still require hidden-gem availability.
+  - Tightened `fetchWithTimeoutAndRetry` so aborts and timeouts are not retried as duplicate long-running requests.
+  - Kept retry behavior limited to likely transient network fetch failures.
+
+- Welcome navigation fix:
+  - Fixed the bad behavior where clicking `Welcome` from another page could show the Welcome modal over the current Country page.
+  - Welcome navigation now resets back to the normal Welcome-over-Discovery state instead of stacking over whichever page was active.
+
+- Files updated in this follow-up:
+  - `hidden-gem-music-app/App.tsx`
+  - `hidden-gem-music-app/src/data/countryDisplay.ts`
+  - `hidden-gem-music-app/src/data/fetchWithTimeout.ts`
+  - `hidden-gem-music-app/src/screens/HiddenGemsScreen.tsx`
+  - `Documents/mp3li implementation timeline document.txt`
+  - `Documentation/QA-log.md`
+  - `hidden-gem-music-app/Documentation/routing-state-and-navigation.md`
+  - `hidden-gem-music-app/Documentation/screen-data-flow.md`
+  - `hidden-gem-music-app/Documentation/interaction-loading-and-overlay-rules.md`
+  - `hidden-gem-music-app/Documentation/frontend-architecture.md`
+
+- Verification completed:
+  - Ran `npm run typecheck -- --noEmit` after implementation fixes.
+  - User verified direct Hidden Gems prompt behavior.
+  - User verified in-app Hidden Gems navigation behavior.
+  - User verified Hidden Gems reload/handoff behavior.
+  - User verified the neutral loading behavior and basic backend data loading.
+  - User verified the glassy Hidden Gems section loading treatment looked correct.
+  - User verified the country-name fallback no longer shows `Loading country...` or flashes country codes.
+  - User verified Welcome navigation no longer appears over the wrong page.
+
+- Commit/push status:
+  - Committed implementation fixes as `7998de5 Implemented code review and optimization changes`.
+  - Pushed to branch `125-bug-bug-hidden-gems-countryyear-selection-prompt-does-not-appear-on-reload-or-direct-navigation`.
+
 Interactive Discovery Map Completion, Code Review Stabilization, and PR-Readiness Pass (May 15, 2026)
 - Objective:
   - Bring the broader interactive Discovery Map / map-or-globe issue into a PR-ready state after the web and mobile Discovery Map behavior was tested repeatedly on the user's devices.

--- a/hidden-gem-music-app/App.tsx
+++ b/hidden-gem-music-app/App.tsx
@@ -16,6 +16,7 @@ import { DashboardScreen } from "./src/screens/DashboardScreen";
 import { DiscoveryScreen } from "./src/screens/DiscoveryScreen";
 import { HiddenGemsScreen } from "./src/screens/HiddenGemsScreen";
 import { WelcomeScreen } from "./src/screens/WelcomeScreen";
+import { worldMapCountries } from "./src/assets/maps/worldMap50m";
 import { loadDiscoveryCountries } from "./src/data/discoveryApi";
 import { loadAvailableYears } from "./src/data/countryApi";
 import { isCountryWithAppData } from "./src/data/countryDisplay";
@@ -65,6 +66,11 @@ type HiddenGemsFocusSelection = {
 const APP_STATE_STORAGE_KEY = "hidden-gem-app-state-v1";
 const HIDDEN_GEMS_HANDOFF_STORAGE_KEY = "hidden-gems-direct-handoff-v1";
 const DEFAULT_DISCOVERY_YEAR = 2025;
+const worldMapCountryNameByCode = new Map(
+  worldMapCountries
+    .filter((country) => typeof country.code === "string" && country.code.trim().length > 0)
+    .map((country) => [country.code!.trim().toUpperCase(), country.name])
+);
 
 function readPersistedAppState(): PersistedAppState {
   if (typeof window === "undefined") {
@@ -155,6 +161,21 @@ function findCountryByIdentifier(list: Country[], identifier: string) {
     (country) =>
       normalizeCountryKey(country.id) === normalized || normalizeCountryKey(country.code) === normalized
   );
+}
+
+function getCountryCodeFromIdentifier(identifier: string, fallbackCode: string) {
+  const trimmedIdentifier = identifier.trim();
+  const isoMatch = trimmedIdentifier.match(/^iso[-_ ]?([a-z]{2,3})$/i);
+  if (isoMatch) {
+    return isoMatch[1].toUpperCase();
+  }
+
+  return trimmedIdentifier.length > 0 && trimmedIdentifier.length <= 3 ? trimmedIdentifier.toUpperCase() : fallbackCode;
+}
+
+function getCountryDisplayNameFromIdentifier(identifier: string, fallbackCode: string) {
+  const countryCode = getCountryCodeFromIdentifier(identifier, fallbackCode);
+  return worldMapCountryNameByCode.get(countryCode) ?? countryCode;
 }
 
 function toInitialStackRoute(route: ScreenRoute): keyof RootStackParamList {
@@ -311,28 +332,36 @@ export default function App() {
         return fromDiscovery;
       }
 
+      const fromKnownCountry = findCountryByIdentifier(allYearsDiscoveryCountries, selectedCountryId) ?? findCountryByIdentifier(countries, selectedCountryId);
+      if (fromKnownCountry) {
+        return {
+          ...fromKnownCountry,
+          hiddenSongs: currentRoute === "country" || currentRoute === "hiddenGems" ? Math.max(fromKnownCountry.hiddenSongs, 1) : fromKnownCountry.hiddenSongs,
+        };
+      }
+
       if (currentRoute === "country" || currentRoute === "hiddenGems") {
-        const inferredCode = selectedCountryId && selectedCountryId.length <= 3 ? selectedCountryId.toUpperCase() : featuredCountry.code;
+        const inferredCode = getCountryCodeFromIdentifier(selectedCountryId, featuredCountry.code);
         return {
           ...featuredCountry,
           id: selectedCountryId || featuredCountry.id,
           code: inferredCode,
-          name: "Loading country...",
-          region: "Loading country data...",
+          name: getCountryDisplayNameFromIdentifier(selectedCountryId, inferredCode),
+          region: featuredCountry.region,
           hiddenSongs: 1,
           genres: [],
           album: "",
           albumArtist: "",
           topSong: "",
           languages: [],
-          sceneNote: "Loading country data...",
+          sceneNote: featuredCountry.sceneNote,
           featuredArtists: [],
         };
       }
 
       return featuredCountry;
     },
-    [apiCountryPool, currentRoute, featuredCountry, selectedCountryId]
+    [allYearsDiscoveryCountries, apiCountryPool, countries, currentRoute, featuredCountry, selectedCountryId]
   );
 
   const comparisonCountryPool = useMemo(
@@ -437,7 +466,18 @@ export default function App() {
 
     switch (route) {
       case "welcome":
-        navigationRef.navigate("welcome");
+        navigationRef.dispatch(
+          CommonActions.reset({
+            index: 1,
+            routes: [
+              {
+                name: "discovery",
+                params: getRouteParams("discovery", selectedYear, selectedCountryId),
+              },
+              { name: "welcome" },
+            ],
+          })
+        );
         break;
       case "discovery":
         navigationRef.navigate("discovery", getRouteParams("discovery", selectedYear, selectedCountryId));
@@ -966,7 +1006,7 @@ export default function App() {
       setLoadingMessage(null);
       return;
     }
-    setLoadingMessage(loading ? "Loading hidden gems..." : null);
+    setLoadingMessage(loading ? "Loading..." : null);
   }, [currentRoute, showHiddenGemsNavIntro]);
 
   if (!fontsLoaded) {

--- a/hidden-gem-music-app/App.tsx
+++ b/hidden-gem-music-app/App.tsx
@@ -18,10 +18,10 @@ import { HiddenGemsScreen } from "./src/screens/HiddenGemsScreen";
 import { WelcomeScreen } from "./src/screens/WelcomeScreen";
 import { loadDiscoveryCountries } from "./src/data/discoveryApi";
 import { loadAvailableYears } from "./src/data/countryApi";
+import { isCountryWithAppData } from "./src/data/countryDisplay";
 import {
   availableYears,
   getCountriesForYear,
-  getCountryByYear,
   getFeaturedCountry,
 } from "./src/data/mockData";
 import { getInitialNavigationSeed, getRouteParams, linking, RootStackParamList } from "./src/navigation/linking";
@@ -49,6 +49,10 @@ function isUiVisibleCountry(country: Pick<Country, "code" | "name">) {
   return country.code.trim().toUpperCase() !== "GLOBAL" && country.name.trim().toLowerCase() !== "global";
 }
 
+function isSelectableApiCountry(country: Country) {
+  return isUiVisibleCountry(country) && isCountryWithAppData(country);
+}
+
 type HiddenGemsFocusSelection = {
   countryId?: string;
   requestKey?: string;
@@ -59,6 +63,7 @@ type HiddenGemsFocusSelection = {
 };
 
 const APP_STATE_STORAGE_KEY = "hidden-gem-app-state-v1";
+const HIDDEN_GEMS_HANDOFF_STORAGE_KEY = "hidden-gems-direct-handoff-v1";
 const DEFAULT_DISCOVERY_YEAR = 2025;
 
 function readPersistedAppState(): PersistedAppState {
@@ -88,6 +93,51 @@ function readPersistedAppState(): PersistedAppState {
     };
   } catch {
     return {};
+  }
+}
+
+function readAndClearHiddenGemsHandoffMarker(seed: { route: ScreenRoute; year?: number; countryId?: string }) {
+  if (seed.route !== "hiddenGems" || typeof window === "undefined") {
+    return false;
+  }
+
+  try {
+    const rawValue = window.sessionStorage.getItem(HIDDEN_GEMS_HANDOFF_STORAGE_KEY);
+    window.sessionStorage.removeItem(HIDDEN_GEMS_HANDOFF_STORAGE_KEY);
+    if (!rawValue) {
+      return false;
+    }
+
+    const parsedValue = JSON.parse(rawValue) as { countryId?: string; year?: number };
+    const markerCountry = typeof parsedValue.countryId === "string" ? normalizeCountryKey(parsedValue.countryId) : "";
+    const seedCountry = typeof seed.countryId === "string" ? normalizeCountryKey(seed.countryId) : "";
+    return Boolean(markerCountry && seedCountry && markerCountry === seedCountry && parsedValue.year === seed.year);
+  } catch {
+    return false;
+  }
+}
+
+function writeHiddenGemsHandoffMarker(countryId: string, year: number) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.sessionStorage.setItem(HIDDEN_GEMS_HANDOFF_STORAGE_KEY, JSON.stringify({ countryId, year }));
+  } catch {
+    // Ignore sessionStorage failures; the direct handoff still works before refresh.
+  }
+}
+
+function clearHiddenGemsHandoffMarker() {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.sessionStorage.removeItem(HIDDEN_GEMS_HANDOFF_STORAGE_KEY);
+  } catch {
+    // Ignore sessionStorage failures.
   }
 }
 
@@ -190,6 +240,10 @@ export default function App() {
   const initialNavigationSeed = initialNavigationSeedRef.current;
   const initialStackRoute = toInitialStackRoute(initialNavigationSeed.route);
   const persistedAppState = persistedAppStateRef.current;
+  const shouldResetHiddenGemsHandoffOnInitialLoad = readAndClearHiddenGemsHandoffMarker(initialNavigationSeed);
+  const shouldStartHiddenGemsWithIntro =
+    initialNavigationSeed.route === "hiddenGems" &&
+    (shouldResetHiddenGemsHandoffOnInitialLoad || !initialNavigationSeed.countryId || typeof initialNavigationSeed.year !== "number");
   const initialYear =
     initialNavigationSeed.route === "country" ||
     initialNavigationSeed.route === "hiddenGems" ||
@@ -198,18 +252,20 @@ export default function App() {
       ? initialNavigationSeed.year ?? DEFAULT_DISCOVERY_YEAR
       : DEFAULT_DISCOVERY_YEAR;
   const initialFeaturedCountry = getFeaturedCountry(initialYear);
+  const initialSelectedCountryId =
+    initialNavigationSeed.route === "country" || initialNavigationSeed.route === "hiddenGems"
+      ? initialNavigationSeed.countryId ?? initialFeaturedCountry.id
+      : initialFeaturedCountry.id;
 
   const [navigationReady, setNavigationReady] = useState(false);
   const [currentRoute, setCurrentRoute] = useState<ScreenRoute>(initialNavigationSeed.route);
   const [selectedYear, setSelectedYear] = useState(initialYear);
-  const [selectedCountryId, setSelectedCountryId] = useState(
-    initialNavigationSeed.countryId ?? persistedAppState.selectedCountryId ?? initialFeaturedCountry.id
-  );
+  const [selectedCountryId, setSelectedCountryId] = useState(initialSelectedCountryId);
   const [comparisonIds, setComparisonIds] = useState<string[]>(
     initialNavigationSeed.route === "comparisonResults" ? persistedAppState.comparisonIds ?? [] : []
   );
   const [loadingMessage, setLoadingMessage] = useState<string | null>(null);
-  const [showHiddenGemsNavIntro, setShowHiddenGemsNavIntro] = useState(false);
+  const [showHiddenGemsNavIntro, setShowHiddenGemsNavIntro] = useState(shouldStartHiddenGemsWithIntro);
   const [hiddenGemsFocusSelection, setHiddenGemsFocusSelection] = useState<HiddenGemsFocusSelection | null>(null);
   const [searchOpen, setSearchOpen] = useState(false);
   const [apiAvailableYears, setApiAvailableYears] = useState<number[]>([]);
@@ -238,13 +294,13 @@ export default function App() {
     }
 
     const merged = Array.from(byId.values())
-      .filter(isUiVisibleCountry)
+      .filter(isSelectableApiCountry)
       .sort((a, b) => a.name.localeCompare(b.name));
-    return merged.length > 0 ? merged : discoveryCountries;
+    return merged.length > 0 ? merged : discoveryCountries.filter(isSelectableApiCountry);
   }, [apiAvailableYears, discoveryCountries, discoveryCountriesByYear]);
   const featuredCountry = useMemo(() => getFeaturedCountry(selectedYear), [selectedYear]);
   const apiCountryPool = useMemo(
-    () => (cachedCountriesForSelectedYear.length > 0 ? cachedCountriesForSelectedYear : discoveryCountries).filter(isUiVisibleCountry),
+    () => (cachedCountriesForSelectedYear.length > 0 ? cachedCountriesForSelectedYear : discoveryCountries).filter(isSelectableApiCountry),
     [cachedCountriesForSelectedYear, discoveryCountries]
   );
 
@@ -255,11 +311,6 @@ export default function App() {
         return fromDiscovery;
       }
 
-      const fromCurrentYear = findCountryByIdentifier(countries, selectedCountryId);
-      if (fromCurrentYear) {
-        return fromCurrentYear;
-      }
-
       if (currentRoute === "country" || currentRoute === "hiddenGems") {
         const inferredCode = selectedCountryId && selectedCountryId.length <= 3 ? selectedCountryId.toUpperCase() : featuredCountry.code;
         return {
@@ -268,20 +319,20 @@ export default function App() {
           code: inferredCode,
           name: "Loading country...",
           region: "Loading country data...",
-          hiddenSongs: 0,
-          genres: ["Loading..."],
-          album: "Loading...",
-          albumArtist: "Loading...",
-          topSong: "Loading...",
-          languages: ["Loading..."],
+          hiddenSongs: 1,
+          genres: [],
+          album: "",
+          albumArtist: "",
+          topSong: "",
+          languages: [],
           sceneNote: "Loading country data...",
-          featuredArtists: ["Loading..."],
+          featuredArtists: [],
         };
       }
 
       return featuredCountry;
     },
-    [apiCountryPool, countries, currentRoute, featuredCountry, selectedCountryId]
+    [apiCountryPool, currentRoute, featuredCountry, selectedCountryId]
   );
 
   const comparisonCountryPool = useMemo(
@@ -312,6 +363,12 @@ export default function App() {
           { label: selectedCountry.name, route: null },
         ];
       case "hiddenGems":
+        if (showHiddenGemsNavIntro) {
+          return [
+            { label: "Welcome", route: "welcome" as ScreenRoute },
+            { label: "Hidden Gems", route: null },
+          ];
+        }
         return [
           { label: "Welcome", route: "welcome" as ScreenRoute },
           { label: selectedCountry.name, route: "country" as ScreenRoute },
@@ -341,7 +398,7 @@ export default function App() {
       default:
         return [{ label: "Welcome", route: "welcome" as ScreenRoute }];
     }
-  }, [currentRoute, selectedCountry.name]);
+  }, [currentRoute, selectedCountry.name, showHiddenGemsNavIntro]);
 
   const syncStateFromNavigation = () => {
     if (!navigationRef.isReady()) {
@@ -368,7 +425,7 @@ export default function App() {
       setSelectedYear((current) => (current === params.year ? current : params.year!));
     }
 
-    if (typeof params.country === "string") {
+    if ((nextRoute === "country" || nextRoute === "hiddenGems") && typeof params.country === "string") {
       setSelectedCountryId((current) => (current === params.country ? current : params.country!));
     }
   };
@@ -389,8 +446,10 @@ export default function App() {
         navigationRef.navigate("country", getRouteParams("country", selectedYear, selectedCountryId));
         break;
       case "hiddenGems":
+        clearHiddenGemsHandoffMarker();
         setShowHiddenGemsNavIntro(true);
-        navigationRef.navigate("hiddenGems", getRouteParams("hiddenGems", selectedYear, selectedCountryId));
+        setHiddenGemsFocusSelection(null);
+        navigationRef.navigate("hiddenGems");
         break;
       case "comparisonSelect":
         if (currentRoute !== "comparisonResults") {
@@ -444,6 +503,7 @@ export default function App() {
         : null
     );
     setShowHiddenGemsNavIntro(false);
+    writeHiddenGemsHandoffMarker(selectedCountryId, selectedYear);
     navigationRef.navigate("hiddenGems", getRouteParams("hiddenGems", selectedYear, selectedCountryId));
   };
 
@@ -483,14 +543,11 @@ export default function App() {
   };
 
   const openCountryFromDiscovery = (countryId: string) => {
-    const existsInCurrentYear = countries.some(
-      (country) => country.id === countryId || country.code === countryId
-    );
     const existsInDiscovery = apiCountryPool.some(
       (country) => country.id === countryId || country.code === countryId
     );
 
-    if (existsInCurrentYear || existsInDiscovery) {
+    if (existsInDiscovery) {
       openCountry(countryId);
       return;
     }
@@ -509,6 +566,7 @@ export default function App() {
       selection ? { ...selection, countryId, requestKey: `${Date.now()}-${Math.random()}` } : null
     );
     setShowHiddenGemsNavIntro(false);
+    writeHiddenGemsHandoffMarker(countryId, selectedYear);
 
     if (!navigationRef.isReady()) {
       return;
@@ -525,15 +583,14 @@ export default function App() {
       return;
     }
 
-    const existsInStatic = countries.some((country) => country.id === selectedCountryId || country.code === selectedCountryId);
     const existsInDiscovery = discoveryCountries.some(
       (country) => country.id === selectedCountryId || country.code === selectedCountryId
     );
 
-    if (!existsInStatic && !existsInDiscovery) {
+    if (!existsInDiscovery) {
       setSelectedCountryId(featuredCountry.id);
     }
-  }, [apiCountryPool, countries, currentRoute, featuredCountry.id, selectedCountryId]);
+  }, [apiCountryPool, currentRoute, discoveryCountries, featuredCountry.id, selectedCountryId]);
 
   useEffect(() => {
     setComparisonIds((current) => {
@@ -568,13 +625,15 @@ export default function App() {
     }
 
     const routeName = activeRoute.name as ScreenRoute;
-    const nextParams = getRouteParams(routeName, selectedYear, selectedCountryId);
+    const nextParams = routeName === "hiddenGems" && showHiddenGemsNavIntro
+      ? { country: undefined, year: undefined }
+      : getRouteParams(routeName, selectedYear, selectedCountryId);
     const currentParams = (activeRoute.params ?? undefined) as RouteParams | undefined;
 
     if (nextParams && !areRouteParamsEqual(currentParams, nextParams)) {
       navigationRef.dispatch(CommonActions.setParams(nextParams));
     }
-  }, [currentRoute, navigationReady, navigationRef, selectedCountryId, selectedYear]);
+  }, [currentRoute, navigationReady, navigationRef, selectedCountryId, selectedYear, showHiddenGemsNavIntro]);
 
   useEffect(() => {
     if (!navigationReady || !navigationRef.isReady()) {
@@ -858,7 +917,6 @@ export default function App() {
         APP_STATE_STORAGE_KEY,
         JSON.stringify({
           selectedYear,
-          selectedCountryId,
           comparisonIds: comparisonIds.slice(0, 2),
         } satisfies PersistedAppState)
       );
@@ -878,6 +936,12 @@ export default function App() {
       hasSeenDiscoveryLoadingRef.current = false;
       setLoadingMessage(`Refreshing ${context} for ${nextYear}...`);
       setIsDiscoveryLoading(true);
+      setSelectedYear(nextYear);
+      return;
+    }
+
+    if (currentRoute === "hiddenGems") {
+      setLoadingMessage(`Refreshing ${context} for ${nextYear}...`);
       setSelectedYear(nextYear);
       return;
     }
@@ -985,7 +1049,7 @@ export default function App() {
                   <DiscoveryScreen
                     isActive={currentRoute === "discovery"}
                     isLoading={isDiscoveryLoading && discoveryCountries.length === 0}
-                    countries={discoveryCountries}
+                    countries={apiCountryPool}
                     allYearsCountries={allYearsDiscoveryCountries}
                     selectedCountryId={selectedCountryId}
                     onSelectCountry={(countryId) => setSelectedCountryId(countryId)}

--- a/hidden-gem-music-app/Documentation/README.md
+++ b/hidden-gem-music-app/Documentation/README.md
@@ -47,6 +47,7 @@ The goal is to avoid repeating the same content across multiple files. If a topi
   - per-screen fetch flow
   - cache/reuse behavior
   - additional-data integration points
+  - country display filtering and fetch timeout/retry behavior
 
 - `interaction-loading-and-overlay-rules.md`
   - popup/overlay behavior
@@ -92,6 +93,9 @@ These are development terms, not necessarily user-facing labels.
 - Hidden song list panel: paged Hidden Gems song-row list.
 - Playing side panel: main selected-song detail panel in Hidden Gems.
 - Nav intro: introductory Hidden Gems prompt/state shown before a country/year selection is confirmed.
+- Section loading veil: glassy/dimmed `Loading...` layer used over loading sections without changing the section layout.
+- Country display helper: shared frontend helper for separating general app-data country filtering from Hidden-Gems-specific availability filtering.
+- Fetch timeout helper: shared frontend fetch wrapper that applies request timeout/retry behavior without retrying aborts or timeouts.
 - Explicit indicator: `E` badge for explicit lyrics or cover content. Code: `src/components/ExplicitIndicator.tsx`.
 - App header: top navigation/header on web layouts. Code: `src/components/AppHeader.tsx`.
 - Mobile bottom nav: bottom navigation on mobile layouts. Code: `src/components/MobileBottomNav.tsx`.

--- a/hidden-gem-music-app/Documentation/frontend-architecture.md
+++ b/hidden-gem-music-app/Documentation/frontend-architecture.md
@@ -203,6 +203,8 @@ Main data-layer files:
 - `src/data/discoveryApi.ts`
 - `src/data/countryApi.ts`
 - `src/data/apiMappers.ts`
+- `src/data/fetchWithTimeout.ts`
+- `src/data/countryDisplay.ts`
 
 Responsibilities:
 
@@ -210,18 +212,22 @@ Responsibilities:
 - fetch helpers
 - cache/reuse maps
 - backend-response mapping into frontend-friendly shapes
+- shared country-display filtering rules
+- stable request timeout/retry behavior
 
 ## Mock/static data role
 
 Mock/static data still exists in:
 
 - `src/data/mockData.ts`
+- `src/assets/maps/worldMap50m.ts`
 
 Current role of that file:
 
 - fallback data
 - default country/year scaffolding
 - UI bootstrapping help where API data is not yet the only source of truth
+- ISO country-name lookup for stable route/header/breadcrumb labels during API reload gaps
 
 It should not be treated as the long-term source of truth for live app behavior where backend data already exists.
 

--- a/hidden-gem-music-app/Documentation/interaction-loading-and-overlay-rules.md
+++ b/hidden-gem-music-app/Documentation/interaction-loading-and-overlay-rules.md
@@ -33,6 +33,7 @@ Current rules:
 - welcome preview content should stay guarded during the close transition and short cooldown
 - clicking outside the welcome modal should behave like the `Discovery Map` action, not like a dangerous bare click-through
 - welcome modal route buttons should close through the guarded route-transition path rather than bypassing the modal state
+- navigating to Welcome from the header or breadcrumbs should reset to the normal Welcome-over-Discovery stack, not layer the Welcome modal over the current active page
 - welcome route buttons should show visible pressed styling on mobile before route work begins
 - welcome dismissal must check whether navigation can go back before calling `goBack`
 - if there is no route to pop, welcome dismissal should navigate to Discovery instead of dispatching an unhandled back action
@@ -75,6 +76,9 @@ Current rules:
 - when the Hidden Gems nav intro is active, the underlying page frame should not stay interactable
 - focus-selection handoff from other screens should resolve only when the target country actually matches the active Hidden Gems context
 - page fallback should not override a stronger exact match when a stronger match is available
+- direct Hidden Gems reload/direct navigation without confirmed country/year params should show the country/year intro prompt
+- app-driven Hidden Gems navigation from Country or preview flows should open the intended country/year page without showing the intro prompt
+- Hidden Gems list, now-playing, and favorite-artists sections should use the shared glassy/dimmed `Loading...` veil while their data is loading
 
 ## Explicit badge rules
 
@@ -98,6 +102,8 @@ Current rules:
 
 - loading text should remain visually stable enough that sections do not jump excessively
 - shared loading text helpers should be reused instead of rebuilding one-off animated loading strings in many screens
+- shared/app-level loading copy should stay neutral as `Loading...` unless a feature-specific message is intentionally required
+- Hidden Gems should not use a separate app-wide `Loading hidden gems...` message when the screen already has section-level loading treatment
 
 ## Discovery scroll and sidebar rules
 

--- a/hidden-gem-music-app/Documentation/routing-state-and-navigation.md
+++ b/hidden-gem-music-app/Documentation/routing-state-and-navigation.md
@@ -140,6 +140,7 @@ Current welcome/navigation guard:
 - welcome dismissal should use `navigationRef.canGoBack()` before calling `goBack`
 - if the welcome screen has no back route to pop, the app should navigate to Discovery directly
 - mobile welcome route buttons should guard against repeated taps during the closing transition
+- header/breadcrumb navigation to `Welcome` should reset into the normal Welcome-over-Discovery stack instead of stacking the Welcome modal over the current active page
 
 Current country-opening rule from Discovery on mobile:
 
@@ -150,6 +151,13 @@ Current country-opening rule from Discovery on mobile:
 ## Hidden Gems focus-selection handoff
 
 Hidden Gems uses app-owned focus handoff so a preview click from another screen can open the full Hidden Gems screen on the intended song.
+
+Direct/reload behavior:
+
+- direct `/hidden-gems` navigation without a confirmed country/year context should show the Hidden Gems country/year intro prompt
+- app-driven Hidden Gems navigation from Country pages or hidden-gem preview clicks should bypass the intro and open the intended country/year page
+- `App.tsx` uses a short-lived session handoff marker to distinguish app-driven Hidden Gems navigation from a fresh direct/reload path
+- when the Hidden Gems intro is active, route params should not force a stale country/year back onto the intro route
 
 Current focus-selection payload can include:
 
@@ -172,6 +180,8 @@ Important behavior:
 - country-sensitive screens keep both `year` and `country` in sync
 - active-route params are updated through `CommonActions.setParams`
 - Discovery default-year behavior is intentionally app-owned so initial Discovery load can use the current product default year without depending on stale route params
+- Country and Hidden Gems headers, breadcrumbs, and document titles should keep a stable full country name while a selected year's API country pool reloads
+- temporary route fallback labels should use known country metadata or ISO/world-map lookup instead of showing `Loading country...` or raw codes such as `AR`
 
 ## Comparison state rules
 

--- a/hidden-gem-music-app/Documentation/screen-data-flow.md
+++ b/hidden-gem-music-app/Documentation/screen-data-flow.md
@@ -35,6 +35,8 @@ This file treats `apiBaseUrl.ts` as part of the frontend data seam, but the loca
 - `src/data/discoveryApi.ts`
 - `src/data/countryApi.ts`
 - `src/data/apiMappers.ts`
+- `src/data/fetchWithTimeout.ts`
+- `src/data/countryDisplay.ts`
 
 These files are the main frontend seam between:
 
@@ -191,6 +193,23 @@ Important current rules:
 - do not over-pull more data than needed for the active page
 - keep page counts based on the real backend total count
 - dedupe songs on the frontend mapping side when the response shape needs that protection
+- Hidden Gems country/year prompt options should use the Hidden-Gems-specific availability filter, not the broader app-data country filter
+- general Discovery/Country/Comparison country pools should not disappear only because a country has zero hidden gems for the selected year
+- while the selected year's API country pool reloads, route/header/breadcrumb labels should use stable known country metadata instead of loading placeholders or raw ISO codes
+- API route ids such as `iso-ar` can be resolved through the world-map ISO metadata so user-facing labels can remain full names such as `Argentina`
+
+## Fetch timeout and retry behavior
+
+Main file:
+
+- `src/data/fetchWithTimeout.ts`
+
+Current rules:
+
+- data helpers should use the shared timeout/retry wrapper where that wrapper is already wired in
+- aborts should not be retried
+- request timeouts should not be retried as a second full timeout window
+- retry should stay limited to likely transient network fetch failures
 
 ## Additional-data field behavior
 

--- a/hidden-gem-music-app/src/data/countryApi.ts
+++ b/hidden-gem-music-app/src/data/countryApi.ts
@@ -1,5 +1,6 @@
 import type { ApiCountryGenreSample, ApiCountryHiddenGemPreview, ApiCountryProfile, ApiCountrySongsPage, ApiHiddenGemResponse } from "../types/api";
 import { getApiBaseUrl } from "./apiBaseUrl";
+import { fetchWithTimeoutAndRetry } from "./fetchWithTimeout";
 
 const countryProfileCache = new Map<string, ApiCountryProfile>();
 const countryHiddenGemsPreviewCache = new Map<string, ApiCountryHiddenGemPreview[]>();
@@ -46,7 +47,7 @@ export async function loadCountryProfile(countryCode: string, year: number, sign
 
   const baseUrl = getApiBaseUrl().replace(/\/$/, "");
   const endpoint = `${baseUrl}/api/country/${countryCode}?year=${year}`;
-  const response = await fetch(endpoint, { signal });
+  const response = await fetchWithTimeoutAndRetry(endpoint, {}, signal);
   const payload = await parseJsonResponse<ApiCountryProfile>(response, endpoint);
   countryProfileCache.set(cacheKey, payload);
   return payload;
@@ -108,7 +109,7 @@ export async function loadHiddenGemsPage(
 
   const baseUrl = getApiBaseUrl().replace(/\/$/, "");
   const endpoint = `${baseUrl}/api/hidden-gems/${countryCode}?year=${year}&minCountries=${minCountries}&page=${page}&pageSize=${pageSize}`;
-  const response = await fetch(endpoint, { signal });
+  const response = await fetchWithTimeoutAndRetry(endpoint, {}, signal);
   const payload = await parseJsonResponse<ApiHiddenGemResponse>(response, endpoint);
   hiddenGemsPageCache.set(cacheKey, payload);
   return payload;
@@ -117,7 +118,7 @@ export async function loadHiddenGemsPage(
 export async function loadAvailableYears(signal?: AbortSignal): Promise<number[]> {
   const baseUrl = getApiBaseUrl().replace(/\/$/, "");
   const endpoint = `${baseUrl}/api/metadata/years`;
-  const response = await fetch(endpoint, { signal });
+  const response = await fetchWithTimeoutAndRetry(endpoint, {}, signal);
   const payload = await parseJsonResponse<unknown[]>(response, endpoint);
 
   return payload
@@ -144,7 +145,7 @@ export async function loadCountrySongsPage(
 
   const baseUrl = getApiBaseUrl().replace(/\/$/, "");
   const endpoint = `${baseUrl}/api/country/${countryCode}/songs?year=${year}&listType=${listType}&page=${page}&pageSize=${pageSize}`;
-  const response = await fetch(endpoint, { signal });
+  const response = await fetchWithTimeoutAndRetry(endpoint, {}, signal);
   const payload = await parseJsonResponse<ApiCountrySongsPage>(response, endpoint);
   countrySongsPageCache.set(cacheKey, payload);
   return payload;
@@ -181,7 +182,7 @@ export async function loadCountryGenreSamples(
 
   const baseUrl = getApiBaseUrl().replace(/\/$/, "");
   const endpoint = `${baseUrl}/api/country/genre-samples?year=${year}&codes=${encodeURIComponent(missingCodes.join(","))}`;
-  const response = await fetch(endpoint, { signal });
+  const response = await fetchWithTimeoutAndRetry(endpoint, {}, signal);
   const payload = await parseJsonResponse<ApiCountryGenreSample[]>(response, endpoint);
   payload.forEach((item) => {
     countryGenreSampleCache.set(buildCountryGenreSampleKey(item.countryCode, year), item);

--- a/hidden-gem-music-app/src/data/countryDisplay.ts
+++ b/hidden-gem-music-app/src/data/countryDisplay.ts
@@ -7,8 +7,16 @@ export function normalizeCountryDisplayName(value: string) {
     .trim();
 }
 
-export function isCountryWithAppData(country: Pick<Country, "code" | "name" | "hiddenSongs" | "hasSongData">) {
+function isVisibleCountry(country: Pick<Country, "code" | "name">) {
   const normalizedCode = country.code.trim().toUpperCase();
   const normalizedName = country.name.trim().toLowerCase();
-  return normalizedCode !== "GLOBAL" && normalizedName !== "global" && country.hasSongData !== false && country.hiddenSongs > 0;
+  return normalizedCode !== "GLOBAL" && normalizedName !== "global";
+}
+
+export function isCountryWithAppData(country: Pick<Country, "code" | "name" | "hasSongData">) {
+  return isVisibleCountry(country) && country.hasSongData !== false;
+}
+
+export function isCountryWithHiddenGems(country: Pick<Country, "code" | "name" | "hiddenSongs" | "hasSongData">) {
+  return isCountryWithAppData(country) && country.hiddenSongs > 0;
 }

--- a/hidden-gem-music-app/src/data/countryDisplay.ts
+++ b/hidden-gem-music-app/src/data/countryDisplay.ts
@@ -1,0 +1,14 @@
+import type { Country } from "../types/content";
+
+export function normalizeCountryDisplayName(value: string) {
+  return value
+    .replace(/\|/g, "'")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function isCountryWithAppData(country: Pick<Country, "code" | "name" | "hiddenSongs" | "hasSongData">) {
+  const normalizedCode = country.code.trim().toUpperCase();
+  const normalizedName = country.name.trim().toLowerCase();
+  return normalizedCode !== "GLOBAL" && normalizedName !== "global" && country.hasSongData !== false && country.hiddenSongs > 0;
+}

--- a/hidden-gem-music-app/src/data/dashboardApi.ts
+++ b/hidden-gem-music-app/src/data/dashboardApi.ts
@@ -8,6 +8,7 @@ import type {
   ApiTrendPoint,
 } from "../types/api";
 import { getApiBaseUrl } from "./apiBaseUrl";
+import { fetchWithTimeoutAndRetry } from "./fetchWithTimeout";
 
 async function parseJsonResponse<T>(response: Response, endpoint: string): Promise<T> {
   if (!response.ok) {
@@ -19,48 +20,48 @@ async function parseJsonResponse<T>(response: Response, endpoint: string): Promi
 export async function loadOverlapRate(start: string, end: string): Promise<ApiOverlapRate> {
   const baseUrl = getApiBaseUrl().replace(/\/$/, "");
   const endpoint = `${baseUrl}/api/dashboard/overlap-rate?start=${start}&end=${end}`;
-  const response = await fetch(endpoint);
+  const response = await fetchWithTimeoutAndRetry(endpoint);
   return parseJsonResponse<ApiOverlapRate>(response, endpoint);
 }
 
 export async function loadDiscoveryGap(start: string, end: string): Promise<ApiDiscoveryGap> {
   const baseUrl = getApiBaseUrl().replace(/\/$/, "");
   const endpoint = `${baseUrl}/api/dashboard/discovery-gap?start=${start}&end=${end}`;
-  const response = await fetch(endpoint);
+  const response = await fetchWithTimeoutAndRetry(endpoint);
   return parseJsonResponse<ApiDiscoveryGap>(response, endpoint);
 }
 
 export async function loadIsolationLeader(start: string, end: string): Promise<ApiIsolationLeader> {
   const baseUrl = getApiBaseUrl().replace(/\/$/, "");
   const endpoint = `${baseUrl}/api/dashboard/isolation-leader?start=${start}&end=${end}`;
-  const response = await fetch(endpoint);
+  const response = await fetchWithTimeoutAndRetry(endpoint);
   return parseJsonResponse<ApiIsolationLeader>(response, endpoint);
 }
 
 export async function loadPeakReach(start: string, end: string): Promise<ApiPeakReach> {
   const baseUrl = getApiBaseUrl().replace(/\/$/, "");
   const endpoint = `${baseUrl}/api/dashboard/peak-reach?start=${start}&end=${end}`;
-  const response = await fetch(endpoint);
+  const response = await fetchWithTimeoutAndRetry(endpoint);
   return parseJsonResponse<ApiPeakReach>(response, endpoint);
 }
 
 export async function loadOverlapTrend(start: string, end: string): Promise<ApiTrendPoint[]> {
   const baseUrl = getApiBaseUrl().replace(/\/$/, "");
   const endpoint = `${baseUrl}/api/dashboard/overlap-trend?start=${start}&end=${end}`;
-  const response = await fetch(endpoint);
+  const response = await fetchWithTimeoutAndRetry(endpoint);
   return parseJsonResponse<ApiTrendPoint[]>(response, endpoint);
 }
 
 export async function loadIsolationRanking(start: string, end: string): Promise<ApiIsolationEntry[]> {
   const baseUrl = getApiBaseUrl().replace(/\/$/, "");
   const endpoint = `${baseUrl}/api/dashboard/isolation-ranking?start=${start}&end=${end}`;
-  const response = await fetch(endpoint);
+  const response = await fetchWithTimeoutAndRetry(endpoint);
   return parseJsonResponse<ApiIsolationEntry[]>(response, endpoint);
 }
 
 export async function loadGapDistribution(start: string, end: string): Promise<ApiGapBucket[]> {
   const baseUrl = getApiBaseUrl().replace(/\/$/, "");
   const endpoint = `${baseUrl}/api/dashboard/gap-distribution?start=${start}&end=${end}`;
-  const response = await fetch(endpoint);
+  const response = await fetchWithTimeoutAndRetry(endpoint);
   return parseJsonResponse<ApiGapBucket[]>(response, endpoint);
 }

--- a/hidden-gem-music-app/src/data/discoveryApi.ts
+++ b/hidden-gem-music-app/src/data/discoveryApi.ts
@@ -2,12 +2,14 @@ import type { Country } from "../types/content";
 import { mapApiCountryGlobeSummary } from "./apiMappers";
 import type { ApiCountryGlobeSummary } from "../types/api";
 import { getApiBaseUrl } from "./apiBaseUrl";
+import { normalizeCountryDisplayName } from "./countryDisplay";
+import { fetchWithTimeoutAndRetry } from "./fetchWithTimeout";
 
 export async function loadDiscoveryCountries(year: number, fallbackCountries: Country[], signal?: AbortSignal): Promise<Country[]> {
   const existingByCode = new Map(fallbackCountries.map((country) => [country.code.toUpperCase(), country]));
   const baseUrl = getApiBaseUrl().replace(/\/$/, "");
   const endpoint = `${baseUrl}/api/discovery/countries?year=${year}`;
-  const response = await fetch(endpoint, { signal });
+  const response = await fetchWithTimeoutAndRetry(endpoint, {}, signal);
 
   if (!response.ok) {
     throw new Error(`Discovery country request failed with status ${response.status}.`);
@@ -24,7 +26,7 @@ export async function loadDiscoveryCountries(year: number, fallbackCountries: Co
     return {
       id: `iso-${normalizedCode.toLowerCase() || index}`,
       code: normalizedCode,
-      name: mapped.countryName,
+      name: normalizeCountryDisplayName(mapped.countryName),
       region: mapped.region,
       lat: typeof mapped.lat === "number" ? mapped.lat : existing?.lat ?? 0,
       long: typeof mapped.long === "number" ? mapped.long : existing?.long ?? 0,

--- a/hidden-gem-music-app/src/data/fetchWithTimeout.ts
+++ b/hidden-gem-music-app/src/data/fetchWithTimeout.ts
@@ -56,6 +56,18 @@ async function fetchOnce(endpoint: string, init: RequestInit, parentSignal?: Abo
   }
 }
 
+function shouldRetryFetchError(error: unknown) {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  if (error.name === "AbortError" || error.name === "TimeoutError") {
+    return false;
+  }
+
+  return error.name === "TypeError" || error.name === "NetworkError";
+}
+
 export async function fetchWithTimeoutAndRetry(
   endpoint: string,
   init: RequestInit = {},
@@ -68,6 +80,9 @@ export async function fetchWithTimeoutAndRetry(
     return await fetchOnce(endpoint, initWithoutSignal, parentSignal, timeoutMs);
   } catch (error) {
     if (parentSignal?.aborted) {
+      throw error;
+    }
+    if (!shouldRetryFetchError(error)) {
       throw error;
     }
     return fetchOnce(endpoint, initWithoutSignal, parentSignal, timeoutMs);

--- a/hidden-gem-music-app/src/data/fetchWithTimeout.ts
+++ b/hidden-gem-music-app/src/data/fetchWithTimeout.ts
@@ -1,0 +1,75 @@
+const DEFAULT_REQUEST_TIMEOUT_MS = 60000;
+
+function createAbortError() {
+  try {
+    return new DOMException("The request was aborted.", "AbortError");
+  } catch {
+    const error = new Error("The request was aborted.");
+    error.name = "AbortError";
+    return error;
+  }
+}
+
+function createTimeoutError(endpoint: string) {
+  const error = new Error(`Request timed out after 60 seconds for ${endpoint}.`);
+  error.name = "TimeoutError";
+  return error;
+}
+
+function mergeAbortSignals(signal: AbortSignal | undefined, timeoutMs: number, endpoint: string) {
+  const controller = new AbortController();
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+  const abortFromParent = () => {
+    controller.abort(signal?.reason ?? createAbortError());
+  };
+
+  if (signal?.aborted) {
+    abortFromParent();
+  } else {
+    signal?.addEventListener("abort", abortFromParent, { once: true });
+    timeoutId = setTimeout(() => {
+      controller.abort(createTimeoutError(endpoint));
+    }, timeoutMs);
+  }
+
+  return {
+    signal: controller.signal,
+    cleanup: () => {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+      signal?.removeEventListener("abort", abortFromParent);
+    },
+  };
+}
+
+async function fetchOnce(endpoint: string, init: RequestInit, parentSignal?: AbortSignal, timeoutMs = DEFAULT_REQUEST_TIMEOUT_MS) {
+  const mergedSignal = mergeAbortSignals(parentSignal, timeoutMs, endpoint);
+  try {
+    return await fetch(endpoint, {
+      ...init,
+      signal: mergedSignal.signal,
+    });
+  } finally {
+    mergedSignal.cleanup();
+  }
+}
+
+export async function fetchWithTimeoutAndRetry(
+  endpoint: string,
+  init: RequestInit = {},
+  parentSignal?: AbortSignal,
+  timeoutMs = DEFAULT_REQUEST_TIMEOUT_MS
+) {
+  const { signal: _ignoredSignal, ...initWithoutSignal } = init;
+
+  try {
+    return await fetchOnce(endpoint, initWithoutSignal, parentSignal, timeoutMs);
+  } catch (error) {
+    if (parentSignal?.aborted) {
+      throw error;
+    }
+    return fetchOnce(endpoint, initWithoutSignal, parentSignal, timeoutMs);
+  }
+}

--- a/hidden-gem-music-app/src/screens/ComparisonResultsScreen.tsx
+++ b/hidden-gem-music-app/src/screens/ComparisonResultsScreen.tsx
@@ -24,7 +24,7 @@ import { SecondarySurfaceFill } from "../components/SecondarySurfaceFill";
 import { getCachedCountryGenreSamples, loadAvailableYears, loadCountryHiddenGemsPreview, loadCountryProfile, loadCountrySongsPage } from "../data/countryApi";
 import { hasKnownSongTitle, mapApiCountryProfile, mapApiSong } from "../data/apiMappers";
 import { useLoadingText, useStableLoadingText } from "../hooks/useLoadingText";
-import { getSongsForCountryYear } from "../data/mockData";
+import { isCountryWithAppData } from "../data/countryDisplay";
 import { Country } from "../types/content";
 import { colors } from "../theme/colors";
 import { typefaces } from "../theme/typography";
@@ -491,6 +491,25 @@ function CountryPageSection({
   );
 }
 
+function SectionLoadingVeil({ visible }: { visible: boolean }) {
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <View style={styles.sectionLoadingVeil} pointerEvents="none">
+      <LinearGradient
+        colors={["rgba(15,16,21,0.72)", "rgba(66,72,101,0.64)", "rgba(15,16,21,0.78)"]}
+        locations={[0, 0.48, 1]}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 1, y: 1 }}
+        style={styles.sectionLoadingVeilFill}
+      />
+      <Text style={styles.sectionLoadingVeilText}>Loading...</Text>
+    </View>
+  );
+}
+
 function StatSquare({
   label,
   value,
@@ -839,7 +858,6 @@ function MainComparisonArea({
           style={styles.mainComparisonScroll}
           contentContainerStyle={styles.mainComparisonListContent}
           showsVerticalScrollIndicator={false}
-          scrollEnabled={Platform.OS !== "web"}
           onLayout={(event) => setViewportHeight(event.nativeEvent.layout.height)}
           onContentSizeChange={(_, height) => setContentHeight(height)}
           onScroll={handleScroll}
@@ -976,6 +994,7 @@ function MainComparisonArea({
             </View>
           ) : null}
         </ScrollView>
+        <SectionLoadingVeil visible={isInitialLoading} />
         {scrollbarVisible ? (
           <View
             ref={trackRef}
@@ -1240,6 +1259,7 @@ function HiddenSongsCarouselSection({
         />
         </View>
       )}
+      <SectionLoadingVeil visible={isLoading} />
     </CountryPageSection>
   );
 }
@@ -1305,6 +1325,7 @@ function FavoriteArtistsSection({
           ))}
         </ScrollView>
       )}
+      <SectionLoadingVeil visible={isLoading} />
     </CountryPageSection>
   );
 }
@@ -1358,7 +1379,7 @@ function ComparisonCountryPane({
   const countryOptions = useMemo(
     () =>
       availableCountries.filter((countryOption) => {
-        if (getSongsForCountryYear(countryOption.id, selectedYear).length <= 0) {
+        if (!isCountryWithAppData(countryOption)) {
           return false;
         }
         return unavailableCountryId ? countryOption.id === country.id || countryOption.id !== unavailableCountryId : true;
@@ -1787,6 +1808,7 @@ function ComparisonCountryPane({
               <Text style={[styles.countrySummarySectionDetailText, styles.countrySummarySectionTextDark]}>{genreLanguageMixText}</Text>
             </View>
           </View>
+          <SectionLoadingVeil visible={initialLoadingProfile} />
         </CountryPageSection>
 
         <FavoriteArtistsSection
@@ -1821,11 +1843,13 @@ function ComparisonCountryPane({
             note="% of this view"
             style={styles.statStripItem}
           />
+          <SectionLoadingVeil visible={isCoreLoading} />
         </View>
 
         <View style={styles.genreAndLanguageSections}>
           <GenreSection title={`${country.name}'s Loved Genres`} bodyText={lovedGenresSectionText} />
           <LanguageSection title={`${country.name}'s Language(s) in Music`} bodyText="Language information coming soon." />
+          <SectionLoadingVeil visible={isCoreLoading} />
         </View>
 
         <HiddenSongsCarouselSection
@@ -2155,8 +2179,29 @@ const styles = StyleSheet.create({
     padding: 0,
   },
   secondaryPanelContent: {
+    position: "relative",
     padding: 18,
     gap: 16,
+  },
+  sectionLoadingVeil: {
+    ...StyleSheet.absoluteFillObject,
+    borderRadius: 14,
+    overflow: "hidden",
+    zIndex: 50,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  sectionLoadingVeilFill: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  sectionLoadingVeilText: {
+    color: colors.textLight,
+    fontFamily: typefaces.display,
+    fontSize: 20,
+    lineHeight: 24,
+    textShadowColor: "rgba(15,16,21,0.42)",
+    textShadowOffset: { width: 0, height: 2 },
+    textShadowRadius: 8,
   },
   customFill: {
     ...StyleSheet.absoluteFillObject,
@@ -2212,6 +2257,7 @@ const styles = StyleSheet.create({
     lineHeight: 24,
   },
   statStripRow: {
+    position: "relative",
     width: "100%",
     flexDirection: "row",
     gap: 8,
@@ -2260,6 +2306,7 @@ const styles = StyleSheet.create({
     lineHeight: 13,
   },
   genreAndLanguageSections: {
+    position: "relative",
     width: "100%",
     flexDirection: "column",
     gap: 12,

--- a/hidden-gem-music-app/src/screens/ComparisonSelectScreen.tsx
+++ b/hidden-gem-music-app/src/screens/ComparisonSelectScreen.tsx
@@ -19,7 +19,7 @@ import { Panel } from "../components/Panel";
 import { ScreenScaffold } from "../components/ScreenScaffold";
 import { SecondarySurfaceFill } from "../components/SecondarySurfaceFill";
 import { GlobePanel } from "../components/globe/GlobePanel";
-import { getSongsForCountryYear } from "../data/mockData";
+import { isCountryWithAppData } from "../data/countryDisplay";
 import { Country } from "../types/content";
 import { colors } from "../theme/colors";
 import { typefaces } from "../theme/typography";
@@ -772,8 +772,8 @@ export function ComparisonSelectScreen({
   );
   const filteredCountries = useMemo(() => {
       const filtered = countries.filter((country) => {
-        // Include only countries that have songs in app data for this year.
-        if (getSongsForCountryYear(country.id, comparisonYear ?? selectedYear).length <= 0) {
+        // Include only countries that have live app data for this year.
+        if (!isCountryWithAppData(country)) {
           return false;
         }
 

--- a/hidden-gem-music-app/src/screens/CountryScreen.tsx
+++ b/hidden-gem-music-app/src/screens/CountryScreen.tsx
@@ -485,6 +485,25 @@ function CountryPageSection({
   );
 }
 
+function SectionLoadingVeil({ visible }: { visible: boolean }) {
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <View style={styles.sectionLoadingVeil} pointerEvents="none">
+      <LinearGradient
+        colors={["rgba(15,16,21,0.72)", "rgba(66,72,101,0.64)", "rgba(15,16,21,0.78)"]}
+        locations={[0, 0.48, 1]}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 1, y: 1 }}
+        style={styles.sectionLoadingVeilFill}
+      />
+      <Text style={styles.sectionLoadingVeilText}>Loading...</Text>
+    </View>
+  );
+}
+
 function StatSquare({
   label,
   value,
@@ -627,7 +646,6 @@ function MainComparisonArea({
           style={styles.mainComparisonScroll}
           contentContainerStyle={styles.mainComparisonListContent}
           showsVerticalScrollIndicator={false}
-          scrollEnabled={Platform.OS !== "web"}
           onLayout={(event) => setViewportHeight(event.nativeEvent.layout.height)}
           onContentSizeChange={(_, height) => setContentHeight(height)}
           onScroll={handleScroll}
@@ -757,6 +775,7 @@ function MainComparisonArea({
             </View>
           ) : null}
         </ScrollView>
+        <SectionLoadingVeil visible={isInitialLoading} />
         {scrollbarVisible ? (
           <View
             ref={trackRef}
@@ -1336,6 +1355,7 @@ function HiddenSongsCarouselSection({
           )}
         </View>
       )}
+      <SectionLoadingVeil visible={isLoading} />
     </CountryPageSection>
   );
 }
@@ -1494,6 +1514,7 @@ function FavoriteArtistsSection({
           ) : null}
         </View>
       )}
+      <SectionLoadingVeil visible={isLoading} />
     </CountryPageSection>
   );
 }
@@ -2097,6 +2118,7 @@ export function CountryScreen({
               <Text style={[styles.countrySummarySectionDetailText, styles.countrySummarySectionTextDark]}>{genreLanguageMixText}</Text>
             </View>
           </View>
+          <SectionLoadingVeil visible={initialLoadingProfile} />
         </CountryPageSection>
 
         <FavoriteArtistsSection
@@ -2147,6 +2169,7 @@ export function CountryScreen({
                 useLoadingStyle={isCoreLoading}
                 style={splitStatsAndInsights && !statsTwoByTwo ? styles.statSquareWide : statsTwoByTwo ? styles.statSquareHalf : null}
               />
+              <SectionLoadingVeil visible={isCoreLoading} />
             </View>
           </View>
           <View
@@ -2164,6 +2187,7 @@ export function CountryScreen({
               title={`${country.name}'s Language(s) in Music`}
               bodyText="Language information coming soon."
             />
+            <SectionLoadingVeil visible={isCoreLoading} />
           </View>
         </View>
 
@@ -2428,8 +2452,29 @@ const styles = StyleSheet.create({
     padding: 0,
   },
   secondaryPanelContent: {
+    position: "relative",
     padding: 18,
     gap: 16,
+  },
+  sectionLoadingVeil: {
+    ...StyleSheet.absoluteFillObject,
+    borderRadius: 14,
+    overflow: "hidden",
+    zIndex: 50,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  sectionLoadingVeilFill: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  sectionLoadingVeilText: {
+    color: colors.textLight,
+    fontFamily: typefaces.display,
+    fontSize: 20,
+    lineHeight: 24,
+    textShadowColor: "rgba(15,16,21,0.42)",
+    textShadowOffset: { width: 0, height: 2 },
+    textShadowRadius: 8,
   },
   customFill: {
     ...StyleSheet.absoluteFillObject,
@@ -2498,6 +2543,7 @@ const styles = StyleSheet.create({
     lineHeight: 24,
   },
   statSquaresGrid: {
+    position: "relative",
     width: "100%",
     flexDirection: "row",
     gap: 16,
@@ -2526,6 +2572,7 @@ const styles = StyleSheet.create({
     flexShrink: 0,
   },
   genreAndLanguageSections: {
+    position: "relative",
     width: "100%",
     minWidth: 320,
     flexDirection: "row",

--- a/hidden-gem-music-app/src/screens/HiddenGemsScreen.tsx
+++ b/hidden-gem-music-app/src/screens/HiddenGemsScreen.tsx
@@ -26,6 +26,7 @@ import { Panel } from "../components/Panel";
 import { ScreenScaffold } from "../components/ScreenScaffold";
 import { SecondarySurfaceFill } from "../components/SecondarySurfaceFill";
 import { getCachedHiddenGemsPage, loadCountryProfile, loadHiddenGemsPage } from "../data/countryApi";
+import { isCountryWithAppData } from "../data/countryDisplay";
 import { hasKnownSongTitle, mapApiCountryProfile, mapApiHiddenGemPage } from "../data/apiMappers";
 import { useLoadingText } from "../hooks/useLoadingText";
 import { ApiHiddenGemResponse } from "../types/api";
@@ -1021,9 +1022,7 @@ export function HiddenGemsScreen({
     [availableYears, selectedYear]
   );
   const countryOptions = useMemo(() => {
-    const filtered = countries.filter((item) => item.hiddenSongs > 0);
-    const source = filtered.length ? filtered : countries;
-    return source.slice().sort((left, right) => left.name.localeCompare(right.name));
+    return countries.filter(isCountryWithAppData).slice().sort((left, right) => left.name.localeCompare(right.name));
   }, [countries]);
   const showCountryDropdownGradient = isCountryDropdownHovered || isCountryDropdownPressed || isCountryDropdownOpen;
   const showYearDropdownGradient = isYearDropdownHovered || isYearDropdownPressed || isYearDropdownOpen;
@@ -1178,6 +1177,7 @@ export function HiddenGemsScreen({
 
     const controller = new AbortController();
     setApiSongs(createLoadingHiddenGemSongs(country.code, selectedYear));
+    setTotalHiddenGemsCount(null);
     setIsSongsLoading(true);
     onSetLoading?.(true);
     loadHiddenGemsPage(country.code, selectedYear, 2, page, hiddenGemsPageSize, controller.signal)
@@ -1813,7 +1813,9 @@ export function HiddenGemsScreen({
                   end={{ x: 0.5, y: 1 }}
                   style={styles.blurbStatCardFill}
                 />
-                <Text style={styles.blurbStatValue}>{displayHiddenGemCount}</Text>
+                <Text style={[styles.blurbStatValue, isScreenLoading ? styles.blurbStatValueLoading : null]}>
+                  {displayHiddenGemCount}
+                </Text>
                 <Text style={styles.blurbStatLabel}>Hidden Gems</Text>
               </View>
             </View>
@@ -2364,7 +2366,8 @@ const styles = StyleSheet.create({
   },
   blurbCopyWebReserved: {
     minWidth: 360,
-    maxWidth: 520,
+    maxWidth: 620,
+    marginLeft: 28,
     flexGrow: 1,
     flexShrink: 1,
   },
@@ -2469,6 +2472,11 @@ const styles = StyleSheet.create({
     lineHeight: 30,
     textAlign: "center",
     marginTop: 3,
+  },
+  blurbStatValueLoading: {
+    fontSize: 17,
+    lineHeight: 20,
+    marginTop: 8,
   },
   blurbYearDropdownWrap: {
     width: 156,

--- a/hidden-gem-music-app/src/screens/HiddenGemsScreen.tsx
+++ b/hidden-gem-music-app/src/screens/HiddenGemsScreen.tsx
@@ -26,7 +26,7 @@ import { Panel } from "../components/Panel";
 import { ScreenScaffold } from "../components/ScreenScaffold";
 import { SecondarySurfaceFill } from "../components/SecondarySurfaceFill";
 import { getCachedHiddenGemsPage, loadCountryProfile, loadHiddenGemsPage } from "../data/countryApi";
-import { isCountryWithAppData } from "../data/countryDisplay";
+import { isCountryWithHiddenGems } from "../data/countryDisplay";
 import { hasKnownSongTitle, mapApiCountryProfile, mapApiHiddenGemPage } from "../data/apiMappers";
 import { useLoadingText } from "../hooks/useLoadingText";
 import { ApiHiddenGemResponse } from "../types/api";
@@ -443,6 +443,25 @@ function PlayerControlButton({
   );
 }
 
+function SectionLoadingVeil({ visible }: { visible: boolean }) {
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <View style={styles.sectionLoadingVeil} pointerEvents="none">
+      <LinearGradient
+        colors={["rgba(15,16,21,0.72)", "rgba(66,72,101,0.64)", "rgba(15,16,21,0.78)"]}
+        locations={[0, 0.48, 1]}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 1, y: 1 }}
+        style={styles.sectionLoadingVeilFill}
+      />
+      <Text style={styles.sectionLoadingVeilText}>Loading...</Text>
+    </View>
+  );
+}
+
 function HiddenSongListPanel({
   songs,
   selectedSongId,
@@ -597,6 +616,7 @@ function HiddenSongListPanel({
           </View>
         ) : null}
       </View>
+      <SectionLoadingVeil visible={isLoading} />
     </Panel>
   );
 }
@@ -606,11 +626,13 @@ function FeaturedArtistsSection({
   selectedYear,
   artists,
   useLoadingLabels = false,
+  isLoading = false,
 }: {
   country: Country;
   selectedYear: number;
   artists: FavoriteArtistPreview[];
   useLoadingLabels?: boolean;
+  isLoading?: boolean;
 }) {
   const { width } = useWindowDimensions();
   const scrollRef = useRef<ScrollView>(null);
@@ -760,6 +782,7 @@ function FeaturedArtistsSection({
           </View>
         ) : null}
       </View>
+      <SectionLoadingVeil visible={isLoading} />
     </Panel>
   );
 }
@@ -955,6 +978,7 @@ function PlayingSidePanel({
           </View>
         ) : null}
       </View>
+      <SectionLoadingVeil visible={isLoading} />
     </Panel>
   );
 }
@@ -1022,7 +1046,7 @@ export function HiddenGemsScreen({
     [availableYears, selectedYear]
   );
   const countryOptions = useMemo(() => {
-    return countries.filter(isCountryWithAppData).slice().sort((left, right) => left.name.localeCompare(right.name));
+    return countries.filter(isCountryWithHiddenGems).slice().sort((left, right) => left.name.localeCompare(right.name));
   }, [countries]);
   const showCountryDropdownGradient = isCountryDropdownHovered || isCountryDropdownPressed || isCountryDropdownOpen;
   const showYearDropdownGradient = isYearDropdownHovered || isYearDropdownPressed || isYearDropdownOpen;
@@ -1900,6 +1924,7 @@ export function HiddenGemsScreen({
             selectedYear={selectedYear}
             artists={favoriteArtists}
             useLoadingLabels={shouldShowNavIntro}
+            isLoading={isScreenLoading}
           />
         </View>
       </View>
@@ -2673,6 +2698,7 @@ const styles = StyleSheet.create({
     flex: 1.06,
   },
   secondaryPanel: {
+    position: "relative",
     minHeight: Platform.OS === "web" ? 760 : 618,
     maxHeight: Platform.OS === "web" ? 760 : 618,
     padding: 0,
@@ -2691,6 +2717,26 @@ const styles = StyleSheet.create({
           scrollbarWidth: "none",
         } as ViewStyle)
       : null),
+  },
+  sectionLoadingVeil: {
+    ...StyleSheet.absoluteFillObject,
+    borderRadius: 14,
+    overflow: "hidden",
+    zIndex: 50,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  sectionLoadingVeilFill: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  sectionLoadingVeilText: {
+    color: colors.textLight,
+    fontFamily: typefaces.display,
+    fontSize: 20,
+    lineHeight: 24,
+    textShadowColor: "rgba(15,16,21,0.42)",
+    textShadowOffset: { width: 0, height: 2 },
+    textShadowRadius: 8,
   },
   songListContent: {
     paddingLeft: 14,
@@ -3145,6 +3191,7 @@ const styles = StyleSheet.create({
     backgroundColor: "rgba(117,82,107,0.58)",
   },
   snapshotPanel: {
+    position: "relative",
     minWidth: 0,
     overflow: "hidden",
   },


### PR DESCRIPTION
# Hidden Gems Prompt, State, Loading, Code Review, and Documentation Fixes

## Summary

_This PR fixes the Hidden Gems country/year prompt reload bug and addresses the related state, loading, country-list, stale placeholder-data, slow-loading UI, code-review, and documentation issues found during review._

The main goal is to treat these bugs as a connected fix instead of isolated and possibly causing more bugs by fixing them individually: Hidden Gems route params, persisted app state, country pools, loading overlays, and Comparison/Country list behavior all share data and navigation state.

After the initial implementation was tested, the branch also received a focused code-review follow-up to stabilize fetch retry behavior, country filtering, Hidden Gems loading copy, full country-name labels, and Welcome navigation behavior.

## What Changed

### Hidden Gems route and persisted state

- Direct `/hidden-gems` navigation without a confirmed country/year context now starts with the country/year selection prompt.
- Main-nav and Dashboard entry into Hidden Gems still open the country/year selection prompt.
- App-driven Country Detail and preview-carousel handoffs still open Hidden Gems directly for the intended country/year/song.
- A short-lived session handoff marker separates app-driven Hidden Gems navigation from fresh direct/reload navigation.
- App state persistence no longer writes the selected country into `hidden-gem-app-state-v1`, preventing stale country/year reuse.
- Hidden Gems intro navigation no longer intentionally writes stale country/year params back into the route.
- Hidden Gems popup mode now uses the breadcrumb path `Welcome / Hidden Gems` instead of breadcrumbing through a stale country.

### Header, breadcrumb, title, and country-name stability

- Hidden Gems year changes no longer cause the header, breadcrumb, or document title to say `Loading country...`.
- Returning from Hidden Gems back to Country no longer leaves the Country header/breadcrumb stuck on `Loading country...`.
- Selected country labels now fall back through known country metadata while the selected year's API country pool reloads.
- API route ids such as `iso-ar` now resolve through the world-map ISO metadata, so the UI keeps showing `Argentina` instead of briefly flashing `AR`.
- Country, Hidden Gems, Comparison, document-title, and breadcrumb labels keep full country names instead of temporary loading labels or raw country codes.

### Country data and filtering cleanup

- Runtime country selectors now use API-backed countries with real app data.
- Comparison and Hidden Gems dropdowns no longer use mock song generation to decide if a country is selectable.
- General app-data country filtering was separated from Hidden-Gems-specific hidden-gem availability filtering.
- Discovery, Country, and Comparison country pools no longer require `hiddenSongs > 0`.
- Hidden Gems prompt/dropdown choices still require actual hidden-gem availability.
- Country names from API data are normalized before rendering so broken pipe-like characters do not appear in selectors.
- Loading country fallback content no longer presents fake generated song/country metadata as real app data.

### Loading and slow-request behavior

- Added a shared frontend fetch wrapper with a 60-second timeout and retry behavior.
- Tightened retry behavior so aborts and timeouts are not retried as duplicate long-running requests.
- Retry behavior is now limited to likely transient network fetch failures.
- Applied timeout/retry behavior to Country, Hidden Gems, Discovery, and Dashboard API calls.
- Added approved dark glassy section-level loading veils to Country Detail and Comparison View initial-loading sections.
- The loading veil now covers the summary, stat squares, loved genres/language sections, favorite artists, hidden-gem preview carousel, and the two main loved-song sections.
- Existing `Loading...` text, CD-case spinners, and inline loading rows remain in place.
- “Most Loved in This Country” and “Loved Here and Elsewhere” only show the section veil during initial page load; later load-more requests keep the inline loading rows.

### Hidden Gems UI fixes

- Hidden Gems song list, now-playing panel, and favorite-artists section now use the same glassy/dimmed `Loading...` veil while loading.
- Hidden Gems global loading copy now uses neutral `Loading...` instead of `Loading hidden gems...`.
- Hidden Gems stat square stays in loading state while the real count is unknown, avoiding transition flashes like `0 Hidden Gems`.
- Hidden Gems stat-square `Loading...` text is reduced so it fits the square.
- Hidden Gems country/year changes clear the previous count immediately so the old number does not shrink before the new count appears.
- Hidden Gems blurb helper text is shifted right on web without moving the blurb controls.

### Welcome navigation fix

- Clicking `Welcome` from the header or breadcrumbs now resets to the normal Welcome-over-Discovery stack.
- Welcome no longer appears as a modal over the current Country or Hidden Gems page.

### Web scrolling and overlay cleanup

- Country Detail and Comparison View main comparison lists now allow natural mousepad/wheel scrolling on web.
- Custom scrollbar behavior is still preserved.
- Discovery refresh/loading overlay state is kept from leaking after leaving Discovery.

### Documentation updates

- Updated the personal implementation timeline with the Issue 125 follow-up, code-review fixes, manual verification, commit, and branch status.
- Updated `Documentation/QA-log.md` with the Hidden Gems direct-navigation/code-review QA entry and manual test checklist.
- Updated frontend professional documentation for:
  - Hidden Gems direct/reload prompt behavior
  - app-driven Hidden Gems handoff behavior
  - stable country-name fallback rules
  - glassy Hidden Gems section loading veils
  - neutral loading copy
  - fetch timeout/retry rules
  - app-data vs Hidden-Gems-specific country filtering
  - Welcome reset behavior

## Files Touched

- `Documents/mp3li implementation timeline document.txt`
- `Documentation/QA-log.md`
- `hidden-gem-music-app/App.tsx`
- `hidden-gem-music-app/Documentation/README.md`
- `hidden-gem-music-app/Documentation/frontend-architecture.md`
- `hidden-gem-music-app/Documentation/interaction-loading-and-overlay-rules.md`
- `hidden-gem-music-app/Documentation/routing-state-and-navigation.md`
- `hidden-gem-music-app/Documentation/screen-data-flow.md`
- `hidden-gem-music-app/src/data/countryApi.ts`
- `hidden-gem-music-app/src/data/discoveryApi.ts`
- `hidden-gem-music-app/src/data/dashboardApi.ts`
- `hidden-gem-music-app/src/data/fetchWithTimeout.ts`
- `hidden-gem-music-app/src/data/countryDisplay.ts`
- `hidden-gem-music-app/src/screens/HiddenGemsScreen.tsx`
- `hidden-gem-music-app/src/screens/CountryScreen.tsx`
- `hidden-gem-music-app/src/screens/ComparisonSelectScreen.tsx`
- `hidden-gem-music-app/src/screens/ComparisonResultsScreen.tsx`

## Testing

- `npm run typecheck -- --noEmit`
- `git diff --check`

Manual browser scenarios to verify:

- Open `/hidden-gems` directly with no country/year params and confirm the country/year prompt appears.
- Enter Hidden Gems from Country Detail and confirm it opens the intended country/year without showing the prompt.
- Refresh after an app-driven Hidden Gems handoff and confirm the selected country/year behavior remains correct.
- Use main navigation and Dashboard Hidden Gems links and confirm they open the prompt.
- Open Hidden Gems from Country Detail or a preview carousel and confirm the intended country/song still opens.
- Switch Hidden Gems country/year and confirm the stat square does not flash `0`.
- Switch Hidden Gems year and confirm the header, document title, and breadcrumbs keep the full country name.
- Return from Hidden Gems to Country and confirm the Country header/breadcrumb do not get stuck on `Loading country...`.
- Confirm API ids like `iso-ar` resolve to full names like `Argentina`, not raw codes like `AR`.
- Confirm Comparison and Hidden Gems dropdowns only show real app-data countries.
- Confirm Country and Comparison main lists scroll with a mousepad on web.
- Confirm the dark section dimming appears during initial Country/Comparison loading and clears after section data loads.
- Confirm Hidden Gems song list, now-playing panel, and favorite-artists section show the glassy/dimmed `Loading...` veil while loading.
- Confirm global Hidden Gems loading text uses neutral `Loading...`.
- Click `Welcome` from Country or Hidden Gems and confirm it returns to the normal Welcome state instead of appearing over the current page.

## User Verification

The user tested the final behavior and confirmed:

- direct Hidden Gems prompt behavior is correct
- in-app Hidden Gems navigation is correct
- Hidden Gems reload/handoff behavior is correct
- basic backend data loading is good
- glassy Hidden Gems loading treatment is correct
- country names no longer show `Loading country...` or flash country codes
- Welcome navigation behavior is good
