### PR TITLE
Progress on Issue 128 Debug Dashboard Issues

### DIFF
--- a/Documentation/QA-log.md
+++ b/Documentation/QA-log.md
@@ -3,6 +3,189 @@
 
 ---
 
+## 2026-05-15 — Dashboard Issue 128 Frontend Fixes and Discovery Dashboard Rename
+
+**Tester:** mp3li / Codex-assisted verification
+**Fix owner:** mp3li / Codex-assisted implementation
+**Scope:** Dashboard country selector, KPI sizing, chapter spacing, Chapter 3 signed value, Chapter 4 peak-song art, Dashboard nav naming/order, PR handoff notes
+
+### What I noticed
+
+Dashboard Issue 128 contained several clear frontend polish requests plus several vague/data-owner requests. The clear frontend items were implemented in this pass. The stored-procedure/data-source/naming-clarification items were documented in the PR markdown instead of guessed.
+
+### What was fixed
+
+- The "See where your country fits in" dropdown now includes countries with app data across available metadata years.
+- Countries with a returned isolation score show the score and label it as an isolation score.
+- Countries with app data but no returned isolation score no longer show a confusing placeholder on the right side of the dropdown.
+- The selected-country banner avoids fake scores when the current ranking response does not include that country.
+- Chapter 1 Discovery Gap Distribution explanatory text now has better spacing below it.
+- The first four Chapter 1 KPI flip cards are larger and render as a two-by-two layout.
+- KPI card content typography was increased and the `flip ↻` hint placement was made consistent.
+- Section divider numbers/headings were increased and given more spacing below.
+- Chapter 2 isolation-score explanation spacing was increased.
+- Chapter 3 now shows a single inline signed value such as `+6 pts` or `-6 pts` instead of stacked plus/minus symbols.
+- The phrase "then a 22-month silence" was removed.
+- Chapter 4 / THE CEILING now displays peak-song art inside the existing CD case component.
+- Conclusion stat cards were enlarged while preserving a two-by-two square-card layout.
+
+### API/model change
+
+The Dashboard peak-reach API response now includes `albumArtUrl`.
+
+Implementation detail:
+
+- `DashboardRepository.GetPeakReachAsync` still calls `sp_GetPeakCrossRegionalReach`.
+- The returned peak song title and artist are passed through the existing Deezer enrichment service.
+- The frontend uses `albumArtUrl` in the Chapter 4 CD case.
+- A known cover-art fallback is present for the current peak song so the UI does not stay blank if enrichment does not resolve art.
+
+### Navigation/name update
+
+- The Dashboard nav label is now `Discovery Dashboard`.
+- Web header nav order is now:
+  - Discovery Map
+  - Discovery Dashboard
+  - Comparison Mode
+  - Hidden Gems
+  - Credits
+- Mobile bottom nav was reordered the same way.
+- Welcome screen copy and buttons were updated so Discovery Dashboard appears directly after Discovery Map.
+- PR handoff notes state that the team has discussed wanting a catchier name but has not settled on one yet.
+
+### Follow-up items intentionally not completed
+
+- "Adjust wording on explanation" needs the exact target text or replacement wording.
+- "Conclusion card - make KPI cards a carousel?" needs a screenshot or expected behavior because the conclusion currently has four stat cards.
+- "Add data sources to About this data" needs exact data-source labels from the data owner.
+- "Adjust isolation scores by country graph to include all countries" appears to require changing `sp_GetIsolationRanking`, which currently uses `SELECT TOP 20`. The PR markdown documents a "Potential SQL direction" without changing that stored procedure in this frontend pass.
+
+### How to test
+
+1. Open Dashboard / Discovery Dashboard.
+2. Confirm the main nav shows `Discovery Dashboard` immediately after `Discovery Map` on web.
+3. Check mobile width and confirm bottom nav order matches.
+4. Open Welcome and confirm its buttons put `Discovery Dashboard` after `Discovery Map`.
+5. Open the Dashboard country dropdown and confirm countries with app data are present.
+6. Confirm countries with scores show `%` and `isolation score`; countries without scores show no right-side placeholder.
+7. Confirm Chapter 1 KPI cards are larger, two-by-two, and still flip correctly.
+8. Confirm section divider spacing, Chapter 2 explanation spacing, and Chapter 3 `+/- pts` alignment.
+9. Confirm Chapter 4 shows CD art for the peak song.
+10. Confirm conclusion stat cards are two-by-two square cards with larger text.
+
+### Verification
+
+- `npm run typecheck` passed.
+- `dotnet build Capstone.API.csproj` passed.
+- `git diff --check` passed.
+
+---
+
+## 2026-05-15 — New Local DB Restore and Post-Restore UI Regression Fixes
+
+**Tester:** mp3li / Codex-assisted verification
+**Fix owner:** mp3li / Codex-assisted implementation
+**Scope:** Local SQL Server restore, backend/browser smoke test, Discovery Map SVG fills, Hidden Gems CD/artist-image loading states
+
+### What I noticed
+
+Before starting Issue 128 dashboard work, Leena provided an updated database backup: `05.15_HiddenGemMusic.bak`.
+
+The local app needed to be verified against the new DB first because the work depends on updated dashboard/country data. The local setup is Docker SQL Server on macOS with SSMS running inside Parallels Windows 11.
+
+After restore, the backend and main app screens worked, but two frontend regressions appeared during hands-on smoke testing:
+
+- Navigating from Dashboard to Discovery could make map country gradients disappear until a hard refresh.
+- Hidden Gems loaded faster, but Favorite Artists/CD artwork could remain blank placeholder colors after the glassy loading veil cleared.
+
+### Restore and DB verification
+
+- Backed up the previous local `HiddenGemMusic` database first.
+- Copied Leena's backup into the Docker SQL container:
+  - source: `/Users/stellar/Downloads/05.15_HiddenGemMusic.bak`
+  - container: `capstone-sql`
+  - destination: `/var/opt/mssql/backup/05.15_HiddenGemMusic.bak`
+- Used `RESTORE FILELISTONLY` and confirmed logical names:
+  - `HiddenGemMusic`
+  - `HiddenGemMusic_log`
+- Restored over the existing local `HiddenGemMusic` database name so the app did not need a new database name or connection string.
+- Confirmed restored table counts:
+
+| Table | Count |
+|---|---:|
+| `dbo.Country` | 246 |
+| `dbo.DIM_Song` | 240,848 |
+| `dbo.DIM_Artist` | 103,015 |
+| `dbo.HiddenGems` | 2,585,433 |
+| `dbo.IsolationScoreByCountry` | 546 |
+
+### Endpoint smoke test
+
+The following browser/API checks returned JSON after restore:
+
+- `GET /api/metadata/years`
+- `GET /api/discovery/countries?year=2025`
+- `GET /api/dashboard/overlap-rate?start=2017-01-01&end=2025-12-31`
+- `GET /api/dashboard/isolation-leader?start=2017-01-01&end=2025-12-31`
+- `GET /api/dashboard/isolation-ranking?start=2017-01-01&end=2025-12-31`
+- `GET /api/dashboard/discovery-gap?start=2017-01-01&end=2025-12-31&minCountries=2`
+- `GET /api/dashboard/gap-distribution?start=2017-01-01&end=2025-12-31`
+- `GET /api/dashboard/peak-reach?start=2017-01-01&end=2025-12-31`
+- `GET /api/dashboard/overlap-trend?start=2017-01-01&end=2025-12-31`
+
+Frontend smoke testing confirmed:
+
+- Dashboard loaded.
+- Discovery loaded.
+- Country page loaded for US / 2025.
+- Hidden Gems loaded for US / 2025.
+- Comparison loaded for US vs. GB / 2025.
+
+### Follow-up items intentionally not fixed in this pass
+
+- `dashboard/isolation-ranking` currently returns 20 countries. That lines up with the upcoming Issue 128 scope and should be handled there with approval.
+- `dashboard/overlap-rate` returned a nonzero `overlapPct` with `songsIn2Plus: 0`, while `overlap-trend` returned nonzero yearly `songsIn2Plus` values. This should be investigated as a later dashboard SP/output-mapping issue.
+
+### Bug 1 — Discovery Map gradients disappeared after route navigation
+
+**Symptom:** After navigating Dashboard → Discovery, countries with data sometimes lost their normal gradient fills and hovered countries lost their active gradient. A hard refresh restored the correct colors.
+
+**Root cause:** `GlobeView.tsx` used fixed SVG gradient IDs such as `map-country-data-fill` and `map-country-active-fill`. On web route transitions, SVG `url(#...)` fill references could resolve against stale or missing paint definitions.
+
+**Fix:** `GlobeView.tsx` now generates unique SVG gradient IDs per map instance with `useId`, and country fill references use those generated IDs.
+
+### Bug 2 — Hidden Gems art loading ended before images were ready
+
+**Symptom:** Favorite Artists CDs could stay as blank placeholder-color cases after the glassy loading veil cleared. The screen had also lost visible per-art spinners in places where image files were still loading.
+
+**Root cause:** Favorite Artists were tied to the hidden-gems song-list loading boolean, but Favorite Artists depend on the separate country-profile request. Also, CD image loading was not tracked independently from API data loading.
+
+**Fixes:**
+
+- Added a profile-specific loading state for Hidden Gems Favorite Artists.
+- Kept Favorite Artists in the glassy/loading state until country profile data arrives.
+- Allowed Favorite Artists to reuse artist image URLs from the loaded Hidden Gems song rows when profile rows do not include image URLs.
+- Updated `CdCaseArt.tsx` so each CD keeps its spinner/dim overlay until its actual image finishes loading or errors.
+- Added equivalent per-image spinner/dim handling to mini CD artwork in the Hidden Gems song list.
+
+### How to test
+
+1. Restore/run against the new `HiddenGemMusic` database.
+2. Open Dashboard, then navigate to Discovery without hard refresh.
+3. Confirm countries with data keep their normal gradient fills.
+4. Hover a country with data and confirm the active gradient appears.
+5. Open Hidden Gems for a country/year with artwork.
+6. Confirm Favorite Artists do not drop to blank placeholders while profile data is still loading.
+7. Confirm CD art areas show individual spinners/dim overlays until their own image appears.
+
+### Verification
+
+- `npm run typecheck` passed after the Discovery Map SVG gradient fix.
+- `npm run typecheck` passed after the Hidden Gems art-loading fixes.
+- User verified the Hidden Gems loading fix worked after retest.
+
+---
+
 ## 2026-05-15 — Discovery Globe SP Optimization and Summary Table
 
 **Tester:** Leena Komenski

--- a/Documents/PR_Issue_128.md
+++ b/Documents/PR_Issue_128.md
@@ -1,0 +1,76 @@
+# PR: Dashboard Issue 128 Frontend Fixes
+
+## Completed In This PR
+
+- Updated the "See where your country fits in" dropdown so it can include all countries with app data across available metadata years.
+- Kept the selector wording minimal and made dropdown labels clarify whether the right-side value is an isolation score or app data without a returned score.
+- Fixed spacing below the Chapter 1 Discovery Gap Distribution explanatory text.
+- Made the first four Chapter 1 KPI flip cards larger and changed them from one row of four to a two-by-two layout.
+- Made the `flip ↻` hint spacing consistent inside the KPI cards.
+- Increased lower conclusion stat cards by about 20% and kept them in a two-by-two square card layout.
+- Made section divider numbers and headers bigger.
+- Added more breathing room under the Chapter 2 isolation-score explanation.
+- Replaced the stacked Chapter 3 plus/minus display with one inline signed value, such as `+6 pts` or `-6 pts`.
+- Removed the phrase "then a 22-month silence."
+- Added real CD cover art to Chapter 4, THE CEILING, using the existing CD case component.
+- Extended the peak reach Dashboard API response with `albumArtUrl` by reusing the existing Deezer enrichment service, with a known cover fallback for the current peak song.
+- Renamed the Dashboard nav item to "Discovery Dashboard" and moved it directly after "Discovery Map" on web, mobile, and Welcome screen navigation.
+
+## Clarification Needed Before Remaining Items Can Be Finished
+
+### "Adjust wording on explanation"
+
+Why this is not completed: the issue does not identify which explanation text should change or what replacement wording is expected.
+
+Follow-up needed: please provide the exact current text, screenshot location, or target replacement copy.
+
+### "Conclusion card - make KPI cards a carousel?"
+
+Why this is not completed: the Dashboard conclusion has four stat cards, and that does not map cleanly to the existing Preview Hidden Gems carousel pattern.
+
+Follow-up needed: please provide a screenshot or describe which conclusion cards should become a carousel and what carousel behavior is expected.
+
+### "Add data sources to About this data"
+
+Why this is not completed: the visible source labels need to come from the data owner so the app does not display guessed or incomplete source wording.
+
+Follow-up needed: please provide the exact data-source names/labels that should appear in About this data.
+
+### Dashboard naming feedback
+
+The Dashboard route/nav label was renamed to "Discovery Dashboard" and moved directly after "Discovery Map" in the web and mobile navigation. The Welcome screen copy and buttons were updated to match. We have discussed wanting a catchier name, but have not landed on one yet, so please flag if "Discovery Dashboard" should be changed before final merge. Goal of rename was simply to not forget. 
+
+### "Adjust isolation scores by country graph to include all countries"
+
+Why this is not completed: the Dashboard chart is fed by `sp_GetIsolationRanking`, and that stored procedure currently uses `SELECT TOP 20`. From the issue text, this likely means the graph should include every country that has isolation-score rows, not just the top 20.
+
+Potential SQL direction:
+
+```sql
+SELECT
+    c.full_name                     AS country_name,
+    c.iso_code,
+    c.region,
+    AVG(isc.isolation_score)        AS isolation_score,
+    MAX(isc.isolation_tier)         AS isolation_tier
+FROM IsolationScoreByCountry isc
+JOIN Country c ON c.country_id = isc.country_id
+WHERE isc.chart_year BETWEEN @YearStart AND @YearEnd
+GROUP BY c.country_id, c.full_name, c.iso_code, c.region
+ORDER BY AVG(isc.isolation_score) DESC;
+```
+
+## Verification
+
+- `npm run typecheck`
+- `dotnet build Capstone.API.csproj`
+
+## Browser Checks For Reviewer
+
+- Dashboard dropdown includes countries with app data, not only the current top-20 isolation ranking rows.
+- Selecting a country with no score in the current ranking response shows app-data availability instead of a fake score.
+- Chapter 1 histogram explanatory text has balanced spacing above and below.
+- Chapter 1 KPI cards render as a larger two-by-two grid.
+- Lower conclusion stat cards are larger and remain in a two-by-two square card layout.
+- Chapter 3 signed stat reads inline as `+6 pts` or `-6 pts`.
+- Chapter 4 peak reach card shows CD cover art when enrichment returns album art.

--- a/Documents/mp3li implementation timeline document.txt
+++ b/Documents/mp3li implementation timeline document.txt
@@ -2,6 +2,146 @@ mp3li implementation timeline document
 
 Updated: May 15, 2026
 
+Dashboard Issue 128 Frontend Polish, Discovery Dashboard Rename, and PR Handoff (May 15, 2026)
+- Objective:
+  - Complete the clear frontend/UI portions of Dashboard Issue 128 after the restored database was verified.
+  - Keep database-owner work separate by documenting the isolation-ranking `TOP 20` finding instead of changing the stored procedure in this pass.
+  - Produce a PR markdown handoff that separates completed work from clarification-needed items.
+
+- Dashboard country selector changes:
+  - Updated the "See where your country fits in" selector so its dropdown can include all countries with app data across available metadata years, not only the current top-20 isolation ranking response.
+  - Kept isolation scores visible only where the Dashboard ranking API actually returns them.
+  - For app-data countries that do not have a returned isolation score, the dropdown now leaves the right side blank instead of showing a confusing placeholder label.
+  - Selected countries without a returned ranking show honest "app data available / no isolation ranking returned" messaging rather than fake score values.
+
+- Dashboard visual fixes completed:
+  - Added balanced spacing below the Chapter 1 Discovery Gap Distribution explanation.
+  - Increased the first four Chapter 1 KPI flip cards and changed them from one row of four into a larger two-by-two layout.
+  - Increased KPI card front/back typography and made the `flip ↻` hint placement consistent.
+  - Increased section divider numbers and headings, then added more spacing below them after review.
+  - Added more spacing under the Chapter 2 isolation-score explanation.
+  - Replaced the Chapter 3 stacked plus/minus display with a single inline signed value such as `+6 pts` or `-6 pts`.
+  - Removed the phrase "then a 22-month silence."
+  - Increased the conclusion stat cards while keeping them in a two-by-two square-card layout.
+
+- Chapter 4 art/API work:
+  - Added CD case art to Chapter 4 / THE CEILING using the existing `CdCaseArt` component.
+  - Extended the Dashboard peak-reach API model with `albumArtUrl`.
+  - Reused the existing backend Deezer enrichment service to resolve peak-song album art.
+  - Added a known cover-art fallback for the current peak-reach song so the CD case does not remain blank when live enrichment misses the art.
+
+- Navigation/name cleanup:
+  - Renamed the Dashboard nav label to `Discovery Dashboard`.
+  - Moved `Discovery Dashboard` directly after `Discovery Map` in the web header nav and mobile bottom nav.
+  - Updated the Welcome screen copy and buttons so `Discovery Dashboard` appears directly after `Discovery Map`.
+  - Updated the mobile/native fallback Dashboard heading to `Discovery Dashboard`.
+  - Noted in the PR handoff that the team has discussed wanting a catchier dashboard name, but has not settled on one yet.
+
+- Clarification/data-owner items documented in the PR markdown:
+  - "Adjust wording on explanation" needs exact target text or replacement wording.
+  - "Conclusion card - make KPI cards a carousel?" needs a screenshot or target behavior because the conclusion only has four stat cards.
+  - "Add data sources to About this data" needs exact source labels from the data owner.
+  - "Adjust isolation scores by country graph to include all countries" appears to require changing `sp_GetIsolationRanking` from `SELECT TOP 20` to all country rows with isolation-score data; documented as "Potential SQL direction" instead of changing the stored procedure.
+
+- Files updated for Issue 128:
+  - `hidden-gem-music-app/src/screens/DashboardScreen.web.tsx`
+  - `hidden-gem-music-app/src/screens/DashboardScreen.tsx`
+  - `hidden-gem-music-app/src/components/AppHeader.tsx`
+  - `hidden-gem-music-app/src/components/MobileBottomNav.tsx`
+  - `hidden-gem-music-app/src/screens/WelcomeScreen.tsx`
+  - `hidden-gem-music-app/src/types/api.ts`
+  - `backend/Capstone.API/Infrastructure/Repositories/DashboardRepository.cs`
+  - `backend/Capstone.API/Models/Dashboard/PeakReachKpi.cs`
+  - `Documents/PR_Issue_128.md`
+
+- Verification completed:
+  - Ran `npm run typecheck` after implementation and follow-up visual adjustments.
+  - Ran `dotnet build Capstone.API.csproj` after the peak-reach API/model change.
+  - Ran `git diff --check`.
+  - User verified the dropdown behavior, histogram spacing, KPI cards, section headers, Chapter 2 spacing, Chapter 3 signed value, removed phrase, and Chapter 4 CD art follow-up behavior during the iteration.
+
+New Local Database Restore, Post-Restore Verification, and UI Regression Fixes (May 15, 2026)
+- Objective:
+  - Restore Leena's updated `05.15_HiddenGemMusic.bak` into the local Docker-hosted SQL Server database before starting Issue 128 dashboard work.
+  - Verify the existing backend and frontend still worked against the new database before making issue-specific changes.
+  - Fix only the regressions found during the post-restore smoke test before returning to planned issue work.
+
+- Local DB restore workflow completed:
+  - Backed up the current local `HiddenGemMusic` database in SSMS before restore.
+  - Copied Leena's backup from macOS Downloads into the Docker SQL Server container:
+    - source file: `/Users/stellar/Downloads/05.15_HiddenGemMusic.bak`
+    - container: `capstone-sql`
+    - container restore path: `/var/opt/mssql/backup/05.15_HiddenGemMusic.bak`
+  - Used `RESTORE FILELISTONLY` to confirm logical names:
+    - `HiddenGemMusic`
+    - `HiddenGemMusic_log`
+  - Restored the backup over the existing local `HiddenGemMusic` database name so the app's existing local connection path could stay unchanged.
+  - Confirmed the restored schema uses `dbo.Country` rather than the older `DIM_Country` name for countries.
+
+- Database sanity checks after restore:
+  - `dbo.Country`: 246 rows
+  - `dbo.DIM_Song`: 240,848 rows
+  - `dbo.DIM_Artist`: 103,015 rows
+  - `dbo.HiddenGems`: 2,585,433 rows
+  - `dbo.IsolationScoreByCountry`: 546 rows
+
+- Browser/API smoke test completed against the restored DB:
+  - `GET /api/metadata/years` returned `2017, 2018, 2019, 2020, 2021, 2023, 2024, 2025`.
+  - `GET /api/discovery/countries?year=2025` returned the restored country list and country-level 2025 hidden-gem data where available.
+  - Dashboard endpoints returned JSON for:
+    - overlap rate
+    - discovery gap
+    - gap distribution
+    - isolation leader
+    - isolation ranking
+    - peak reach
+    - overlap trend
+  - Frontend smoke testing confirmed Dashboard, Discovery, Country 2025, Hidden Gems 2025, and Comparison 2025 could still load.
+
+- Post-restore observations recorded before Issue 128 work:
+  - Dashboard isolation ranking currently returns only 20 countries; this matches the upcoming issue scope and was not fixed in this verification pass.
+  - Dashboard overlap rate returned `songsIn2Plus: 0` while `overlapPct` was nonzero; this was flagged as a likely output-mapping or stored-procedure result issue for later approval-gated work.
+  - Hidden Gems loaded much faster after the DB/update work, but first-load Country/Comparison paths could still feel slower for uncached countries because those screens perform more profile/list/enrichment work before all sections settle.
+
+- Bug fixed: Discovery Map gradients disappeared after Dashboard-to-Discovery navigation:
+  - Symptom:
+    - Navigating from Dashboard to Discovery sometimes made countries with data lose their normal fill/gradient until a hard refresh.
+    - Hovered countries also lost the active gradient.
+  - Cause:
+    - The map SVG used fixed gradient IDs such as `map-country-data-fill` and `map-country-active-fill`.
+    - On web route transitions, SVG `url(#...)` references could resolve against stale/missing paint definitions.
+  - Fix:
+    - `GlobeView.tsx` now generates per-instance SVG gradient IDs with `useId`.
+    - Country fill references now point to those unique IDs so map fills survive route transitions.
+
+- Bug fixed: Hidden Gems art loading ended before CD/artist images appeared:
+  - Symptom:
+    - Favorite Artists CDs could sit as blank placeholder-color cases long after the glassy loading veil disappeared.
+    - The previous spinner behavior had disappeared for parts of the screen because page-level loading ended before individual images finished loading.
+  - Cause:
+    - Favorite Artists used the hidden-gems song-list loading boolean, but the artist section depends on the separate country-profile request.
+    - CD image loading was not tracked independently from API data loading.
+  - Fix:
+    - `HiddenGemsScreen.tsx` now tracks country-profile loading separately for the Favorite Artists section.
+    - Favorite Artists stay in the glassy/loading state until profile data arrives.
+    - Favorite Artists can reuse loaded hidden-gems song artist images when the profile row is missing the image URL.
+    - `CdCaseArt.tsx` and mini CD rendering now keep an individual spinner/dim overlay until each actual image finishes loading or errors.
+
+- Files updated in this follow-up:
+  - `hidden-gem-music-app/src/components/globe/GlobeView.tsx`
+  - `hidden-gem-music-app/src/components/CdCaseArt.tsx`
+  - `hidden-gem-music-app/src/screens/HiddenGemsScreen.tsx`
+  - `Documents/mp3li implementation timeline document.txt`
+  - `Documentation/QA-log.md`
+  - `hidden-gem-music-app/Documentation/interaction-loading-and-overlay-rules.md`
+  - `hidden-gem-music-app/Documentation/screen-data-flow.md`
+
+- Verification completed:
+  - Ran `npm run typecheck` after the Discovery Map gradient fix.
+  - Ran `npm run typecheck` after the Hidden Gems image-loading fixes.
+  - User verified the Discovery Map gradient issue was fixed.
+  - User verified the Hidden Gems favorite-artist/CD loading fix worked.
+
 Hidden Gems Direct Navigation, Code Review Fixes, and Documentation Follow-Up (May 15, 2026)
 - Objective:
   - Complete the Issue 125 follow-up after hands-on review confirmed the Hidden Gems country/year selection prompt now behaves correctly on reload and direct navigation.

--- a/backend/Capstone.API/Documentation/apis/current-backend-api-surface.md
+++ b/backend/Capstone.API/Documentation/apis/current-backend-api-surface.md
@@ -304,6 +304,8 @@ Current behavior notes:
 - `start` and `end` are `DateOnly` query parameters
 - several KPI routes return `404` when no single-row KPI result exists
 - list/chart endpoints generally return `200` with an empty collection instead of `404`
+- `peak-reach` returns the stored procedure's peak song/artist/date/count plus `albumArtUrl` when the existing Deezer enrichment service resolves cover art for that song
+- `isolation-ranking` currently returns the stored procedure result as-is; `sp_GetIsolationRanking` currently limits rows with `SELECT TOP 20`
 
 ### GlobeController
 

--- a/backend/Capstone.API/Infrastructure/Repositories/DashboardRepository.cs
+++ b/backend/Capstone.API/Infrastructure/Repositories/DashboardRepository.cs
@@ -10,13 +10,17 @@ namespace Capstone.API.Infrastructure.Repositories
     public class DashboardRepository : IDashboardRepository
     {
         private readonly IDataRepository _db;
+        private readonly IDeezerSongEnrichmentService _deezerSongEnrichmentService;
 
         /// <summary>
         /// Initializes a new instance of DashboardRepository using the default connection.
         /// </summary>
-        public DashboardRepository(IDataRepositoryFactory factory)
+        public DashboardRepository(
+            IDataRepositoryFactory factory,
+            IDeezerSongEnrichmentService deezerSongEnrichmentService)
         {
             _db = factory.Create("DefaultConnection");
+            _deezerSongEnrichmentService = deezerSongEnrichmentService;
         }
 
         /// <inheritdoc/>
@@ -104,12 +108,19 @@ namespace Capstone.API.Infrastructure.Repositories
             var row = rows.FirstOrDefault();
             if (row == null) return null;
 
+            var songTitle = AsString(row, "song_title");
+            var artistName = AsString(row, "artist_name");
+            var metadata = !string.IsNullOrWhiteSpace(songTitle) && !string.IsNullOrWhiteSpace(artistName)
+                ? await _deezerSongEnrichmentService.ResolveSongMetadataAsync(songTitle, artistName, cancellationToken)
+                : null;
+
             return new PeakReachKpi
             {
                 PeakCountryCount = AsInt(row, "peak_country_count"),
-                SongTitle = AsString(row, "song_title"),
-                ArtistName = AsString(row, "artist_name"),
-                PeakDate = AsNullableDateOnly(row, "peak_date")
+                SongTitle = songTitle,
+                ArtistName = artistName,
+                PeakDate = AsNullableDateOnly(row, "peak_date"),
+                AlbumArtUrl = metadata?.AlbumArtUrl
             };
         }
 

--- a/backend/Capstone.API/Models/Dashboard/PeakReachKpi.cs
+++ b/backend/Capstone.API/Models/Dashboard/PeakReachKpi.cs
@@ -27,5 +27,10 @@ namespace Capstone.API.Models.Dashboard
         /// Gets or sets the date on which peak reach was recorded.
         /// </summary>
         public DateOnly? PeakDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the resolved album artwork URL for the peak reach song.
+        /// </summary>
+        public string? AlbumArtUrl { get; set; }
     }
 }

--- a/hidden-gem-music-app/Documentation/frontend-architecture.md
+++ b/hidden-gem-music-app/Documentation/frontend-architecture.md
@@ -52,9 +52,11 @@ Key shared shell components:
   - breadcrumb trail
   - search trigger
   - search overlay host
+  - current web nav order: Discovery Map, Discovery Dashboard, Comparison Mode, Hidden Gems, Credits
 
 - `src/components/MobileBottomNav.tsx`
   - mobile-only bottom navigation behavior
+  - current mobile nav order mirrors web: Discovery Map, Discovery Dashboard, Compare, Hidden Gems, Credits
 
 - `src/components/ScreenScaffold.tsx`
   - shared background
@@ -93,6 +95,7 @@ Current ownership rule:
 Current exception:
 
 - Dashboard still has a web-specific file because the web dashboard uses `recharts`
+- The Dashboard user-facing label is `Discovery Dashboard`; the route key remains `dashboard`.
 
 ## Shared layout and visual language
 
@@ -192,6 +195,12 @@ This keeps:
 - persisted route state
 
 in one app-owned seam instead of scattering them across screens.
+
+Current naming/order rule:
+
+- `Discovery Dashboard` should appear directly after `Discovery Map` in both web and mobile navigation.
+- Welcome screen action buttons should follow the same order.
+- The team has discussed wanting a catchier dashboard name, but `Discovery Dashboard` is the current applied label until a replacement is chosen.
 
 ## Data layer ownership
 

--- a/hidden-gem-music-app/Documentation/interaction-loading-and-overlay-rules.md
+++ b/hidden-gem-music-app/Documentation/interaction-loading-and-overlay-rules.md
@@ -79,6 +79,8 @@ Current rules:
 - direct Hidden Gems reload/direct navigation without confirmed country/year params should show the country/year intro prompt
 - app-driven Hidden Gems navigation from Country or preview flows should open the intended country/year page without showing the intro prompt
 - Hidden Gems list, now-playing, and favorite-artists sections should use the shared glassy/dimmed `Loading...` veil while their data is loading
+- Hidden Gems Favorite Artists must follow the country-profile request state, not only the Hidden Gems song-list request state
+- CD artwork should keep an individual spinner/dim treatment until its own image file finishes loading or errors; page-level data loading finishing does not mean image loading has finished
 
 ## Explicit badge rules
 
@@ -126,6 +128,7 @@ Current rules:
 - mobile reset should remain visible and use the same immediate press-feedback convention as arrow and zoom controls
 - mobile map country interaction uses first tap to preview/select and second tap on the same country to open detail
 - tapping a different country after a preview should preview that different country first, not open it immediately
+- SVG map paint definitions must use instance-safe IDs so web route transitions do not make country gradient fills resolve against stale or missing definitions
 
 ## Route-leave request rule
 

--- a/hidden-gem-music-app/Documentation/screen-data-flow.md
+++ b/hidden-gem-music-app/Documentation/screen-data-flow.md
@@ -64,6 +64,16 @@ Hidden Gems:
 
 - `GET /api/hidden-gems/{countryCode}?year={year}&minCountries={n}&page={page}&pageSize={pageSize}`
 
+Dashboard / Discovery Dashboard:
+
+- `GET /api/dashboard/overlap-rate?start={date}&end={date}`
+- `GET /api/dashboard/discovery-gap?start={date}&end={date}&minCountries={n}`
+- `GET /api/dashboard/gap-distribution?start={date}&end={date}`
+- `GET /api/dashboard/isolation-leader?start={date}&end={date}`
+- `GET /api/dashboard/isolation-ranking?start={date}&end={date}`
+- `GET /api/dashboard/peak-reach?start={date}&end={date}`
+- `GET /api/dashboard/overlap-trend?start={date}&end={date}`
+
 ## Frontend cache/reuse behavior
 
 Current frontend cache maps include:
@@ -197,6 +207,35 @@ Important current rules:
 - general Discovery/Country/Comparison country pools should not disappear only because a country has zero hidden gems for the selected year
 - while the selected year's API country pool reloads, route/header/breadcrumb labels should use stable known country metadata instead of loading placeholders or raw ISO codes
 - API route ids such as `iso-ar` can be resolved through the world-map ISO metadata so user-facing labels can remain full names such as `Argentina`
+- Favorite Artists are profile-backed, so their loading state should follow the country-profile request rather than the page-list request
+- Favorite Artists may reuse artist image URLs already present in loaded Hidden Gems song rows when the profile side does not provide an image URL
+- CD image loading is separate from API data loading; image slots should keep per-art loading feedback until the image file itself loads or errors
+
+## Discovery Dashboard flow
+
+Main files:
+
+- `src/screens/DashboardScreen.web.tsx`
+- `src/screens/DashboardScreen.tsx`
+- `src/data/dashboardApi.ts`
+- `src/data/discoveryApi.ts`
+- `src/data/countryApi.ts`
+
+Current flow:
+
+1. The web Dashboard loads its KPI/chart data from the Dashboard API date range `2017-01-01` through `2025-12-31`.
+2. The country selector separately builds its dropdown from countries with app data across available metadata years.
+3. Isolation scores are displayed only for countries included in the current `isolation-ranking` response.
+4. Countries with app data but no returned isolation score stay selectable and use honest no-score messaging rather than fake ranking values.
+5. Chapter 4 peak reach uses `albumArtUrl` from the Dashboard peak-reach response when available.
+
+Important current rules:
+
+- The Dashboard nav label is `Discovery Dashboard`.
+- The nav order should keep `Discovery Dashboard` directly after `Discovery Map` on web, mobile, and Welcome screen actions.
+- The country selector and isolation ranking chart do not currently have the same source: the selector uses app-data countries, while the chart uses `sp_GetIsolationRanking`.
+- `sp_GetIsolationRanking` currently returns the stored procedure result as-is; if the graph needs all isolation-score countries, the stored procedure/data-owner path needs to remove its `SELECT TOP 20` limit.
+- Peak reach art should come from backend enrichment when possible; the frontend can use a known fallback only to avoid a blank CD for the current peak song.
 
 ## Fetch timeout and retry behavior
 

--- a/hidden-gem-music-app/src/components/AppHeader.tsx
+++ b/hidden-gem-music-app/src/components/AppHeader.tsx
@@ -12,9 +12,9 @@ import { typefaces } from "../theme/typography";
 
 const navItems: Array<{ label: string; route: ScreenRoute }> = [
   { label: "Discovery Map", route: "discovery" },
+  { label: "Discovery Dashboard", route: "dashboard" },
   { label: "Comparison Mode", route: "comparisonSelect" },
   { label: "Hidden Gems", route: "hiddenGems" },
-  { label: "Dashboard", route: "dashboard" },
   { label: "Credits", route: "credits" },
 ];
 

--- a/hidden-gem-music-app/src/components/CdCaseArt.tsx
+++ b/hidden-gem-music-app/src/components/CdCaseArt.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { ActivityIndicator, Image, StyleSheet, View } from "react-native";
 
 import { colors } from "../theme/colors";
@@ -24,10 +25,16 @@ export function CdCaseArt({
   withArtBackdrop = true,
 }: Props) {
   const hasArtImage = typeof artImageUrl === "string" && artImageUrl.trim().length > 0;
+  const [artLoaded, setArtLoaded] = useState(false);
   const artSize = Math.round(size * ART_SIZE_RATIO);
   const left = Math.round(size * ART_LEFT_RATIO);
   const top = Math.round(size * ART_TOP_RATIO);
   const spinnerSize = Math.max(18, Math.round(size * 0.14));
+  const showLoadingOverlay = loading || (hasArtImage && !artLoaded);
+
+  useEffect(() => {
+    setArtLoaded(false);
+  }, [artImageUrl]);
 
   return (
     <View style={[styles.cdCaseFrame, { width: size, height: size }]}>
@@ -45,9 +52,15 @@ export function CdCaseArt({
           ]}
         >
           {hasArtImage ? (
-            <Image source={{ uri: artImageUrl }} style={styles.cdCaseBackdropImage} resizeMode="cover" />
+            <Image
+              source={{ uri: artImageUrl }}
+              style={[styles.cdCaseBackdropImage, !artLoaded ? styles.cdCaseBackdropImageLoading : null]}
+              resizeMode="cover"
+              onLoad={() => setArtLoaded(true)}
+              onError={() => setArtLoaded(true)}
+            />
           ) : null}
-          {loading ? (
+          {showLoadingOverlay ? (
             <View style={styles.loadingOverlay}>
               <ActivityIndicator size={spinnerSize} color={colors.textLight} />
             </View>
@@ -79,6 +92,9 @@ const styles = StyleSheet.create({
   cdCaseBackdropImage: {
     width: "100%",
     height: "100%",
+  },
+  cdCaseBackdropImageLoading: {
+    opacity: 0.28,
   },
   loadingOverlay: {
     ...StyleSheet.absoluteFillObject,

--- a/hidden-gem-music-app/src/components/MobileBottomNav.tsx
+++ b/hidden-gem-music-app/src/components/MobileBottomNav.tsx
@@ -8,9 +8,9 @@ import { typefaces } from "../theme/typography";
 
 const mobileNavItems: Array<{ label: string; route: ScreenRoute }> = [
   { label: "Discovery Map", route: "discovery" },
+  { label: "Discovery Dashboard", route: "dashboard" },
   { label: "Compare", route: "comparisonSelect" },
   { label: "Hidden Gems", route: "hiddenGems" },
-  { label: "Dashboard", route: "dashboard" },
   { label: "Credits", route: "credits" },
 ];
 const mobileSearchItem = { label: "Search", route: "search" as const };

--- a/hidden-gem-music-app/src/components/globe/GlobeView.tsx
+++ b/hidden-gem-music-app/src/components/globe/GlobeView.tsx
@@ -1,5 +1,5 @@
 import { LinearGradient } from "expo-linear-gradient";
-import { Fragment, useEffect, useMemo, useRef, useState } from "react";
+import { Fragment, useEffect, useId, useMemo, useRef, useState } from "react";
 import { LayoutChangeEvent, PanResponder, Platform, Pressable, ScrollView, StyleSheet, Text, useWindowDimensions, View } from "react-native";
 import Svg, { Defs, Path, RadialGradient as SvgRadialGradient, Stop } from "react-native-svg";
 
@@ -190,6 +190,10 @@ export function GlobeView({
   const [containerWidth, setContainerWidth] = useState(0);
   const [zoom, setZoom] = useState(DEFAULT_ZOOM);
   const [offset, setOffset] = useState<ViewportOffset>(DEFAULT_OFFSET);
+  const gradientIdPrefix = useId().replace(/:/g, "");
+  const baseFillId = `${gradientIdPrefix}-map-country-base-fill`;
+  const dataFillId = `${gradientIdPrefix}-map-country-data-fill`;
+  const activeFillId = `${gradientIdPrefix}-map-country-active-fill`;
   const hoverTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const hoverSelectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const hoverSyncFrameRef = useRef<number | null>(null);
@@ -698,17 +702,17 @@ export function GlobeView({
                 viewBox={svgViewBox}
               >
                 <Defs>
-                  <SvgRadialGradient id="map-country-base-fill" cx="38%" cy="28%" r="88%">
+                  <SvgRadialGradient id={baseFillId} cx="38%" cy="28%" r="88%">
                     <Stop offset="0%" stopColor={colors.backgroundBottom} stopOpacity={0.94} />
                     <Stop offset="54%" stopColor={colors.backgroundRaised} stopOpacity={0.98} />
                     <Stop offset="100%" stopColor={colors.panelAlt} stopOpacity={1} />
                   </SvgRadialGradient>
-                  <SvgRadialGradient id="map-country-data-fill" cx="34%" cy="26%" r="92%">
+                  <SvgRadialGradient id={dataFillId} cx="34%" cy="26%" r="92%">
                     <Stop offset="0%" stopColor={colors.navGradient} stopOpacity={0.98} />
                     <Stop offset="50%" stopColor={colors.accent} stopOpacity={0.96} />
                     <Stop offset="100%" stopColor={colors.backgroundRaised} stopOpacity={0.98} />
                   </SvgRadialGradient>
-                  <SvgRadialGradient id="map-country-active-fill" cx="36%" cy="24%" r="92%">
+                  <SvgRadialGradient id={activeFillId} cx="36%" cy="24%" r="92%">
                     <Stop offset="0%" stopColor={colors.navGradient} stopOpacity={1} />
                     <Stop offset="52%" stopColor={colors.backgroundRaised} stopOpacity={0.98} />
                     <Stop offset="100%" stopColor={colors.button} stopOpacity={0.96} />
@@ -732,9 +736,9 @@ export function GlobeView({
                           ? MOBILE_COUNTRY_FILL
                           : "transparent"
                       : isHovered || isFocusedCountry
-                        ? "url(#map-country-active-fill)"
+                        ? `url(#${activeFillId})`
                         : hasMapData
-                          ? "url(#map-country-data-fill)"
+                          ? `url(#${dataFillId})`
                           : "transparent";
                   const stroke = comparisonColor
                     ? comparisonColor

--- a/hidden-gem-music-app/src/screens/DashboardScreen.tsx
+++ b/hidden-gem-music-app/src/screens/DashboardScreen.tsx
@@ -52,7 +52,7 @@ export function DashboardScreen({ year, metrics, countries }: Props) {
     <ScreenScaffold>
       <View style={styles.screen}>
         <DiscoveryBlurb
-          heading="Global Overlap Dashboard"
+          heading="Discovery Dashboard"
           body={`This dashboard summarizes discovery behavior for ${year}, including overlap, isolation, and hidden gem concentration across countries.`}
         />
 

--- a/hidden-gem-music-app/src/screens/DashboardScreen.web.tsx
+++ b/hidden-gem-music-app/src/screens/DashboardScreen.web.tsx
@@ -24,6 +24,9 @@ import {
 } from "recharts";
 
 import {
+  loadAvailableYears,
+} from "../data/countryApi";
+import {
   loadDiscoveryGap,
   loadGapDistribution,
   loadIsolationLeader,
@@ -32,6 +35,8 @@ import {
   loadOverlapTrend,
   loadPeakReach,
 } from "../data/dashboardApi";
+import { loadDiscoveryCountries } from "../data/discoveryApi";
+import { isCountryWithAppData } from "../data/countryDisplay";
 import type {
   ApiDiscoveryGap,
   ApiGapBucket,
@@ -41,6 +46,8 @@ import type {
   ApiPeakReach,
   ApiTrendPoint,
 } from "../types/api";
+import type { Country } from "../types/content";
+import { CdCaseArt } from "../components/CdCaseArt";
 import { GemIcon } from "../components/GemIcon";
 import { ScreenScaffold } from "../components/ScreenScaffold";
 import { colors } from "../theme/colors";
@@ -78,6 +85,11 @@ const KPI_BAR = {
   green: "#4ade80",
 };
 
+const KNOWN_PEAK_REACH_ART: Record<string, string> = {
+  "stay (with justin bieber)|the kid laroi":
+    "https://coverartarchive.org/release/9edb549d-b9cd-47b8-8b33-523b0bf8e301/front-500",
+};
+
 // ---------------------------------------------------------------------------
 // Navigation helper (web only — avoids touching App.tsx)
 // ---------------------------------------------------------------------------
@@ -86,6 +98,11 @@ function navigateTo(path: string) {
   if (typeof window !== "undefined") {
     window.location.href = path;
   }
+}
+
+function getKnownPeakReachArtUrl(songTitle?: string | null, artistName?: string | null) {
+  const key = `${songTitle ?? ""}|${artistName ?? ""}`.trim().toLowerCase();
+  return KNOWN_PEAK_REACH_ART[key];
 }
 
 // ---------------------------------------------------------------------------
@@ -106,28 +123,58 @@ const tickStyle = { fill: colors.text, fontSize: 11, opacity: 0.7 };
 // Country Selector
 // ---------------------------------------------------------------------------
 
+type CountrySelectorOption = {
+  isoCode: string;
+  countryName: string;
+  isolationScore: number | null;
+  isolationTier: string | null;
+};
+
+async function loadDashboardCountriesWithAppData() {
+  const years = await loadAvailableYears().catch(() => [2025]);
+  const countrySets = await Promise.all(
+    years.map((year) => loadDiscoveryCountries(year, []).catch(() => []))
+  );
+  const countriesByCode = new Map<string, Country>();
+
+  countrySets.flat().forEach((country) => {
+    if (!isCountryWithAppData(country)) return;
+    const code = country.code.toUpperCase();
+    const existing = countriesByCode.get(code);
+    if (!existing || country.hiddenSongs > existing.hiddenSongs) {
+      countriesByCode.set(code, country);
+    }
+  });
+
+  return Array.from(countriesByCode.values());
+}
+
 function CountrySelector({
   data,
   selectedCountry,
   onSelect,
   onClear,
 }: {
-  data: ApiIsolationEntry[];
-  selectedCountry: ApiIsolationEntry | null;
-  onSelect: (entry: ApiIsolationEntry) => void;
+  data: CountrySelectorOption[];
+  selectedCountry: CountrySelectorOption | null;
+  onSelect: (entry: CountrySelectorOption) => void;
   onClear: () => void;
 }) {
   const [isOpen, setIsOpen] = useState(false);
 
-  const tierLabel = (entry: ApiIsolationEntry) => {
+  const tierLabel = (entry: CountrySelectorOption) => {
+    if (entry.isolationScore === null) return null;
     if (entry.isolationScore > 65) return "highly isolated — most of your charts stay local";
     if (entry.isolationScore >= 40) return "moderately isolated — some crossover, a lot still stays home";
     return "well connected — your market overlaps heavily with global trends";
   };
 
   const rank = selectedCountry
-    ? data.findIndex((e) => e.isoCode === selectedCountry.isoCode) + 1
+    ? data
+        .filter((entry) => entry.isolationScore !== null)
+        .findIndex((e) => e.isoCode === selectedCountry.isoCode) + 1
     : null;
+  const selectedTierLabel = selectedCountry ? tierLabel(selectedCountry) : null;
 
   return (
     <View style={styles.countrySelectorWrap}>
@@ -138,7 +185,7 @@ function CountrySelector({
         <Text style={styles.countrySelectorText}>
           {selectedCountry
             ? `Viewing: ${selectedCountry.countryName}`
-            : "See where your country fits into this story"}
+            : "See where your country fits in"}
         </Text>
         <Text style={styles.countrySelectorChevron}>{isOpen ? "▲" : "▼"}</Text>
       </Pressable>
@@ -167,9 +214,14 @@ function CountrySelector({
               }}
             >
               <Text style={styles.countryDropdownName}>{entry.countryName}</Text>
-              <Text style={styles.countryDropdownScore}>
-                {Math.round(entry.isolationScore)}%
-              </Text>
+              {entry.isolationScore !== null ? (
+                <View style={styles.countryDropdownMeta}>
+                  <Text style={styles.countryDropdownScore}>
+                    {Math.round(entry.isolationScore)}%
+                  </Text>
+                  <Text style={styles.countryDropdownCaption}>isolation score</Text>
+                </View>
+              ) : null}
             </Pressable>
           ))}
         </View>
@@ -181,12 +233,20 @@ function CountrySelector({
             <View style={styles.countryBannerDot} />
             <Text style={styles.countryBannerText}>
               <Text style={styles.countryBannerName}>{selectedCountry.countryName}</Text>
-              {" "}has an isolation score of{" "}
-              <Text style={styles.countryBannerName}>
-                {Math.round(selectedCountry.isolationScore)}%
-              </Text>
-              {" — "}{tierLabel(selectedCountry)}.
-              {rank ? ` It's ranked #${rank} of ${data.length} countries in this dataset.` : ""}
+              {selectedCountry.isolationScore !== null && selectedTierLabel ? (
+                <>
+                  {" "}has an isolation score of{" "}
+                  <Text style={styles.countryBannerName}>
+                    {Math.round(selectedCountry.isolationScore)}%
+                  </Text>
+                  {" — "}{selectedTierLabel}.
+                  {rank
+                    ? ` It's ranked #${rank} of ${data.filter((entry) => entry.isolationScore !== null).length} countries in the current isolation ranking.`
+                    : ""}
+                </>
+              ) : (
+                " is available in the app data. Isolation ranking data was not returned for this country."
+              )}
             </Text>
           </View>
           <Pressable onPress={onClear} style={styles.countryBannerClear}>
@@ -217,22 +277,14 @@ function PullStat({
   number,
   unit,
   context,
-  stackedSign,
 }: {
   number: string;
   unit?: string;
   context: string;
-  stackedSign?: boolean;
 }) {
   return (
     <View style={styles.pullStat}>
       <View style={styles.pullStatDisplay}>
-        {stackedSign ? (
-          <View style={styles.pullStatSignStack}>
-            <Text style={styles.pullStatSign}>+</Text>
-            <Text style={styles.pullStatSign}>−</Text>
-          </View>
-        ) : null}
         <Text style={styles.pullStatNumber}>{number}</Text>
         {unit ? <Text style={styles.pullStatUnit}>{unit}</Text> : null}
       </View>
@@ -343,7 +395,7 @@ function KpiCard({
       <View style={[styles.kpiAccentBar, { backgroundColor: barColor }]} />
       <View style={styles.kpiContent}>
         {flipped ? back : (
-          <View>
+          <View style={styles.kpiFrontShell}>
             {front}
             <Text style={styles.kpiFlipHint}>flip ↻</Text>
           </View>
@@ -511,7 +563,7 @@ function IsolationBarChart({
   selectedCountry,
 }: {
   data: ApiIsolationEntry[];
-  selectedCountry: ApiIsolationEntry | null;
+  selectedCountry: CountrySelectorOption | null;
 }) {
   const chartHeight = Math.max(data.length * 28 + 40, 240);
 
@@ -835,10 +887,11 @@ function DashboardScreenContent() {
   const [peakReach, setPeakReach] = useState<ApiPeakReach | null>(null);
   const [trendData, setTrendData] = useState<ApiTrendPoint[]>([]);
   const [isolationRanking, setIsolationRanking] = useState<ApiIsolationEntry[]>([]);
+  const [dashboardCountries, setDashboardCountries] = useState<Country[]>([]);
   const [gapDistribution, setGapDistribution] = useState<ApiGapBucket[]>([]);
   const [loading, setLoading] = useState(true);
   const [fetchError, setFetchError] = useState<string | null>(null);
-  const [selectedCountry, setSelectedCountry] = useState<ApiIsolationEntry | null>(null);
+  const [selectedCountry, setSelectedCountry] = useState<CountrySelectorOption | null>(null);
 
   useEffect(() => {
     const start = "2017-01-01";
@@ -866,6 +919,10 @@ function DashboardScreenContent() {
         setFetchError(err instanceof Error ? err.message : "Failed to load dashboard data");
         setLoading(false);
       });
+
+    loadDashboardCountriesWithAppData()
+      .then(setDashboardCountries)
+      .catch(() => setDashboardCountries([]));
   }, []);
 
   // All pull-stat values derived from API data
@@ -879,6 +936,34 @@ function DashboardScreenContent() {
     const scores = isolationRanking.map((e) => e.isolationScore);
     return Math.round(Math.max(...scores) - Math.min(...scores));
   }, [isolationRanking]);
+
+  const countryOptions = useMemo<CountrySelectorOption[]>(() => {
+    const isolationByCode = new Map(
+      isolationRanking.map((entry) => [entry.isoCode.toUpperCase(), entry])
+    );
+
+    if (dashboardCountries.length === 0) {
+      return isolationRanking.map((entry) => ({
+        isoCode: entry.isoCode,
+        countryName: entry.countryName,
+        isolationScore: entry.isolationScore,
+        isolationTier: entry.isolationTier,
+      }));
+    }
+
+    return dashboardCountries
+      .filter(isCountryWithAppData)
+      .map((country) => {
+        const isolationEntry = isolationByCode.get(country.code.toUpperCase());
+        return {
+          isoCode: country.code,
+          countryName: country.name,
+          isolationScore: isolationEntry?.isolationScore ?? null,
+          isolationTier: isolationEntry?.isolationTier ?? null,
+        };
+      })
+      .sort((a, b) => a.countryName.localeCompare(b.countryName));
+  }, [dashboardCountries, isolationRanking]);
 
   const overlapChange = useMemo(() => {
     const nonGap = trendData.filter((p) => !p.isGap && p.overlapPct > 0);
@@ -894,26 +979,33 @@ function DashboardScreenContent() {
   }, [trendData]);
 
   // Card 3 personalization
+  const selectedCountryHasIsolation = selectedCountry?.isolationScore !== null && selectedCountry?.isolationScore !== undefined;
   const isolationCardScore = selectedCountry
-    ? Math.round(selectedCountry.isolationScore)
+    ? selectedCountryHasIsolation
+      ? Math.round(selectedCountry.isolationScore as number)
+      : null
     : isolationLeader
     ? Math.round(isolationLeader.isolationScore)
     : null;
   const isolationCardName =
     selectedCountry?.countryName ?? isolationLeader?.countryName ?? "";
-  const isolationCardTierLabel = selectedCountry
-    ? selectedCountry.isolationScore > 65
+  const isolationCardTierLabel = selectedCountryHasIsolation
+    ? (selectedCountry?.isolationScore as number) > 65
       ? "highly isolated market"
-      : selectedCountry.isolationScore >= 40
+      : (selectedCountry?.isolationScore as number) >= 40
       ? "moderately isolated"
       : "well connected"
+    : selectedCountry
+    ? "app data available"
     : "most isolated market";
-  const isolationCardBarColor = selectedCountry
-    ? selectedCountry.isolationScore > 65
+  const isolationCardBarColor = selectedCountryHasIsolation
+    ? (selectedCountry?.isolationScore as number) > 65
       ? KPI_BAR.red
-      : selectedCountry.isolationScore >= 40
+      : (selectedCountry?.isolationScore as number) >= 40
       ? "#fb923c"
       : KPI_BAR.green
+    : selectedCountry
+    ? KPI_BAR.blue
     : KPI_BAR.red;
 
   // Personalized CTA labels
@@ -938,6 +1030,8 @@ function DashboardScreenContent() {
         return `peak ${d.toLocaleString("default", { month: "short" })} ${d.getFullYear()}`;
       })()
     : null;
+  const peakReachArtUrl =
+    peakReach?.albumArtUrl ?? getKnownPeakReachArtUrl(peakReach?.songTitle, peakReach?.artistName);
 
   // Scrollbar state
   const pageScrollRef = useRef<ScrollView>(null);
@@ -1059,7 +1153,7 @@ function DashboardScreenContent() {
                   This isn't a taste difference — it's a structural gap in how music travels.
                 </Text>
                 <CountrySelector
-                  data={isolationRanking}
+                  data={countryOptions}
                   selectedCountry={selectedCountry}
                   onSelect={setSelectedCountry}
                   onClear={() => setSelectedCountry(null)}
@@ -1120,7 +1214,7 @@ function DashboardScreenContent() {
                   <ChapterCard label="DISCOVERY GAP DISTRIBUTION">
                     <DiscoveryGapHistogram data={gapDistribution} />
                   </ChapterCard>
-                  <Text style={styles.pullQuote}>
+                  <Text style={[styles.pullQuote, styles.histogramPullQuote]}>
                     Most songs that cross any border do so within two weeks. The long tail —
                     songs that took months or never arrived at all — is what the discovery gap
                     is made of.
@@ -1181,7 +1275,7 @@ function DashboardScreenContent() {
                   />
                 ) : null}
 
-                {isolationCardScore !== null ? (
+                {selectedCountry || isolationCardScore !== null ? (
                   <KpiCard
                     barColor={isolationCardBarColor}
                     front={
@@ -1189,7 +1283,9 @@ function DashboardScreenContent() {
                         <Text style={styles.kpiLabel}>
                           {selectedCountry ? "Your Country" : "Most Isolated Market"}
                         </Text>
-                        <Text style={styles.kpiNumber}>{isolationCardScore}%</Text>
+                        <Text style={styles.kpiNumber}>
+                          {isolationCardScore !== null ? `${isolationCardScore}%` : "—"}
+                        </Text>
                         <Text style={styles.kpiSublabel}>
                           {isolationCardName} — {isolationCardTierLabel}
                         </Text>
@@ -1202,7 +1298,9 @@ function DashboardScreenContent() {
                         </Text>
                         <Text style={styles.kpiBackBody}>
                           {selectedCountry
-                            ? selectedCountry.isolationScore > 65
+                            ? selectedCountry.isolationScore === null
+                              ? `${selectedCountry.countryName} is available in the app data, but the current isolation ranking response does not include a score for it.`
+                              : selectedCountry.isolationScore > 65
                               ? `${selectedCountry.countryName} has an isolation score of ${Math.round(selectedCountry.isolationScore)}%. Most of its chart stays local — it has some of the most to discover.`
                               : selectedCountry.isolationScore >= 40
                               ? `${selectedCountry.countryName} has an isolation score of ${Math.round(selectedCountry.isolationScore)}%. Some global crossover, but still plenty of undiscovered music.`
@@ -1310,10 +1408,9 @@ function DashboardScreenContent() {
                 <View style={styles.chapterLeft}>
                   {overlapChange !== null ? (
                     <PullStat
-                      number={String(overlapChange.delta)}
+                      number={`${overlapChange.direction === "rose" ? "+" : "-"}${overlapChange.delta}`}
                       unit="pts"
-                      context={`overlap ${overlapChange.direction} from ${overlapChange.pct2017}% to ${overlapChange.pct2021}% between 2017 and 2021 — then a 22-month silence.`}
-                      stackedSign
+                      context={`overlap ${overlapChange.direction} from ${overlapChange.pct2017}% to ${overlapChange.pct2021}% between 2017 and 2021.`}
                     />
                   ) : null}
                 </View>
@@ -1376,11 +1473,11 @@ function DashboardScreenContent() {
                         </Text>
                       </ArgumentText>
                       <View style={styles.songRefCard}>
-                        <View
-                          style={[
-                            styles.songRefSwatch,
-                            { backgroundColor: rowBackdropColors[0] },
-                          ]}
+                        <CdCaseArt
+                          size={74}
+                          placeholderColor={rowBackdropColors[0]}
+                          artImageUrl={peakReachArtUrl}
+                          loading={!peakReachArtUrl}
                         />
                         <View style={styles.songRefInfo}>
                           <Text style={styles.songRefTitle}>{peakReach.songTitle}</Text>
@@ -1694,6 +1791,7 @@ const styles = StyleSheet.create({
   countryDropdownItem: {
     flexDirection: "row",
     alignItems: "center",
+    gap: 12,
     paddingHorizontal: 16,
     paddingVertical: 10,
     borderBottomWidth: 0.5,
@@ -1709,10 +1807,20 @@ const styles = StyleSheet.create({
     fontSize: 13,
   },
   countryDropdownScore: {
-    color: colors.text,
+    color: colors.accent,
     fontFamily: typefaces.body,
     fontSize: 12,
-    opacity: 0.7,
+    fontWeight: "600",
+  },
+  countryDropdownMeta: {
+    alignItems: "flex-end",
+    gap: 1,
+  },
+  countryDropdownCaption: {
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 9,
+    opacity: 0.45,
   },
   countryBanner: {
     flexDirection: "row",
@@ -1769,13 +1877,13 @@ const styles = StyleSheet.create({
   chapterLabelRow: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 12,
-    marginBottom: 28,
+    gap: 14,
+    marginBottom: 52,
   },
   chapterCircle: {
-    width: 32,
-    height: 32,
-    borderRadius: 16,
+    width: 46,
+    height: 46,
+    borderRadius: 23,
     borderWidth: 1.5,
     borderColor: "rgba(117,82,107,0.6)",
     backgroundColor: "rgba(117,82,107,0.08)",
@@ -1785,14 +1893,14 @@ const styles = StyleSheet.create({
   chapterNumber: {
     color: colors.accent,
     fontFamily: typefaces.body,
-    fontSize: 13,
+    fontSize: 18,
     fontWeight: "700",
   },
   chapterTitle: {
     color: colors.text,
     fontFamily: typefaces.body,
-    fontSize: 13,
-    letterSpacing: 2,
+    fontSize: 18,
+    letterSpacing: 2.4,
     textTransform: "uppercase" as any,
     fontWeight: "500",
     opacity: 0.75,
@@ -1824,22 +1932,7 @@ const styles = StyleSheet.create({
   pullStatDisplay: {
     flexDirection: "row",
     alignItems: "baseline",
-    flexWrap: "wrap",
-  },
-  pullStatSignStack: {
-    flexDirection: "column",
-    alignItems: "center",
-    justifyContent: "flex-end",
-    marginRight: 2,
-    marginBottom: 6,
-  },
-  pullStatSign: {
-    color: colors.accent,
-    fontFamily: typefaces.display,
-    fontSize: 48,
-    fontWeight: "700",
-    lineHeight: 52,
-    letterSpacing: -2,
+    flexWrap: "nowrap",
   },
   pullStatNumber: {
     color: colors.accent,
@@ -1874,7 +1967,7 @@ const styles = StyleSheet.create({
     lineHeight: 19,
     maxWidth: 220,
     opacity: 0.5,
-    marginTop: 12,
+    marginTop: 20,
     fontStyle: "italic",
   },
 
@@ -1984,22 +2077,26 @@ const styles = StyleSheet.create({
     paddingLeft: 12,
     marginTop: 12,
   },
+  histogramPullQuote: {
+    marginBottom: 12,
+  },
 
   // —— KPI flip cards ——
   kpiGrid: {
     flexDirection: "row",
     flexWrap: "wrap",
-    gap: 10,
+    gap: 16,
   },
   kpiCard: {
     flex: 1,
-    minWidth: 180,
+    flexBasis: "45%",
+    minWidth: 300,
     flexDirection: "row",
     backgroundColor: "rgba(255,255,255,0.04)",
     borderWidth: 0.5,
     borderColor: "rgba(255,255,255,0.08)",
     borderRadius: 10,
-    minHeight: 100,
+    minHeight: 140,
     overflow: "hidden",
     cursor: "pointer" as any,
   },
@@ -2013,10 +2110,15 @@ const styles = StyleSheet.create({
   },
   kpiContent: {
     flex: 1,
-    padding: 12,
+    padding: 16,
+  },
+  kpiFrontShell: {
+    flex: 1,
+    justifyContent: "space-between",
+    gap: 12,
   },
   kpiFront: {
-    gap: 4,
+    gap: 6,
   },
   kpiBack: {
     gap: 8,
@@ -2024,26 +2126,26 @@ const styles = StyleSheet.create({
   kpiLabel: {
     color: colors.text,
     fontFamily: typefaces.body,
-    fontSize: 12,
+    fontSize: 13,
     opacity: 0.6,
   },
   kpiNumber: {
     color: colors.textStrong,
     fontFamily: typefaces.display,
-    fontSize: 32,
+    fontSize: 38,
     fontWeight: "700",
-    lineHeight: 36,
+    lineHeight: 42,
   },
   kpiSublabel: {
     color: colors.text,
     fontFamily: typefaces.body,
-    fontSize: 12,
-    lineHeight: 16,
+    fontSize: 13,
+    lineHeight: 18,
   },
   kpiSecondary: {
     color: colors.text,
     fontFamily: typefaces.body,
-    fontSize: 11,
+    fontSize: 12,
     opacity: 0.5,
   },
   kpiFlipHint: {
@@ -2057,14 +2159,14 @@ const styles = StyleSheet.create({
   kpiBackTitle: {
     color: colors.textStrong,
     fontFamily: typefaces.display,
-    fontSize: 13,
+    fontSize: 15,
     fontWeight: "600",
   },
   kpiBackBody: {
     color: colors.text,
     fontFamily: typefaces.body,
-    fontSize: 13,
-    lineHeight: 18,
+    fontSize: 14,
+    lineHeight: 20,
     opacity: 0.75,
   },
   kpiCta: {
@@ -2182,7 +2284,9 @@ const styles = StyleSheet.create({
     gap: 20,
   },
   conclusionRight: {
-    minWidth: 240,
+    width: 444,
+    minWidth: 444,
+    maxWidth: "100%",
     flex: 0,
   },
   conclusionHeadline: {
@@ -2213,30 +2317,34 @@ const styles = StyleSheet.create({
   statGrid: {
     flexDirection: "row",
     flexWrap: "wrap",
-    gap: 10,
+    gap: 12,
+    width: "100%",
   },
   statCard: {
-    flex: 1,
-    minWidth: 110,
+    flexGrow: 0,
+    flexShrink: 0,
+    flexBasis: 216,
+    width: 216,
+    aspectRatio: 1,
     backgroundColor: "rgba(255,255,255,0.04)",
     borderWidth: 0.5,
     borderColor: "rgba(255,255,255,0.08)",
     borderRadius: 10,
-    padding: 14,
-    gap: 4,
+    padding: 17,
+    gap: 6,
   },
   statNumber: {
     color: colors.accent,
     fontFamily: typefaces.display,
-    fontSize: 32,
+    fontSize: 46,
     fontWeight: "700",
-    lineHeight: 36,
+    lineHeight: 50,
   },
   statLabel: {
     color: colors.text,
     fontFamily: typefaces.body,
-    fontSize: 11,
-    lineHeight: 15,
+    fontSize: 15,
+    lineHeight: 20,
     opacity: 0.65,
   },
 

--- a/hidden-gem-music-app/src/screens/HiddenGemsScreen.tsx
+++ b/hidden-gem-music-app/src/screens/HiddenGemsScreen.tsx
@@ -324,14 +324,33 @@ function MiniCdCase({
   artImageUrl?: string;
   showPlayButton: boolean;
 }) {
+  const hasArtImage = typeof artImageUrl === "string" && artImageUrl.trim().length > 0;
+  const [artLoaded, setArtLoaded] = useState(false);
   const artSize = Math.round(54 * CD_ART_SIZE_RATIO);
   const left = Math.round(54 * CD_ART_LEFT_RATIO);
   const top = Math.round(54 * CD_ART_TOP_RATIO);
 
+  useEffect(() => {
+    setArtLoaded(false);
+  }, [artImageUrl]);
+
   return (
     <View style={styles.miniCdCaseFrame}>
       <View style={[styles.miniCdCaseBackdrop, { left, top, width: artSize, height: artSize, backgroundColor: color }]}>
-        {artImageUrl ? <Image source={{ uri: artImageUrl }} style={styles.miniCdCaseBackdropImage} resizeMode="cover" /> : null}
+        {hasArtImage ? (
+          <Image
+            source={{ uri: artImageUrl }}
+            style={[styles.miniCdCaseBackdropImage, !artLoaded ? styles.miniCdCaseBackdropImageLoading : null]}
+            resizeMode="cover"
+            onLoad={() => setArtLoaded(true)}
+            onError={() => setArtLoaded(true)}
+          />
+        ) : null}
+        {hasArtImage && !artLoaded ? (
+          <View style={styles.miniCdLoadingOverlay}>
+            <ActivityIndicator size={14} color={colors.textLight} />
+          </View>
+        ) : null}
       </View>
       <Image source={cdCaseSource} style={styles.miniCdCaseImage} resizeMode="contain" />
       {showPlayButton ? (
@@ -1002,6 +1021,7 @@ export function HiddenGemsScreen({
   const isStacked = isNativePlatform;
   const isBlurbStacked = isNativePlatform || width < 1380;
   const [apiProfile, setApiProfile] = useState<ReturnType<typeof mapApiCountryProfile> | null>(null);
+  const [isProfileLoading, setIsProfileLoading] = useState(showNavIntro);
   const [apiSongs, setApiSongs] = useState<Song[] | null>(null);
   const [isSongsLoading, setIsSongsLoading] = useState(showNavIntro);
   const [hasNextPage, setHasNextPage] = useState(false);
@@ -1153,21 +1173,29 @@ export function HiddenGemsScreen({
   useEffect(() => {
     if (!isActive || shouldShowNavIntro) {
       setApiProfile(null);
+      setIsProfileLoading(false);
       return;
     }
     const controller = new AbortController();
+    setApiProfile(null);
+    setIsProfileLoading(true);
     loadCountryProfile(country.code, selectedYear, controller.signal)
       .then((profilePayload) => {
-        setApiProfile(mapApiCountryProfile(profilePayload));
+        if (!controller.signal.aborted) {
+          setApiProfile(mapApiCountryProfile(profilePayload));
+          setIsProfileLoading(false);
+        }
       })
       .catch(() => {
         if (!(controller.signal.aborted)) {
           setApiProfile(null);
+          setIsProfileLoading(false);
         }
       });
 
     return () => {
       controller.abort();
+      setIsProfileLoading(false);
     };
   }, [country.code, isActive, selectedYear, shouldShowNavIntro]);
 
@@ -1436,6 +1464,11 @@ export function HiddenGemsScreen({
       return [];
     }
 
+    const imageByArtist = new Map(
+      hiddenGemSongs
+        .filter((song) => song.artistImageUrl && song.artistImageUrl.trim().length > 0)
+        .map((song) => [song.artist.trim().toLowerCase(), song.artistImageUrl] as const)
+    );
     const selectedArtists: FavoriteArtistPreview[] = [];
     const seen = new Set<string>();
     const addArtist = (name: string, songTitle: string, artistImageUrl?: string) => {
@@ -1445,7 +1478,7 @@ export function HiddenGemsScreen({
       }
 
       seen.add(normalized);
-      selectedArtists.push({ artist: name, songTitle, artistImageUrl });
+      selectedArtists.push({ artist: name, songTitle, artistImageUrl: artistImageUrl || imageByArtist.get(normalized) });
     };
 
     apiProfile.topUniqueSongs.forEach((song) => addArtist(song.artist, song.title, song.artistImageUrl));
@@ -1454,7 +1487,7 @@ export function HiddenGemsScreen({
     }
 
     return selectedArtists;
-  }, [apiProfile]);
+  }, [apiProfile, hiddenGemSongs]);
 
   const selectedSongIndex = hiddenGemSongs.findIndex((song) => song.id === selectedSong.id);
   const hasPreviousSong = selectedSongIndex > 0 || page > 1;
@@ -1923,8 +1956,8 @@ export function HiddenGemsScreen({
             country={country}
             selectedYear={selectedYear}
             artists={favoriteArtists}
-            useLoadingLabels={shouldShowNavIntro}
-            isLoading={isScreenLoading}
+            useLoadingLabels={shouldShowNavIntro || isProfileLoading}
+            isLoading={isScreenLoading || isProfileLoading}
           />
         </View>
       </View>
@@ -2890,6 +2923,15 @@ const styles = StyleSheet.create({
   miniCdCaseBackdropImage: {
     width: "100%",
     height: "100%",
+  },
+  miniCdCaseBackdropImageLoading: {
+    opacity: 0.28,
+  },
+  miniCdLoadingOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "rgba(15,16,21,0.2)",
   },
   miniCdCaseImage: {
     width: 54,

--- a/hidden-gem-music-app/src/screens/WelcomeScreen.tsx
+++ b/hidden-gem-music-app/src/screens/WelcomeScreen.tsx
@@ -141,11 +141,12 @@ export function WelcomeScreen({ onDismiss, onSelectRoute }: Props) {
               The purpose of this app is to find and display the 'Discovery Gap' — What music is most loved in each
               country, and how much was that country's most loved music spread, shared, and loved by other countries?
               Explore the Discovery Gap multiple ways: the discovery map, country detail pages, comparison mode,
-              listen to 30 second previews of hidden gems, and the discovery dashboard (name TBD). Utilize filters in
+              listen to 30 second previews of hidden gems, and the Discovery Dashboard. Utilize filters in
               multiple areas of the app to fine tune your discovery.
             </Text>
             <View style={styles.buttonStack}>
               <ActionButton label="Discovery Map" size="compact" onPress={() => dismissWithAction(() => onSelectRoute("discovery"))} />
+              <ActionButton label="Discovery Dashboard" size="compact" onPress={() => dismissWithAction(() => onSelectRoute("dashboard"))} />
               <ActionButton
                 label="Comparison Mode"
                 size="compact"
@@ -156,7 +157,6 @@ export function WelcomeScreen({ onDismiss, onSelectRoute }: Props) {
                 size="compact"
                 onPress={() => dismissWithAction(() => onSelectRoute("hiddenGems"))}
               />
-              <ActionButton label="Dashboard" size="compact" onPress={() => dismissWithAction(() => onSelectRoute("dashboard"))} />
               <ActionButton label="Credits" size="compact" onPress={() => dismissWithAction(() => onSelectRoute("credits"))} />
             </View>
           </View>

--- a/hidden-gem-music-app/src/types/api.ts
+++ b/hidden-gem-music-app/src/types/api.ts
@@ -161,6 +161,7 @@ export type ApiPeakReach = {
   songTitle: string;
   artistName: string;
   peakDate: string;
+  albumArtUrl?: string | null;
 };
 
 export type ApiTrendPoint = {


### PR DESCRIPTION
# PR: Progress on Issue 128 Debug Dashboard Issues

## Completed In This PR

- Updated the "See where your country fits in" dropdown so it can include all countries with app data across available metadata years.
- Kept the selector wording minimal and made dropdown labels clarify whether the right-side value is an isolation score or app data without a returned score.
- Fixed spacing below the Chapter 1 Discovery Gap Distribution explanatory text.
- Made the first four Chapter 1 KPI flip cards larger and changed them from one row of four to a two-by-two layout.
- Made the `flip ↻` hint spacing consistent inside the KPI cards.
- Increased lower conclusion stat cards by about 20% and kept them in a two-by-two square card layout.
- Made section divider numbers and headers bigger.
- Added more breathing room under the Chapter 2 isolation-score explanation.
- Replaced the stacked Chapter 3 plus/minus display with one inline signed value, such as `+6 pts` or `-6 pts`.
- Removed the phrase "then a 22-month silence."
- Added real CD cover art to Chapter 4, THE CEILING, using the existing CD case component.
- Extended the peak reach Dashboard API response with `albumArtUrl` by reusing the existing Deezer enrichment service, with a known cover fallback for the current peak song.
- Renamed the Dashboard nav item to "Discovery Dashboard" and moved it directly after "Discovery Map" on web, mobile, and Welcome screen navigation.

## Clarification Needed Before Remaining Items Can Be Finished

### "Adjust wording on explanation"

Why this is not completed: the issue does not identify which explanation text should change or what replacement wording is expected.

Follow-up needed: please provide the exact current text, screenshot location, or target replacement copy.

### "Conclusion card - make KPI cards a carousel?"

Why this is not completed: the Dashboard conclusion has four stat cards, and that does not map cleanly to the existing Preview Hidden Gems carousel pattern.

Follow-up needed: please provide a screenshot or describe which conclusion cards should become a carousel and what carousel behavior is expected.

### "Add data sources to About this data"

Why this is not completed: the visible source labels need to come from the data owner so the app does not display guessed or incomplete source wording.

Follow-up needed: please provide the exact data-source names/labels that should appear in About this data.

### Dashboard naming feedback

The Dashboard route/nav label was renamed to "Discovery Dashboard" and moved directly after "Discovery Map" in the web and mobile navigation. The Welcome screen copy and buttons were updated to match. We have discussed wanting a catchier name, but have not landed on one yet, so please flag if "Discovery Dashboard" should be changed before final merge. Goal of rename was simply to not forget. 

### "Adjust isolation scores by country graph to include all countries"

Why this is not completed: the Dashboard chart is fed by `sp_GetIsolationRanking`, and that stored procedure currently uses `SELECT TOP 20`. From the issue text, this likely means the graph should include every country that has isolation-score rows, not just the top 20.

Potential SQL direction:

```sql
SELECT
    c.full_name                     AS country_name,
    c.iso_code,
    c.region,
    AVG(isc.isolation_score)        AS isolation_score,
    MAX(isc.isolation_tier)         AS isolation_tier
FROM IsolationScoreByCountry isc
JOIN Country c ON c.country_id = isc.country_id
WHERE isc.chart_year BETWEEN @YearStart AND @YearEnd
GROUP BY c.country_id, c.full_name, c.iso_code, c.region
ORDER BY AVG(isc.isolation_score) DESC;
```

## Verification

- `npm run typecheck`
- `dotnet build Capstone.API.csproj`

## Browser Checks For Reviewer

- Dashboard dropdown includes countries with app data, not only the current top-20 isolation ranking rows.
- Selecting a country with no score in the current ranking response shows app-data availability instead of a fake score.
- Chapter 1 histogram explanatory text has balanced spacing above and below.
- Chapter 1 KPI cards render as a larger two-by-two grid.
- Lower conclusion stat cards are larger and remain in a two-by-two square card layout.
- Chapter 3 signed stat reads inline as `+6 pts` or `-6 pts`.
- Chapter 4 peak reach card shows CD cover art when enrichment returns album art.
