### PR TITLE
Completed Issue 123 Implement Language Data Across the App and Created Presentation Data Prep Tool for Loading Optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,8 @@ Generated\ Files/
 
 # Local live song enrichment cache
 backend/Capstone.API/live_song_enrichment_cache/
+backend/Capstone.API/Data/discovery_samples_cache.json
+backend/Capstone.API/Data/presentation_data_cache.json
 
 # Local additional-data getter runtime/output artifacts
 tools/mp3li_additional_data_getter_v2/output*/

--- a/backend/Capstone.API/Controllers/CountryController.cs
+++ b/backend/Capstone.API/Controllers/CountryController.cs
@@ -21,10 +21,13 @@ namespace Capstone.API.Controllers
         private const int DefaultSongsPageSize = 50;
         private const int MaxSongsPageSize = 100;
         private const int MaxGenreSampleCodes = 16;
+        private const int MaxLanguageSampleCodes = 16;
         private const string AvailableYearsCacheKey = "country-controller-available-years";
 
         private readonly ICountryRepository _repo;
         private readonly IMetadataRepository _metadataRepo;
+        private readonly IDiscoverySampleCacheService _discoverySampleCache;
+        private readonly IPresentationDataCacheService _presentationDataCache;
         private readonly ILogger<CountryController> _logger;
         private readonly IMemoryCache _memoryCache;
 
@@ -34,11 +37,15 @@ namespace Capstone.API.Controllers
         public CountryController(
             ICountryRepository repo,
             IMetadataRepository metadataRepo,
+            IDiscoverySampleCacheService discoverySampleCache,
+            IPresentationDataCacheService presentationDataCache,
             IMemoryCache memoryCache,
             ILogger<CountryController> logger)
         {
             _repo = repo;
             _metadataRepo = metadataRepo;
+            _discoverySampleCache = discoverySampleCache;
+            _presentationDataCache = presentationDataCache;
             _memoryCache = memoryCache;
             _logger = logger;
         }
@@ -59,10 +66,24 @@ namespace Capstone.API.Controllers
             try
             {
                 var normalizedCode = code.ToUpperInvariant();
+                var cacheKey = BuildPresentationCacheKey("country-profile", normalizedCode, year);
+                var cached = await _presentationDataCache.GetAsync(cacheKey, cancellationToken);
+                if (cached.HasValue)
+                {
+                    return Ok(cached.Value);
+                }
+
                 var result = await _repo.GetCountryProfileAsync(normalizedCode, year, cancellationToken);
                 if (result == null)
                     return NotFound();
 
+                var favoriteArtists = BuildFavoriteArtists(result);
+                if (favoriteArtists.Count > 0)
+                {
+                    await _discoverySampleCache.SaveFavoriteArtistsAsync(normalizedCode, year, favoriteArtists, cancellationToken);
+                }
+
+                await _presentationDataCache.SaveAsync(cacheKey, result, cancellationToken);
                 return Ok(result);
             }
             catch (SqlException ex)
@@ -99,7 +120,15 @@ namespace Capstone.API.Controllers
             try
             {
                 var normalizedCode = code.ToUpperInvariant();
+                var cacheKey = BuildPresentationCacheKey("country-hidden-gems-preview", normalizedCode, year, normalizedLimit);
+                var cached = await _presentationDataCache.GetAsync(cacheKey, cancellationToken);
+                if (cached.HasValue)
+                {
+                    return Ok(cached.Value);
+                }
+
                 var result = await _repo.GetHiddenGemsPreviewAsync(normalizedCode, year, normalizedLimit, cancellationToken);
+                await _presentationDataCache.SaveAsync(cacheKey, result, cancellationToken);
                 return Ok(result);
             }
             catch (SqlException ex)
@@ -150,6 +179,13 @@ namespace Capstone.API.Controllers
             try
             {
                 var normalizedCode = code.ToUpperInvariant();
+                var cacheKey = BuildPresentationCacheKey("country-songs", normalizedCode, year, normalizedListType, normalizedPage, normalizedPageSize);
+                var cached = await _presentationDataCache.GetAsync(cacheKey, cancellationToken);
+                if (cached.HasValue)
+                {
+                    return Ok(cached.Value);
+                }
+
                 var result = await _repo.GetCountrySongsPageAsync(
                     normalizedCode,
                     year,
@@ -157,6 +193,7 @@ namespace Capstone.API.Controllers
                     normalizedPage,
                     normalizedPageSize,
                     cancellationToken);
+                await _presentationDataCache.SaveAsync(cacheKey, result, cancellationToken);
                 return Ok(result);
             }
             catch (SqlException ex)
@@ -218,7 +255,14 @@ namespace Capstone.API.Controllers
                     return await _memoryCache.GetOrCreateAsync(cacheKey, async (entry) =>
                     {
                         entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(30);
-                        var genres = await _repo.GetCountryGenreSampleAsync(countryCode, year, cancellationToken);
+                        var cachedGenres = await _discoverySampleCache.GetGenresAsync(countryCode, year, cancellationToken);
+                        var genres = cachedGenres.Count > 0
+                            ? cachedGenres
+                            : await _repo.GetCountryGenreSampleAsync(countryCode, year, cancellationToken);
+                        if (genres.Count > 0 && cachedGenres.Count == 0)
+                        {
+                            await _discoverySampleCache.SaveGenresAsync(countryCode, year, genres, cancellationToken);
+                        }
                         return new Capstone.API.Models.Country.CountryGenreSample
                         {
                             CountryCode = countryCode,
@@ -249,6 +293,87 @@ namespace Capstone.API.Controllers
             }
         }
 
+        /// <summary>
+        /// Returns small file-backed language samples for one or more countries in a selected year.
+        /// GET /api/country/language-samples?year={year}&amp;codes=US,CA,JP
+        /// </summary>
+        [HttpGet("language-samples")]
+        public async Task<IActionResult> GetCountryLanguageSamples(
+            [FromQuery] int year = 2021,
+            [FromQuery] string codes = "",
+            CancellationToken cancellationToken = default)
+        {
+            var availableYears = await _memoryCache.GetOrCreateAsync(AvailableYearsCacheKey, async (entry) =>
+            {
+                entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(5);
+                return (await _metadataRepo.GetAvailableYearsAsync()).ToHashSet();
+            }) ?? new HashSet<int>();
+
+            if (!availableYears.Contains(year))
+            {
+                return BadRequest(new { message = $"Year {year} is unavailable in this dataset." });
+            }
+
+            var normalizedCodes = codes
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Select((value) => value.ToUpperInvariant())
+                .Where((value) => CountryCodeRegex.IsMatch(value))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Take(MaxLanguageSampleCodes)
+                .ToList();
+
+            if (normalizedCodes.Count == 0)
+            {
+                return BadRequest(new { message = "At least one valid 2-letter country code is required." });
+            }
+
+            try
+            {
+                var tasks = normalizedCodes.Select(async (countryCode) =>
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var cacheKey = $"country-language-sample::{year}::{countryCode}";
+                    return await _memoryCache.GetOrCreateAsync(cacheKey, async (entry) =>
+                    {
+                        entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(30);
+                        var cachedLanguages = await _discoverySampleCache.GetLanguagesAsync(countryCode, year, cancellationToken);
+                        var languages = cachedLanguages.Count > 0
+                            ? cachedLanguages
+                            : await _repo.GetCountryLanguageSampleAsync(countryCode, year, cancellationToken);
+                        if (languages.Count > 0 && cachedLanguages.Count == 0)
+                        {
+                            await _discoverySampleCache.SaveLanguagesAsync(countryCode, year, languages, cancellationToken);
+                        }
+                        return new Capstone.API.Models.Country.CountryLanguageSample
+                        {
+                            CountryCode = countryCode,
+                            Languages = languages.ToList()
+                        };
+                    });
+                });
+
+                var results = (await Task.WhenAll(tasks))
+                    .Where(sample => sample is not null)
+                    .ToList();
+
+                return Ok(results);
+            }
+            catch (SqlException ex)
+            {
+                _logger.LogError(ex, "SQL error getting country language samples for year {Year} codes {Codes}", year, codes);
+                return StatusCode(503, new { message = "Database temporarily unavailable while retrieving country language samples." });
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                return new EmptyResult();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error getting country language samples for year {Year} codes {Codes}", year, codes);
+                return StatusCode(500, new { message = "An unexpected error occurred while retrieving country language samples." });
+            }
+        }
+
         private async Task<string?> ValidateInputsAsync(string code, int year)
         {
             if (string.IsNullOrWhiteSpace(code) || !CountryCodeRegex.IsMatch(code))
@@ -268,6 +393,45 @@ namespace Capstone.API.Controllers
             }
 
             return null;
+        }
+
+        private static List<Capstone.API.Models.Country.FavoriteArtistSample> BuildFavoriteArtists(Capstone.API.Models.Country.CountryProfile profile)
+        {
+            var favoriteArtists = new List<Capstone.API.Models.Country.FavoriteArtistSample>(8);
+            var seenArtists = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            void AddArtist(Capstone.API.Models.Shared.Song song)
+            {
+                var artist = song.ArtistName?.Trim();
+                if (string.IsNullOrWhiteSpace(artist) || !seenArtists.Add(artist) || favoriteArtists.Count >= 8)
+                {
+                    return;
+                }
+
+                favoriteArtists.Add(new Capstone.API.Models.Country.FavoriteArtistSample
+                {
+                    Artist = artist,
+                    SongTitle = song.SongName?.Trim() ?? string.Empty,
+                    ArtistImageUrl = string.IsNullOrWhiteSpace(song.ArtistImageUrl) ? null : song.ArtistImageUrl.Trim()
+                });
+            }
+
+            foreach (var song in profile.TopUniqueSongs)
+            {
+                AddArtist(song);
+            }
+
+            foreach (var song in profile.TopSharedSongs)
+            {
+                AddArtist(song);
+            }
+
+            return favoriteArtists;
+        }
+
+        private static string BuildPresentationCacheKey(string endpoint, params object[] parts)
+        {
+            return string.Join("::", new[] { endpoint }.Concat(parts.Select(part => part.ToString() ?? ""))).ToUpperInvariant();
         }
     }
 }

--- a/backend/Capstone.API/Controllers/HiddenGemsController.cs
+++ b/backend/Capstone.API/Controllers/HiddenGemsController.cs
@@ -12,14 +12,19 @@ namespace Capstone.API.Controllers
     public class HiddenGemsController : ControllerBase
     {
         private readonly IHiddenGemsRepository _repo;
+        private readonly IPresentationDataCacheService _presentationDataCache;
         private readonly ILogger<HiddenGemsController> _logger;
 
         /// <summary>
         /// Initializes a new instance of HiddenGemsController.
         /// </summary>
-        public HiddenGemsController(IHiddenGemsRepository repo, ILogger<HiddenGemsController> logger)
+        public HiddenGemsController(
+            IHiddenGemsRepository repo,
+            IPresentationDataCacheService presentationDataCache,
+            ILogger<HiddenGemsController> logger)
         {
             _repo = repo;
+            _presentationDataCache = presentationDataCache;
             _logger = logger;
         }
 
@@ -47,7 +52,16 @@ namespace Capstone.API.Controllers
 
             try
             {
-                var result = await _repo.GetHiddenGemsAsync(code.ToUpper(), year, minCountries, page, pageSize, cancellationToken);
+                var normalizedCode = code.ToUpperInvariant();
+                var cacheKey = BuildPresentationCacheKey("hidden-gems", normalizedCode, year, minCountries, page, pageSize);
+                var cached = await _presentationDataCache.GetAsync(cacheKey, cancellationToken);
+                if (cached.HasValue)
+                {
+                    return Ok(cached.Value);
+                }
+
+                var result = await _repo.GetHiddenGemsAsync(normalizedCode, year, minCountries, page, pageSize, cancellationToken);
+                await _presentationDataCache.SaveAsync(cacheKey, result, cancellationToken);
                 return Ok(result);
             }
             catch (SqlException ex)
@@ -64,6 +78,11 @@ namespace Capstone.API.Controllers
                 _logger.LogError(ex, "Error getting hidden gems for {CountryCode} year {Year}", code, year);
                 return StatusCode(500, new { message = "An unexpected error occurred while retrieving hidden gems data." });
             }
+        }
+
+        private static string BuildPresentationCacheKey(string endpoint, params object[] parts)
+        {
+            return string.Join("::", new[] { endpoint }.Concat(parts.Select(part => part.ToString() ?? ""))).ToUpperInvariant();
         }
     }
 }

--- a/backend/Capstone.API/Controllers/LanguageController.cs
+++ b/backend/Capstone.API/Controllers/LanguageController.cs
@@ -1,0 +1,31 @@
+using Capstone.API.Infrastructure.Interfaces;
+using Capstone.API.Models.Language;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Capstone.API.Controllers
+{
+    [ApiController]
+    [Route("api/language")]
+    public class LanguageController : ControllerBase
+    {
+        private const int MaxLookupSongs = 100;
+
+        private readonly ILanguageLookupService _languageLookupService;
+
+        public LanguageController(ILanguageLookupService languageLookupService)
+        {
+            _languageLookupService = languageLookupService;
+        }
+
+        [HttpPost("songs")]
+        public IActionResult GetSongLanguageMatches([FromBody] LanguageSongLookupRequest request)
+        {
+            var songs = request.Songs
+                .Where((song) => !string.IsNullOrWhiteSpace(song.SongName) && !string.IsNullOrWhiteSpace(song.ArtistName))
+                .Take(MaxLookupSongs)
+                .ToList();
+
+            return Ok(_languageLookupService.FindMatches(songs));
+        }
+    }
+}

--- a/backend/Capstone.API/Documentation/apis/project-integration-endpoints.md
+++ b/backend/Capstone.API/Documentation/apis/project-integration-endpoints.md
@@ -38,6 +38,7 @@ These are the app endpoints the frontend calls.
   - enriched top shared songs
   - enriched top unique songs
   - sampled genres used in summary text
+  - cached by the local presentation-data cache when the response has been warmed
 
 ### 2. Country hidden-gems preview
 
@@ -48,6 +49,7 @@ These are the app endpoints the frontend calls.
 - Current role:
   - preview carousel songs for country and comparison screens
   - live Deezer enrichment applied on backend
+  - cached by the local presentation-data cache when the response has been warmed
 
 ### 3. Country songs paged list
 
@@ -59,6 +61,7 @@ These are the app endpoints the frontend calls.
   - `Most Loved in This Country`
   - `Loved Here and Elsewhere`
   - live Deezer enrichment applied on backend
+  - cached by the local presentation-data cache when the response has been warmed
 
 ### 4. Country genre samples
 
@@ -70,8 +73,32 @@ These are the app endpoints the frontend calls.
   - Discovery Map country-list genre line
   - Discovery Map hover/detail genre line
   - uses the current repo’s `B / I / Y` sampling logic on the backend
+  - reads local `Data/discovery_samples_cache.json` before recomputing sample data
 
-### 5. Hidden Gems page
+### 5. Country language samples
+
+- Endpoint:
+  - `GET /api/country/language-samples?year={year}&codes={comma_separated_country_codes}`
+- Frontend wrapper:
+  - `loadCountryLanguageSamples`
+- Current role:
+  - Discovery Map country-list language line
+  - Discovery Map hover/detail language line
+  - sample-based language display for the selected country/year
+  - reads local `Data/discovery_samples_cache.json` before recomputing sample data
+
+### 6. Song language lookup
+
+- Endpoint:
+  - `POST /api/language/songs`
+- Frontend wrapper:
+  - `loadLanguageMatchesForSongs`
+- Current role:
+  - enriches visible/paged song rows with detected language values and Genius lyrics URLs
+  - uses the compact file-backed language match dataset generated from the finished language output
+  - returns no match safely when a song is not in the language dataset
+
+### 7. Hidden Gems page
 
 - Endpoint:
   - `GET /api/hidden-gems/{countryCode}?year={year}&minCountries={minCountries}&page={page}&pageSize={pageSize}`
@@ -80,8 +107,9 @@ These are the app endpoints the frontend calls.
 - Current role:
   - main Hidden Gems screen song list
   - live Deezer enrichment applied on backend
+  - cached by the local presentation-data cache when the response has been warmed
 
-### 6. Metadata years
+### 8. Metadata years
 
 - Endpoint:
   - `GET /api/metadata/years`
@@ -91,7 +119,7 @@ These are the app endpoints the frontend calls.
   - shared selected-year options for screen flows that depend on year-specific enrichment
   - source of truth for Discovery and Comparison year availability, including 2025 when present in the dataset
 
-### 7. Comparison
+### 9. Comparison
 
 - Endpoint:
   - `GET /api/comparison?countryA={countryCode}&countryB={countryCode}&year={year}`
@@ -101,6 +129,59 @@ These are the app endpoints the frontend calls.
 - Current behavior:
   - country codes must be two different 2-letter ISO codes
   - year validation follows the metadata-years source of truth instead of the older hard-coded 2021 maximum
+
+## Local file-backed data and presentation prep
+
+### Compact language match data
+
+- File:
+  - `backend/Capstone.API/Data/language_matches.json`
+- Current role:
+  - first-iteration app language source
+  - generated from completed language output
+  - loaded once by the backend language lookup service
+- Long-term plan:
+  - move this language data into the database and replace file-backed lookup with database-backed queries
+
+### Discovery sample cache
+
+- File:
+  - `backend/Capstone.API/Data/discovery_samples_cache.json`
+- Current role:
+  - local ignored cache for Discovery genre samples
+  - local ignored cache for Discovery language samples
+  - local ignored cache for favorite artist samples
+  - used before recomputing Discovery sample data
+- Notes:
+  - this is presentation/local runtime support, not the final database architecture
+
+### Presentation data cache
+
+- File:
+  - `backend/Capstone.API/Data/presentation_data_cache.json`
+- Current role:
+  - local ignored cache for warmed endpoint responses
+  - supports Country Detail, Comparison View, and Hidden Gems demo paths
+  - backend endpoints read it when a matching payload exists and otherwise fall back to normal repository/provider loading
+- Notes:
+  - useful for presentation reliability and future data-prep review
+  - not a replacement for moving stable data into the database
+
+### Presentation data prep tool
+
+- File:
+  - `tools/presentation_data_prep.py`
+- Current role:
+  - interactive local tool for warming selected presentation data
+  - supports Discovery Map, Country Pages, and Hidden Gems prep modes
+  - supports all countries or 10-country ranges
+  - supports all configured demo years or specific years
+- Practical presentation plan:
+  - preload Discovery Map data for 2024 and 2025
+  - preload first 20 countries for 2024 and 2025 for Country Detail / Comparison View flows
+  - preload matching Hidden Gems pages needed for the live demo
+- Future use:
+  - Leena can use the same tool to gather app-pulled external/provider-backed data before later database import work, if that is useful for a future iteration
 
 ## External provider endpoints used by the current live backend path
 

--- a/backend/Capstone.API/Infrastructure/Interfaces/ICountryRepository.cs
+++ b/backend/Capstone.API/Infrastructure/Interfaces/ICountryRepository.cs
@@ -39,5 +39,10 @@ namespace Capstone.API.Infrastructure.Interfaces
         /// Returns a small set of sampled distinct genres for a country-year view.
         /// </summary>
         Task<IReadOnlyList<string>> GetCountryGenreSampleAsync(string countryCode, int year, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Returns a small set of sampled distinct lyric languages for a country-year view.
+        /// </summary>
+        Task<IReadOnlyList<string>> GetCountryLanguageSampleAsync(string countryCode, int year, CancellationToken cancellationToken = default);
     }
 }

--- a/backend/Capstone.API/Infrastructure/Interfaces/IDiscoverySampleCacheService.cs
+++ b/backend/Capstone.API/Infrastructure/Interfaces/IDiscoverySampleCacheService.cs
@@ -1,0 +1,18 @@
+using Capstone.API.Models.Country;
+
+namespace Capstone.API.Infrastructure.Interfaces
+{
+    /// <summary>
+    /// Reads and writes file-backed Discovery genre/language samples.
+    /// </summary>
+    public interface IDiscoverySampleCacheService
+    {
+        Task<IReadOnlyList<string>> GetGenresAsync(string countryCode, int year, CancellationToken cancellationToken = default);
+        Task<IReadOnlyList<string>> GetLanguagesAsync(string countryCode, int year, CancellationToken cancellationToken = default);
+        Task<IReadOnlyList<FavoriteArtistSample>> GetFavoriteArtistsAsync(string countryCode, int year, CancellationToken cancellationToken = default);
+        Task SaveGenresAsync(string countryCode, int year, IReadOnlyList<string> genres, CancellationToken cancellationToken = default);
+        Task SaveLanguagesAsync(string countryCode, int year, IReadOnlyList<string> languages, CancellationToken cancellationToken = default);
+        Task SaveFavoriteArtistsAsync(string countryCode, int year, IReadOnlyList<FavoriteArtistSample> favoriteArtists, CancellationToken cancellationToken = default);
+        Task<IReadOnlyList<DiscoverySampleCacheEntry>> GetAllAsync(CancellationToken cancellationToken = default);
+    }
+}

--- a/backend/Capstone.API/Infrastructure/Interfaces/ILanguageLookupService.cs
+++ b/backend/Capstone.API/Infrastructure/Interfaces/ILanguageLookupService.cs
@@ -1,0 +1,12 @@
+using Capstone.API.Models.Language;
+using Capstone.API.Models.Shared;
+
+namespace Capstone.API.Infrastructure.Interfaces
+{
+    public interface ILanguageLookupService
+    {
+        LanguageMatch? FindMatch(string? songName, string? artistName);
+        LanguageMatch? FindMatch(Song song);
+        IReadOnlyList<LanguageSongMatch> FindMatches(IEnumerable<LanguageSongLookupItem> songs);
+    }
+}

--- a/backend/Capstone.API/Infrastructure/Interfaces/IPresentationDataCacheService.cs
+++ b/backend/Capstone.API/Infrastructure/Interfaces/IPresentationDataCacheService.cs
@@ -1,0 +1,13 @@
+using System.Text.Json;
+
+namespace Capstone.API.Infrastructure.Interfaces
+{
+    /// <summary>
+    /// Reads and writes locally warmed endpoint payloads used for presentation demos.
+    /// </summary>
+    public interface IPresentationDataCacheService
+    {
+        Task<JsonElement?> GetAsync(string key, CancellationToken cancellationToken = default);
+        Task SaveAsync(string key, object payload, CancellationToken cancellationToken = default);
+    }
+}

--- a/backend/Capstone.API/Infrastructure/Repositories/CountryRepository.cs
+++ b/backend/Capstone.API/Infrastructure/Repositories/CountryRepository.cs
@@ -14,19 +14,23 @@ namespace Capstone.API.Infrastructure.Repositories
         private static readonly string[] PreferredGenrePrefixes = ["B", "I", "Y"];
         private const int RawSongBatchSize = 100;
         private const int GenreSampleScanCapPerList = 200;
+        private const int LanguageDuplicateSkipLimit = 12;
 
         private readonly IDataRepository _db;
         private readonly IDeezerSongEnrichmentService _deezerSongEnrichmentService;
+        private readonly ILanguageLookupService _languageLookupService;
 
         /// <summary>
         /// Initializes a new instance of CountryRepository using the default connection.
         /// </summary>
         public CountryRepository(
             IDataRepositoryFactory factory,
-            IDeezerSongEnrichmentService deezerSongEnrichmentService)
+            IDeezerSongEnrichmentService deezerSongEnrichmentService,
+            ILanguageLookupService languageLookupService)
         {
             _db = factory.Create("DefaultConnection");
             _deezerSongEnrichmentService = deezerSongEnrichmentService;
+            _languageLookupService = languageLookupService;
         }
 
         /// <inheritdoc/>
@@ -208,6 +212,115 @@ namespace Capstone.API.Infrastructure.Repositories
             }
 
             return selectedGenres;
+        }
+
+        /// <inheritdoc/>
+        public async Task<IReadOnlyList<string>> GetCountryLanguageSampleAsync(string countryCode, int year, CancellationToken cancellationToken = default)
+        {
+            var selectedLanguages = new List<string>(3);
+            var seenLanguages = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var candidateSongs = await LoadLanguageCandidateSongsAsync(countryCode, year, cancellationToken);
+
+            foreach (var prefix in PreferredGenrePrefixes)
+            {
+                var language = FindDistinctLanguageForPrefix(candidateSongs, prefix, seenLanguages);
+                if (string.IsNullOrWhiteSpace(language))
+                {
+                    continue;
+                }
+
+                seenLanguages.Add(language);
+                selectedLanguages.Add(language);
+            }
+
+            if (selectedLanguages.Count < 3)
+            {
+                FillRemainingDistinctLanguages(candidateSongs, selectedLanguages, seenLanguages);
+            }
+
+            return selectedLanguages;
+        }
+
+        private async Task<List<Song>> LoadLanguageCandidateSongsAsync(string countryCode, int year, CancellationToken cancellationToken)
+        {
+            var candidates = new List<Song>(RawSongBatchSize * 2);
+            foreach (var listType in new[] { "shared", "unique" })
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var rows = await _db.GetDataAsync("sp_GetCountrySongsPaged", new Dictionary<string, object?>
+                {
+                    { "@CountryCode", countryCode },
+                    { "@Year", year },
+                    { "@ListType", listType },
+                    { "@Offset", 0 },
+                    { "@PageSize", RawSongBatchSize }
+                }, cancellationToken);
+
+                candidates.AddRange(rows.Select(MapSong));
+            }
+
+            return candidates;
+        }
+
+        private string? FindDistinctLanguageForPrefix(IEnumerable<Song> songs, string prefix, HashSet<string> seenLanguages)
+        {
+            foreach (var song in songs)
+            {
+                if (!SongStartsWithPrefix(song.SongName, prefix))
+                {
+                    continue;
+                }
+
+                var language = FindFirstDistinctLanguage(song, seenLanguages);
+                if (!string.IsNullOrWhiteSpace(language))
+                {
+                    return language;
+                }
+            }
+
+            return null;
+        }
+
+        private void FillRemainingDistinctLanguages(IEnumerable<Song> songs, List<string> selectedLanguages, HashSet<string> seenLanguages)
+        {
+            foreach (var song in songs)
+            {
+                if (selectedLanguages.Count >= 3)
+                {
+                    return;
+                }
+
+                var language = FindFirstDistinctLanguage(song, seenLanguages);
+                if (string.IsNullOrWhiteSpace(language))
+                {
+                    continue;
+                }
+
+                seenLanguages.Add(language);
+                selectedLanguages.Add(language);
+            }
+        }
+
+        private string? FindFirstDistinctLanguage(Song song, HashSet<string> seenLanguages)
+        {
+            var match = _languageLookupService.FindMatch(song);
+            if (match is null)
+            {
+                return null;
+            }
+
+            foreach (var language in match.Languages)
+            {
+                var trimmed = language.Trim();
+                if (string.IsNullOrWhiteSpace(trimmed) || seenLanguages.Contains(trimmed))
+                {
+                    continue;
+                }
+
+                return trimmed;
+            }
+
+            return null;
         }
 
         private async Task<List<Song>> EnrichSongRowsAsync(IEnumerable<Song> songs, int limit, CancellationToken cancellationToken)
@@ -409,6 +522,160 @@ namespace Capstone.API.Infrastructure.Repositories
                         seenGenres.Add(primaryGenre);
                         selectedGenres.Add(primaryGenre);
                         if (selectedGenres.Count >= 3)
+                        {
+                            return;
+                        }
+                    }
+
+                    scanOffset += rows.Count;
+                    if (scanOffset >= totalRawCount)
+                    {
+                        break;
+                    }
+                }
+            }
+        }
+
+        private async Task<string?> FindDistinctLanguageForPrefixAsync(
+            string countryCode,
+            int year,
+            string prefix,
+            HashSet<string> seenLanguages,
+            CancellationToken cancellationToken)
+        {
+            var duplicateSkips = 0;
+            foreach (var listType in new[] { "shared", "unique" })
+            {
+                var inspectedRows = 0;
+                var scanOffset = 0;
+
+                while (inspectedRows < GenreSampleScanCapPerList && duplicateSkips < LanguageDuplicateSkipLimit)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var rows = (await _db.GetDataAsync("sp_GetCountrySongsPaged", new Dictionary<string, object?>
+                    {
+                        { "@CountryCode", countryCode },
+                        { "@Year", year },
+                        { "@ListType", listType },
+                        { "@Offset", scanOffset },
+                        { "@PageSize", RawSongBatchSize }
+                    }, cancellationToken)).ToList();
+
+                    if (rows.Count == 0)
+                    {
+                        break;
+                    }
+
+                    var totalRawCount = RowValueReader.AsIntAny(rows[0], "total_count", "TotalCount");
+                    foreach (var row in rows)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        inspectedRows++;
+                        var mapped = MapSong(row);
+                        if (!SongStartsWithPrefix(mapped.SongName, prefix))
+                        {
+                            continue;
+                        }
+
+                        var match = _languageLookupService.FindMatch(mapped);
+                        if (match is null)
+                        {
+                            continue;
+                        }
+
+                        foreach (var language in match.Languages)
+                        {
+                            var trimmed = language.Trim();
+                            if (string.IsNullOrWhiteSpace(trimmed))
+                            {
+                                continue;
+                            }
+
+                            if (seenLanguages.Contains(trimmed))
+                            {
+                                duplicateSkips++;
+                                continue;
+                            }
+
+                            return trimmed;
+                        }
+                    }
+
+                    scanOffset += rows.Count;
+                    if (scanOffset >= totalRawCount)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private async Task FillRemainingDistinctLanguagesAsync(
+            string countryCode,
+            int year,
+            List<string> selectedLanguages,
+            HashSet<string> seenLanguages,
+            CancellationToken cancellationToken)
+        {
+            var duplicateSkips = 0;
+            foreach (var listType in new[] { "shared", "unique" })
+            {
+                var inspectedRows = 0;
+                var scanOffset = 0;
+
+                while (selectedLanguages.Count < 3 && inspectedRows < GenreSampleScanCapPerList && duplicateSkips < LanguageDuplicateSkipLimit)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var rows = (await _db.GetDataAsync("sp_GetCountrySongsPaged", new Dictionary<string, object?>
+                    {
+                        { "@CountryCode", countryCode },
+                        { "@Year", year },
+                        { "@ListType", listType },
+                        { "@Offset", scanOffset },
+                        { "@PageSize", RawSongBatchSize }
+                    }, cancellationToken)).ToList();
+
+                    if (rows.Count == 0)
+                    {
+                        break;
+                    }
+
+                    var totalRawCount = RowValueReader.AsIntAny(rows[0], "total_count", "TotalCount");
+                    foreach (var row in rows)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        inspectedRows++;
+                        var match = _languageLookupService.FindMatch(MapSong(row));
+                        if (match is null)
+                        {
+                            continue;
+                        }
+
+                        foreach (var language in match.Languages)
+                        {
+                            var trimmed = language.Trim();
+                            if (string.IsNullOrWhiteSpace(trimmed))
+                            {
+                                continue;
+                            }
+
+                            if (seenLanguages.Contains(trimmed))
+                            {
+                                duplicateSkips++;
+                                continue;
+                            }
+
+                            seenLanguages.Add(trimmed);
+                            selectedLanguages.Add(trimmed);
+                            if (selectedLanguages.Count >= 3)
+                            {
+                                return;
+                            }
+                        }
+
+                        if (duplicateSkips >= LanguageDuplicateSkipLimit)
                         {
                             return;
                         }

--- a/backend/Capstone.API/Infrastructure/Repositories/FileBackedDiscoverySampleCacheService.cs
+++ b/backend/Capstone.API/Infrastructure/Repositories/FileBackedDiscoverySampleCacheService.cs
@@ -1,0 +1,204 @@
+using System.Text.Json;
+using Capstone.API.Infrastructure.Interfaces;
+using Capstone.API.Models.Country;
+
+namespace Capstone.API.Infrastructure.Repositories
+{
+    /// <summary>
+    /// Persists Discovery sample results so normal app browsing can seed a reusable local cache.
+    /// </summary>
+    public class FileBackedDiscoverySampleCacheService : IDiscoverySampleCacheService
+    {
+        private static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = true
+        };
+
+        private readonly string _cachePath;
+        private readonly SemaphoreSlim _gate = new(1, 1);
+        private Dictionary<string, DiscoverySampleCacheEntry>? _entriesByKey;
+
+        public FileBackedDiscoverySampleCacheService(IWebHostEnvironment environment)
+        {
+            _cachePath = Path.Combine(environment.ContentRootPath, "Data", "discovery_samples_cache.json");
+        }
+
+        public async Task<IReadOnlyList<string>> GetGenresAsync(string countryCode, int year, CancellationToken cancellationToken = default)
+        {
+            var entry = await GetEntryAsync(countryCode, year, cancellationToken);
+            return entry is null ? Array.Empty<string>() : entry.Genres;
+        }
+
+        public async Task<IReadOnlyList<string>> GetLanguagesAsync(string countryCode, int year, CancellationToken cancellationToken = default)
+        {
+            var entry = await GetEntryAsync(countryCode, year, cancellationToken);
+            return entry is null ? Array.Empty<string>() : entry.Languages;
+        }
+
+        public async Task<IReadOnlyList<FavoriteArtistSample>> GetFavoriteArtistsAsync(string countryCode, int year, CancellationToken cancellationToken = default)
+        {
+            var entry = await GetEntryAsync(countryCode, year, cancellationToken);
+            return entry is null ? Array.Empty<FavoriteArtistSample>() : entry.FavoriteArtists;
+        }
+
+        public Task SaveGenresAsync(string countryCode, int year, IReadOnlyList<string> genres, CancellationToken cancellationToken = default)
+        {
+            return SaveAsync(countryCode, year, entry => entry.Genres = CleanValues(genres), cancellationToken);
+        }
+
+        public Task SaveLanguagesAsync(string countryCode, int year, IReadOnlyList<string> languages, CancellationToken cancellationToken = default)
+        {
+            return SaveAsync(countryCode, year, entry => entry.Languages = CleanValues(languages), cancellationToken);
+        }
+
+        public Task SaveFavoriteArtistsAsync(string countryCode, int year, IReadOnlyList<FavoriteArtistSample> favoriteArtists, CancellationToken cancellationToken = default)
+        {
+            return SaveAsync(countryCode, year, entry => entry.FavoriteArtists = CleanFavoriteArtists(favoriteArtists), cancellationToken);
+        }
+
+        public async Task<IReadOnlyList<DiscoverySampleCacheEntry>> GetAllAsync(CancellationToken cancellationToken = default)
+        {
+            await EnsureLoadedAsync(cancellationToken);
+            return _entriesByKey!.Values
+                .OrderBy(entry => entry.Year)
+                .ThenBy(entry => entry.CountryCode)
+                .ToList();
+        }
+
+        private async Task<DiscoverySampleCacheEntry?> GetEntryAsync(string countryCode, int year, CancellationToken cancellationToken)
+        {
+            await EnsureLoadedAsync(cancellationToken);
+            _entriesByKey!.TryGetValue(BuildKey(countryCode, year), out var entry);
+            return entry;
+        }
+
+        private async Task SaveAsync(string countryCode, int year, Action<DiscoverySampleCacheEntry> update, CancellationToken cancellationToken)
+        {
+            await _gate.WaitAsync(cancellationToken);
+            try
+            {
+                await EnsureLoadedCoreAsync(cancellationToken);
+                var normalizedCode = countryCode.Trim().ToUpperInvariant();
+                var key = BuildKey(normalizedCode, year);
+                if (!_entriesByKey!.TryGetValue(key, out var entry))
+                {
+                    entry = new DiscoverySampleCacheEntry
+                    {
+                        CountryCode = normalizedCode,
+                        Year = year
+                    };
+                    _entriesByKey[key] = entry;
+                }
+
+                update(entry);
+                entry.UpdatedAtUtc = DateTime.UtcNow;
+                await WriteCacheAsync(cancellationToken);
+            }
+            finally
+            {
+                _gate.Release();
+            }
+        }
+
+        private async Task EnsureLoadedAsync(CancellationToken cancellationToken)
+        {
+            if (_entriesByKey is not null)
+            {
+                return;
+            }
+
+            await _gate.WaitAsync(cancellationToken);
+            try
+            {
+                await EnsureLoadedCoreAsync(cancellationToken);
+            }
+            finally
+            {
+                _gate.Release();
+            }
+        }
+
+        private async Task EnsureLoadedCoreAsync(CancellationToken cancellationToken)
+        {
+            if (_entriesByKey is not null)
+            {
+                return;
+            }
+
+            if (!File.Exists(_cachePath))
+            {
+                _entriesByKey = new Dictionary<string, DiscoverySampleCacheEntry>(StringComparer.OrdinalIgnoreCase);
+                return;
+            }
+
+            await using var stream = File.OpenRead(_cachePath);
+            var entries = await JsonSerializer.DeserializeAsync<List<DiscoverySampleCacheEntry>>(stream, JsonOptions, cancellationToken)
+                ?? new List<DiscoverySampleCacheEntry>();
+
+            _entriesByKey = entries
+                .Where(entry => !string.IsNullOrWhiteSpace(entry.CountryCode) && entry.Year > 0)
+                .GroupBy(entry => BuildKey(entry.CountryCode, entry.Year), StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(
+                    group => group.Key,
+                    group => group.Last(),
+                    StringComparer.OrdinalIgnoreCase);
+        }
+
+        private async Task WriteCacheAsync(CancellationToken cancellationToken)
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(_cachePath)!);
+            var entries = _entriesByKey!.Values
+                .OrderBy(entry => entry.Year)
+                .ThenBy(entry => entry.CountryCode)
+                .ToList();
+
+            await using var stream = File.Create(_cachePath);
+            await JsonSerializer.SerializeAsync(stream, entries, JsonOptions, cancellationToken);
+        }
+
+        private static string BuildKey(string countryCode, int year)
+        {
+            return $"{countryCode.Trim().ToUpperInvariant()}::{year}";
+        }
+
+        private static List<string> CleanValues(IEnumerable<string> values)
+        {
+            return values
+                .Select(value => value.Trim())
+                .Where(value => !string.IsNullOrWhiteSpace(value))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Take(3)
+                .ToList();
+        }
+
+        private static List<FavoriteArtistSample> CleanFavoriteArtists(IEnumerable<FavoriteArtistSample> favoriteArtists)
+        {
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var cleaned = new List<FavoriteArtistSample>();
+
+            foreach (var artist in favoriteArtists)
+            {
+                var name = artist.Artist.Trim();
+                if (string.IsNullOrWhiteSpace(name) || !seen.Add(name))
+                {
+                    continue;
+                }
+
+                cleaned.Add(new FavoriteArtistSample
+                {
+                    Artist = name,
+                    SongTitle = artist.SongTitle.Trim(),
+                    ArtistImageUrl = string.IsNullOrWhiteSpace(artist.ArtistImageUrl) ? null : artist.ArtistImageUrl.Trim()
+                });
+
+                if (cleaned.Count >= 8)
+                {
+                    break;
+                }
+            }
+
+            return cleaned;
+        }
+    }
+}

--- a/backend/Capstone.API/Infrastructure/Repositories/FileBackedLanguageLookupService.cs
+++ b/backend/Capstone.API/Infrastructure/Repositories/FileBackedLanguageLookupService.cs
@@ -1,0 +1,143 @@
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Capstone.API.Infrastructure.Interfaces;
+using Capstone.API.Models.Language;
+using Capstone.API.Models.Shared;
+
+namespace Capstone.API.Infrastructure.Repositories
+{
+    public class FileBackedLanguageLookupService : ILanguageLookupService
+    {
+        private static readonly Regex NonAlphaNumericRegex = new("[^a-z0-9]+", RegexOptions.Compiled);
+        private static readonly Regex WhitespaceRegex = new("\\s+", RegexOptions.Compiled);
+
+        private readonly Lazy<Dictionary<string, LanguageMatch>> _matchesByKey;
+
+        public FileBackedLanguageLookupService(IWebHostEnvironment environment, ILogger<FileBackedLanguageLookupService> logger)
+        {
+            _matchesByKey = new Lazy<Dictionary<string, LanguageMatch>>(() => LoadMatches(environment.ContentRootPath, logger));
+        }
+
+        public LanguageMatch? FindMatch(string? songName, string? artistName)
+        {
+            var key = BuildKey(songName, artistName);
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                return null;
+            }
+
+            return _matchesByKey.Value.TryGetValue(key, out var match) ? match : null;
+        }
+
+        public LanguageMatch? FindMatch(Song song)
+        {
+            return FindMatch(song.SongName, song.ArtistName);
+        }
+
+        public IReadOnlyList<LanguageSongMatch> FindMatches(IEnumerable<LanguageSongLookupItem> songs)
+        {
+            var results = new List<LanguageSongMatch>();
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var song in songs)
+            {
+                var key = BuildKey(song.SongName, song.ArtistName);
+                if (string.IsNullOrWhiteSpace(key) || !seen.Add(key))
+                {
+                    continue;
+                }
+
+                var match = FindMatch(song.SongName, song.ArtistName);
+                if (match is null)
+                {
+                    continue;
+                }
+
+                results.Add(new LanguageSongMatch
+                {
+                    SongName = song.SongName?.Trim() ?? match.SongName,
+                    ArtistName = song.ArtistName?.Trim() ?? match.ArtistName,
+                    LyricsUrl = match.LyricsUrl,
+                    Languages = match.Languages
+                });
+            }
+
+            return results;
+        }
+
+        private static Dictionary<string, LanguageMatch> LoadMatches(string contentRootPath, ILogger logger)
+        {
+            var path = Path.Combine(contentRootPath, "Data", "language_matches.json");
+            if (!File.Exists(path))
+            {
+                logger.LogWarning("Language match file not found at {Path}", path);
+                return new Dictionary<string, LanguageMatch>(StringComparer.OrdinalIgnoreCase);
+            }
+
+            using var stream = File.OpenRead(path);
+            var matches = JsonSerializer.Deserialize<List<LanguageMatch>>(stream, new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            }) ?? [];
+
+            var result = new Dictionary<string, LanguageMatch>(StringComparer.OrdinalIgnoreCase);
+            foreach (var match in matches)
+            {
+                var key = BuildKey(match.NormalizedSongName, match.NormalizedArtistName, alreadyNormalized: true);
+                if (string.IsNullOrWhiteSpace(key) || result.ContainsKey(key))
+                {
+                    continue;
+                }
+
+                match.Languages = match.Languages
+                    .Where((language) => !string.IsNullOrWhiteSpace(language))
+                    .Select((language) => language.Trim())
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+
+                if (match.Languages.Count == 0)
+                {
+                    continue;
+                }
+
+                result[key] = match;
+            }
+
+            logger.LogInformation("Loaded {Count} file-backed language matches.", result.Count);
+            return result;
+        }
+
+        private static string BuildKey(string? songName, string? artistName, bool alreadyNormalized = false)
+        {
+            var normalizedSong = alreadyNormalized ? songName?.Trim() : Normalize(songName);
+            var normalizedArtist = alreadyNormalized ? artistName?.Trim() : Normalize(artistName);
+            return string.IsNullOrWhiteSpace(normalizedSong) || string.IsNullOrWhiteSpace(normalizedArtist)
+                ? ""
+                : $"{normalizedSong}::{normalizedArtist}";
+        }
+
+        private static string Normalize(string? value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return "";
+            }
+
+            var normalized = value.Normalize(NormalizationForm.FormD);
+            var builder = new StringBuilder(normalized.Length);
+            foreach (var character in normalized)
+            {
+                if (CharUnicodeInfo.GetUnicodeCategory(character) != UnicodeCategory.NonSpacingMark)
+                {
+                    builder.Append(char.ToLowerInvariant(character));
+                }
+            }
+
+            var withoutMarks = builder.ToString().Normalize(NormalizationForm.FormC).Trim();
+            var alphaNumeric = NonAlphaNumericRegex.Replace(withoutMarks, " ");
+            return WhitespaceRegex.Replace(alphaNumeric, " ").Trim();
+        }
+    }
+}

--- a/backend/Capstone.API/Infrastructure/Repositories/FileBackedPresentationDataCacheService.cs
+++ b/backend/Capstone.API/Infrastructure/Repositories/FileBackedPresentationDataCacheService.cs
@@ -1,0 +1,113 @@
+using System.Text.Json;
+using Capstone.API.Infrastructure.Interfaces;
+using Capstone.API.Models.Country;
+
+namespace Capstone.API.Infrastructure.Repositories
+{
+    /// <summary>
+    /// Persists warmed API responses so presentation demo pages can reuse them after restarts.
+    /// </summary>
+    public class FileBackedPresentationDataCacheService : IPresentationDataCacheService
+    {
+        private static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = true
+        };
+
+        private readonly string _cachePath;
+        private readonly SemaphoreSlim _gate = new(1, 1);
+        private Dictionary<string, PresentationDataCacheEntry>? _entriesByKey;
+
+        public FileBackedPresentationDataCacheService(IWebHostEnvironment environment)
+        {
+            _cachePath = Path.Combine(environment.ContentRootPath, "Data", "presentation_data_cache.json");
+        }
+
+        public async Task<JsonElement?> GetAsync(string key, CancellationToken cancellationToken = default)
+        {
+            await EnsureLoadedAsync(cancellationToken);
+            if (_entriesByKey!.TryGetValue(key, out var entry))
+            {
+                return entry.Payload.Clone();
+            }
+
+            return null;
+        }
+
+        public async Task SaveAsync(string key, object payload, CancellationToken cancellationToken = default)
+        {
+            await _gate.WaitAsync(cancellationToken);
+            try
+            {
+                await EnsureLoadedCoreAsync(cancellationToken);
+                _entriesByKey![key] = new PresentationDataCacheEntry
+                {
+                    Key = key,
+                    Payload = JsonSerializer.SerializeToElement(payload, JsonOptions),
+                    UpdatedAtUtc = DateTime.UtcNow
+                };
+                await WriteCacheAsync(cancellationToken);
+            }
+            finally
+            {
+                _gate.Release();
+            }
+        }
+
+        private async Task EnsureLoadedAsync(CancellationToken cancellationToken)
+        {
+            if (_entriesByKey is not null)
+            {
+                return;
+            }
+
+            await _gate.WaitAsync(cancellationToken);
+            try
+            {
+                await EnsureLoadedCoreAsync(cancellationToken);
+            }
+            finally
+            {
+                _gate.Release();
+            }
+        }
+
+        private async Task EnsureLoadedCoreAsync(CancellationToken cancellationToken)
+        {
+            if (_entriesByKey is not null)
+            {
+                return;
+            }
+
+            if (!File.Exists(_cachePath))
+            {
+                _entriesByKey = new Dictionary<string, PresentationDataCacheEntry>(StringComparer.OrdinalIgnoreCase);
+                return;
+            }
+
+            await using var stream = File.OpenRead(_cachePath);
+            var entries = await JsonSerializer.DeserializeAsync<List<PresentationDataCacheEntry>>(stream, JsonOptions, cancellationToken)
+                ?? new List<PresentationDataCacheEntry>();
+
+            _entriesByKey = entries
+                .Where(entry => !string.IsNullOrWhiteSpace(entry.Key))
+                .GroupBy(entry => entry.Key, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(
+                    group => group.Key,
+                    group => group.Last(),
+                    StringComparer.OrdinalIgnoreCase);
+        }
+
+        private async Task WriteCacheAsync(CancellationToken cancellationToken)
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(_cachePath)!);
+            var entries = _entriesByKey!.Values
+                .OrderBy(entry => entry.Key)
+                .ToList();
+
+            await using var stream = File.Create(_cachePath);
+            await JsonSerializer.SerializeAsync(stream, entries, JsonOptions, cancellationToken);
+        }
+    }
+}

--- a/backend/Capstone.API/Models/Country/CountryLanguageSample.cs
+++ b/backend/Capstone.API/Models/Country/CountryLanguageSample.cs
@@ -1,0 +1,11 @@
+namespace Capstone.API.Models.Country
+{
+    /// <summary>
+    /// Represents a small file-backed language sample for one country and year.
+    /// </summary>
+    public class CountryLanguageSample
+    {
+        public string CountryCode { get; set; } = "";
+        public List<string> Languages { get; set; } = [];
+    }
+}

--- a/backend/Capstone.API/Models/Country/DiscoverySampleCacheEntry.cs
+++ b/backend/Capstone.API/Models/Country/DiscoverySampleCacheEntry.cs
@@ -1,0 +1,15 @@
+namespace Capstone.API.Models.Country
+{
+    /// <summary>
+    /// Stores resolved Discovery genre/language samples for a country and year.
+    /// </summary>
+    public class DiscoverySampleCacheEntry
+    {
+        public string CountryCode { get; set; } = string.Empty;
+        public int Year { get; set; }
+        public List<string> Genres { get; set; } = new();
+        public List<string> Languages { get; set; } = new();
+        public List<FavoriteArtistSample> FavoriteArtists { get; set; } = new();
+        public DateTime UpdatedAtUtc { get; set; } = DateTime.UtcNow;
+    }
+}

--- a/backend/Capstone.API/Models/Country/FavoriteArtistSample.cs
+++ b/backend/Capstone.API/Models/Country/FavoriteArtistSample.cs
@@ -1,0 +1,12 @@
+namespace Capstone.API.Models.Country
+{
+    /// <summary>
+    /// Stores a lightweight favorite artist sample for a country-year view.
+    /// </summary>
+    public class FavoriteArtistSample
+    {
+        public string Artist { get; set; } = string.Empty;
+        public string SongTitle { get; set; } = string.Empty;
+        public string? ArtistImageUrl { get; set; }
+    }
+}

--- a/backend/Capstone.API/Models/Country/PresentationDataCacheEntry.cs
+++ b/backend/Capstone.API/Models/Country/PresentationDataCacheEntry.cs
@@ -1,0 +1,14 @@
+using System.Text.Json;
+
+namespace Capstone.API.Models.Country
+{
+    /// <summary>
+    /// Stores a reusable local response payload for presentation data warming.
+    /// </summary>
+    public class PresentationDataCacheEntry
+    {
+        public string Key { get; set; } = string.Empty;
+        public JsonElement Payload { get; set; }
+        public DateTime UpdatedAtUtc { get; set; } = DateTime.UtcNow;
+    }
+}

--- a/backend/Capstone.API/Models/Language/LanguageMatch.cs
+++ b/backend/Capstone.API/Models/Language/LanguageMatch.cs
@@ -1,0 +1,15 @@
+namespace Capstone.API.Models.Language
+{
+    /// <summary>
+    /// Represents one file-backed language match produced by mp3li Additional Data Getter v2.
+    /// </summary>
+    public class LanguageMatch
+    {
+        public string NormalizedSongName { get; set; } = "";
+        public string NormalizedArtistName { get; set; } = "";
+        public string SongName { get; set; } = "";
+        public string ArtistName { get; set; } = "";
+        public string LyricsUrl { get; set; } = "";
+        public List<string> Languages { get; set; } = [];
+    }
+}

--- a/backend/Capstone.API/Models/Language/LanguageSongLookupRequest.cs
+++ b/backend/Capstone.API/Models/Language/LanguageSongLookupRequest.cs
@@ -1,0 +1,13 @@
+namespace Capstone.API.Models.Language
+{
+    public class LanguageSongLookupRequest
+    {
+        public List<LanguageSongLookupItem> Songs { get; set; } = [];
+    }
+
+    public class LanguageSongLookupItem
+    {
+        public string? SongName { get; set; }
+        public string? ArtistName { get; set; }
+    }
+}

--- a/backend/Capstone.API/Models/Language/LanguageSongMatch.cs
+++ b/backend/Capstone.API/Models/Language/LanguageSongMatch.cs
@@ -1,0 +1,10 @@
+namespace Capstone.API.Models.Language
+{
+    public class LanguageSongMatch
+    {
+        public string SongName { get; set; } = "";
+        public string ArtistName { get; set; } = "";
+        public string LyricsUrl { get; set; } = "";
+        public List<string> Languages { get; set; } = [];
+    }
+}

--- a/backend/Capstone.API/Program.cs
+++ b/backend/Capstone.API/Program.cs
@@ -33,6 +33,9 @@ builder.Services.AddCors(options =>
 // Infrastructure — generic SP execution layer
 builder.Services.AddSingleton<IDataRepositoryFactory, DataRepositoryFactory>();
 builder.Services.AddSingleton<IDeezerSongEnrichmentService, DeezerSongEnrichmentService>();
+builder.Services.AddSingleton<ILanguageLookupService, FileBackedLanguageLookupService>();
+builder.Services.AddSingleton<IDiscoverySampleCacheService, FileBackedDiscoverySampleCacheService>();
+builder.Services.AddSingleton<IPresentationDataCacheService, FileBackedPresentationDataCacheService>();
 
 // Domain repositories — one per screen area
 builder.Services.AddScoped<IGlobeRepository, GlobeRepository>();

--- a/hidden-gem-music-app/Documentation/screen-data-flow.md
+++ b/hidden-gem-music-app/Documentation/screen-data-flow.md
@@ -59,6 +59,11 @@ Country:
 - `GET /api/country/{countryCode}?year={year}`
 - `GET /api/country/{countryCode}/songs?year={year}&listType={shared|unique}&page={page}&pageSize={pageSize}`
 - `GET /api/country/genre-samples?year={year}&codes={comma-separated-codes}`
+- `GET /api/country/language-samples?year={year}&codes={comma-separated-codes}`
+
+Language:
+
+- `POST /api/language/songs`
 
 Hidden Gems:
 
@@ -83,6 +88,7 @@ Current frontend cache maps include:
 - `hiddenGemsPageCache`
 - `countrySongsPageCache`
 - `countryGenreSampleCache`
+- `countryLanguageSampleCache`
 
 Discovery year reuse is also kept in app state through:
 
@@ -95,6 +101,17 @@ Important note:
 - these caches are frontend session-memory reuse
 - they improve the active running session
 - they do not replace backend/local persisted enrichment data
+
+Backend/local persisted data now exists for two presentation-oriented paths:
+
+- `backend/Capstone.API/Data/discovery_samples_cache.json`
+  - stores Discovery genre/language/favorite-artist samples keyed by country and year
+  - the backend reads this before recomputing Discovery samples
+- `backend/Capstone.API/Data/presentation_data_cache.json`
+  - stores warmed endpoint payloads for country profile, country song lists, country hidden-gem previews, and Hidden Gems pages
+  - the backend reads this when available and falls back to the normal repository/provider path when no cached payload exists
+
+Both files are local runtime data and are ignored by git.
 
 ## Discovery screen flow
 
@@ -119,6 +136,8 @@ Current flow:
    - the active filtered country set
    - and the broader current Discovery country pool for dimmed-but-visible context
 7. Genre samples are prefetched in smaller batches through `loadCountryGenreSamples`.
+8. Language samples are prefetched through `loadCountryLanguageSamples`.
+9. The currently selected or hovered country is prioritized, while the visible list rows are preloaded in backend-safe chunks.
 
 Important current rule:
 
@@ -126,6 +145,7 @@ Important current rule:
 - the custom map does not call an external map service at runtime; it renders from the app-owned geometry asset
 - the map and list should use the same song-data quality rules so "No song data" states do not conflict with misleading "Unknown" album/song labels
 - changing year should update the active country data without resetting the user's current map viewport
+- Discovery language and genre summaries should show loading text until their specific sample result is available, then use cached/backend sample text without requiring each row to be hovered first
 
 ## Country screen flow
 
@@ -139,11 +159,14 @@ Current flow:
 1. Country profile loads through `loadCountryProfile`.
 2. Shared and unique song lists load through `loadCountrySongsPage`.
 3. Hidden-gem preview data is derived from page 1 of the real Hidden Gems endpoint.
-4. Favorite artists, album art, song metadata, and additional-data fields are mapped into the UI from the backend response path.
+4. Loaded song rows are enriched with language data when a language match exists.
+5. Favorite artists, album art, song metadata, and additional-data fields are mapped into the UI from the backend response path.
+6. Stat squares and genre/language summary sections render as soon as their own data is ready instead of waiting for every downstream section.
 
 Important current rule:
 
 - hidden-gem preview behavior should stay aligned to the real Hidden Gems data path, not a fake/mock-only preview flow
+- country page API calls can reuse backend presentation-cache payloads when they exist, but must fall back to normal live loading when they do not
 
 ## Comparison Results flow
 
@@ -156,11 +179,29 @@ Current flow:
 
 1. The app chooses the active comparison countries through `comparisonIds`.
 2. The screen loads country profile and song-list data for each selected country.
-3. Hidden-gem preview behavior is kept parallel to the Country Detail behavior where possible.
+3. Language and genre sample text follows the same sample-based behavior as Country Detail.
+4. Hidden-gem preview behavior is kept parallel to the Country Detail behavior where possible.
 
 Important current rule:
 
 - comparison should use the app-provided available country pool rather than depending on Discovery being the currently visible screen
+- comparison benefits from the same backend presentation-cache payloads as Country Detail because it uses the same country profile and song-list endpoints
+
+## Presentation data prep flow
+
+Main file:
+
+- `tools/presentation_data_prep.py`
+
+Current role:
+
+- warms selected app endpoints before a live presentation
+- supports Discovery Map, Country Pages, and Hidden Gems prep modes
+- lets the user choose all countries or 10-country ranges
+- lets the user choose all supported demo years or one target year
+- writes warmed backend responses to local ignored cache files through the normal backend endpoints
+
+This tool is for presentation reliability and future data-prep support. It is not the long-term replacement for moving finalized language/sample data into the database.
 
 ## Comparison Select map flow
 

--- a/hidden-gem-music-app/src/components/DiscoverySidebarPanels.tsx
+++ b/hidden-gem-music-app/src/components/DiscoverySidebarPanels.tsx
@@ -21,8 +21,11 @@ type Props = {
   selectedYear?: number;
   genreSummaryByCountryCode?: Record<string, string | undefined>;
   genreLoadingByCountryCode?: Record<string, boolean | undefined>;
+  languageSummaryByCountryCode?: Record<string, string | undefined>;
+  languageLoadingByCountryCode?: Record<string, boolean | undefined>;
   loadingText?: string;
   onEnsureGenreSample?: (countryCode: string) => void;
+  onEnsureLanguageSample?: (countryCode: string) => void;
   onNearListEnd?: () => void;
 };
 
@@ -41,8 +44,11 @@ export function DiscoverySidebarPanels({
   selectedYear,
   genreSummaryByCountryCode,
   genreLoadingByCountryCode,
+  languageSummaryByCountryCode,
+  languageLoadingByCountryCode,
   loadingText = "Loading...",
   onEnsureGenreSample,
+  onEnsureLanguageSample,
   onNearListEnd,
 }: Props) {
   const { width } = useWindowDimensions();
@@ -66,6 +72,7 @@ export function DiscoverySidebarPanels({
   const [listScrollY, setListScrollY] = useState(0);
   const [isDraggingListScrollbar, setIsDraggingListScrollbar] = useState(false);
   const nearListEndTriggeredRef = useRef(false);
+  const lastAutoScrollSignalRef = useRef<number | null>(null);
 
   const showFilterScrollbar = isWeb && expandedPanel === "filters" && filterViewportHeight > 0;
   const filterHasOverflow = showFilterScrollbar && filterContentHeight > filterViewportHeight;
@@ -221,6 +228,11 @@ export function DiscoverySidebarPanels({
     if (expandedPanel !== "list" || !selectedCountryId || autoScrollSignal == null) {
       return;
     }
+
+    if (lastAutoScrollSignalRef.current === autoScrollSignal) {
+      return;
+    }
+    lastAutoScrollSignalRef.current = autoScrollSignal;
 
     const scrollToSelectedCountry = () => {
       const y = positionsRef.current[selectedCountryId];
@@ -385,23 +397,27 @@ export function DiscoverySidebarPanels({
                     selected={country.id === selectedCountryId}
                     onHover={() => {
                       onEnsureGenreSample?.(country.code);
+                      onEnsureLanguageSample?.(country.code);
                       onSelectCountry(country.id);
                       onHoverCountryChange?.(country.id);
                     }}
                     onHoverOut={() => onHoverCountryChange?.(null)}
                     onTitlePress={() => {
                       onEnsureGenreSample?.(country.code);
+                      onEnsureLanguageSample?.(country.code);
                       onOpenCountry(country.id);
                     }}
-                    genreLine={genreSummaryByCountryCode?.[country.code] ?? (genreLoadingByCountryCode?.[country.code] ? loadingText : "Loading...")}
-                    languageLine="Coming Soon"
+                    genreLine={genreSummaryByCountryCode?.[country.code] ?? loadingText}
+                    languageLine={languageSummaryByCountryCode?.[country.code] ?? loadingText}
                     onPress={() => {
                       onEnsureGenreSample?.(country.code);
+                      onEnsureLanguageSample?.(country.code);
                       onSelectCountry(country.id);
                       onOpenCountry(country.id);
                     }}
                     onPressIn={() => {
                       onEnsureGenreSample?.(country.code);
+                      onEnsureLanguageSample?.(country.code);
                       onSelectCountry(country.id);
                     }}
                   />

--- a/hidden-gem-music-app/src/components/globe/GlobePanel.tsx
+++ b/hidden-gem-music-app/src/components/globe/GlobePanel.tsx
@@ -28,6 +28,7 @@ type Props = {
   genreLoadingByCountryCode?: Record<string, boolean | undefined>;
   loadingText?: string;
   onEnsureGenreSample?: (countryCode: string) => void;
+  onEnsureLanguageSample?: (countryCode: string) => void;
   isActive?: boolean;
 };
 
@@ -54,6 +55,7 @@ export function GlobePanel({
   genreLoadingByCountryCode,
   loadingText,
   onEnsureGenreSample,
+  onEnsureLanguageSample,
   isActive,
 }: Props) {
   const activeCountry = countries.find((country) => country.id === activeCountryId);
@@ -90,6 +92,7 @@ export function GlobePanel({
             genreLoadingByCountryCode={genreLoadingByCountryCode}
             loadingText={loadingText}
             onEnsureGenreSample={onEnsureGenreSample}
+            onEnsureLanguageSample={onEnsureLanguageSample}
             isActive={isActive}
           />
         )}

--- a/hidden-gem-music-app/src/components/globe/GlobeView.tsx
+++ b/hidden-gem-music-app/src/components/globe/GlobeView.tsx
@@ -30,6 +30,7 @@ type Props = {
   genreLoadingByCountryCode?: Record<string, boolean | undefined>;
   loadingText?: string;
   onEnsureGenreSample?: (countryCode: string) => void;
+  onEnsureLanguageSample?: (countryCode: string) => void;
   isActive?: boolean;
 };
 
@@ -177,6 +178,7 @@ export function GlobeView({
   genreLoadingByCountryCode,
   loadingText = "Loading...",
   onEnsureGenreSample,
+  onEnsureLanguageSample,
   isActive = true,
 }: Props) {
   const { width } = useWindowDimensions();
@@ -428,6 +430,8 @@ export function GlobeView({
     }
 
     setHoveredCountryId(country.id);
+    onEnsureGenreSample?.(country.code);
+    onEnsureLanguageSample?.(country.code);
     if (selectOnHover) {
       hoverSelectTimeoutRef.current = setTimeout(() => {
         if (hoveredCountryIdRef.current !== country.id) {

--- a/hidden-gem-music-app/src/data/apiMappers.ts
+++ b/hidden-gem-music-app/src/data/apiMappers.ts
@@ -29,6 +29,8 @@ export type UiSongPreview = {
   contributors?: string[];
   artistAlbumCount?: number;
   tracklist?: string[];
+  languages?: string[];
+  lyricsUrl?: string;
 };
 
 export type UiSharedSongPreview = UiSongPreview & {
@@ -126,6 +128,8 @@ export const mapApiSong = (song: ApiSong): UiSongPreview => ({
   tracklist: Array.isArray(song.tracklist)
     ? song.tracklist.filter((track): track is string => typeof track === "string" && track.trim().length > 0)
     : [],
+  languages: [],
+  lyricsUrl: "",
 });
 
 export const mapApiSharedSong = (song: ApiSharedSong): UiSharedSongPreview => ({

--- a/hidden-gem-music-app/src/data/countryApi.ts
+++ b/hidden-gem-music-app/src/data/countryApi.ts
@@ -1,4 +1,11 @@
-import type { ApiCountryGenreSample, ApiCountryHiddenGemPreview, ApiCountryProfile, ApiCountrySongsPage, ApiHiddenGemResponse } from "../types/api";
+import type {
+  ApiCountryGenreSample,
+  ApiCountryHiddenGemPreview,
+  ApiCountryLanguageSample,
+  ApiCountryProfile,
+  ApiCountrySongsPage,
+  ApiHiddenGemResponse,
+} from "../types/api";
 import { getApiBaseUrl } from "./apiBaseUrl";
 import { fetchWithTimeoutAndRetry } from "./fetchWithTimeout";
 
@@ -7,6 +14,8 @@ const countryHiddenGemsPreviewCache = new Map<string, ApiCountryHiddenGemPreview
 const hiddenGemsPageCache = new Map<string, ApiHiddenGemResponse>();
 const countrySongsPageCache = new Map<string, ApiCountrySongsPage>();
 const countryGenreSampleCache = new Map<string, ApiCountryGenreSample>();
+const countryLanguageSampleCache = new Map<string, ApiCountryLanguageSample>();
+const countrySampleRequestSize = 16;
 
 function buildCountryYearKey(countryCode: string, year: number) {
   return `${countryCode.trim().toUpperCase()}::${year}`;
@@ -28,6 +37,18 @@ function buildCountrySongsPageKey(
 
 function buildCountryGenreSampleKey(countryCode: string, year: number) {
   return `${buildCountryYearKey(countryCode, year)}::genre-sample`;
+}
+
+function buildCountryLanguageSampleKey(countryCode: string, year: number) {
+  return `${buildCountryYearKey(countryCode, year)}::language-sample`;
+}
+
+function chunkCountryCodes(countryCodes: string[]) {
+  const chunks: string[][] = [];
+  for (let index = 0; index < countryCodes.length; index += countrySampleRequestSize) {
+    chunks.push(countryCodes.slice(index, index + countrySampleRequestSize));
+  }
+  return chunks;
 }
 
 async function parseJsonResponse<T>(response: Response, endpoint: string): Promise<T> {
@@ -195,20 +216,66 @@ export async function loadCountryGenreSamples(
   }
 
   const baseUrl = getApiBaseUrl().replace(/\/$/, "");
-  const endpoint = `${baseUrl}/api/country/genre-samples?year=${year}&codes=${encodeURIComponent(missingCodes.join(","))}`;
-  const response = await fetchWithTimeoutAndRetry(endpoint, {}, signal);
-  const payload = await parseJsonResponse<ApiCountryGenreSample[]>(response, endpoint);
-  payload.forEach((item) => {
-    countryGenreSampleCache.set(buildCountryGenreSampleKey(item.countryCode, year), item);
-  });
+  for (const codeBatch of chunkCountryCodes(missingCodes)) {
+    const endpoint = `${baseUrl}/api/country/genre-samples?year=${year}&codes=${encodeURIComponent(codeBatch.join(","))}`;
+    const response = await fetchWithTimeoutAndRetry(endpoint, {}, signal);
+    const payload = await parseJsonResponse<ApiCountryGenreSample[]>(response, endpoint);
+    payload.forEach((item) => {
+      countryGenreSampleCache.set(buildCountryGenreSampleKey(item.countryCode, year), item);
+    });
+  }
 
   return normalizedCodes
     .map((code) => countryGenreSampleCache.get(buildCountryGenreSampleKey(code, year)))
     .filter((entry): entry is ApiCountryGenreSample => Boolean(entry));
 }
 
+export async function loadCountryLanguageSamples(
+  countryCodes: string[],
+  year: number,
+  signal?: AbortSignal
+): Promise<ApiCountryLanguageSample[]> {
+  const normalizedCodes = Array.from(
+    new Set(
+      countryCodes
+        .map((code) => code.trim().toUpperCase())
+        .filter((code) => /^[A-Z]{2}$/.test(code))
+    )
+  );
+
+  if (normalizedCodes.length === 0) {
+    return [];
+  }
+
+  const cachedSamples = normalizedCodes
+    .map((code) => countryLanguageSampleCache.get(buildCountryLanguageSampleKey(code, year)))
+    .filter((entry): entry is ApiCountryLanguageSample => Boolean(entry));
+  const cachedCodes = new Set(cachedSamples.map((entry) => entry.countryCode.toUpperCase()));
+  const missingCodes = normalizedCodes.filter((code) => !cachedCodes.has(code));
+
+  if (missingCodes.length > 0) {
+    const baseUrl = getApiBaseUrl().replace(/\/$/, "");
+    for (const codeBatch of chunkCountryCodes(missingCodes)) {
+      const endpoint = `${baseUrl}/api/country/language-samples?year=${year}&codes=${encodeURIComponent(codeBatch.join(","))}`;
+      const response = await fetchWithTimeoutAndRetry(endpoint, {}, signal);
+      const payload = await parseJsonResponse<ApiCountryLanguageSample[]>(response, endpoint);
+      payload.forEach((item) => {
+        countryLanguageSampleCache.set(buildCountryLanguageSampleKey(item.countryCode, year), item);
+      });
+    }
+  }
+
+  return normalizedCodes
+    .map((code) => countryLanguageSampleCache.get(buildCountryLanguageSampleKey(code, year)))
+    .filter((entry): entry is ApiCountryLanguageSample => Boolean(entry));
+}
+
 export function getCachedCountryGenreSamples(countryCode: string, year: number): string[] {
   return countryGenreSampleCache.get(buildCountryGenreSampleKey(countryCode, year))?.genres ?? [];
+}
+
+export function getCachedCountryLanguageSamples(countryCode: string, year: number): string[] {
+  return countryLanguageSampleCache.get(buildCountryLanguageSampleKey(countryCode, year))?.languages ?? [];
 }
 
 export function getCachedHiddenGemsPage(

--- a/hidden-gem-music-app/src/data/languageApi.ts
+++ b/hidden-gem-music-app/src/data/languageApi.ts
@@ -1,0 +1,151 @@
+import type { ApiLanguageSongLookupItem, ApiLanguageSongMatch } from "../types/api";
+import { getApiBaseUrl } from "./apiBaseUrl";
+
+export type LanguageEnrichedSong = {
+  title: string;
+  artist: string;
+  languages?: string[];
+  lyricsUrl?: string;
+};
+
+const languageMatchCache = new Map<string, ApiLanguageSongMatch | null>();
+
+export function formatLanguageLabel(language: string) {
+  return language.trim().replace(/\s+\([a-z]{2,3}\)$/i, "");
+}
+
+function normalizeLookupValue(value: string | null | undefined) {
+  return (value ?? "")
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function buildLanguageLookupKey(songName: string | null | undefined, artistName: string | null | undefined) {
+  const normalizedSong = normalizeLookupValue(songName);
+  const normalizedArtist = normalizeLookupValue(artistName);
+  return normalizedSong && normalizedArtist ? `${normalizedSong}::${normalizedArtist}` : "";
+}
+
+async function requestLanguageMatches(songs: ApiLanguageSongLookupItem[], signal?: AbortSignal) {
+  const baseUrl = getApiBaseUrl().replace(/\/$/, "");
+  const endpoint = `${baseUrl}/api/language/songs`;
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ songs }),
+    signal,
+  });
+
+  if (!response.ok) {
+    throw new Error(`Request failed for ${endpoint} with status ${response.status}.`);
+  }
+
+  return (await response.json()) as ApiLanguageSongMatch[];
+}
+
+export async function loadLanguageMatchesForSongs<T extends LanguageEnrichedSong>(songs: T[], signal?: AbortSignal): Promise<Map<string, ApiLanguageSongMatch>> {
+  const keysToRequest = new Set<string>();
+  const songsToRequest: ApiLanguageSongLookupItem[] = [];
+
+  songs.forEach((song) => {
+    const key = buildLanguageLookupKey(song.title, song.artist);
+    if (!key || languageMatchCache.has(key) || keysToRequest.has(key)) {
+      return;
+    }
+
+    keysToRequest.add(key);
+    songsToRequest.push({ songName: song.title, artistName: song.artist });
+  });
+
+  if (songsToRequest.length > 0) {
+    const matches = await requestLanguageMatches(songsToRequest, signal);
+    const matchedByKey = new Map(matches.map((match) => [buildLanguageLookupKey(match.songName, match.artistName), match]));
+    keysToRequest.forEach((key) => {
+      languageMatchCache.set(key, matchedByKey.get(key) ?? null);
+    });
+  }
+
+  const result = new Map<string, ApiLanguageSongMatch>();
+  songs.forEach((song) => {
+    const key = buildLanguageLookupKey(song.title, song.artist);
+    const match = key ? languageMatchCache.get(key) : null;
+    if (key && match) {
+      result.set(key, match);
+    }
+  });
+
+  return result;
+}
+
+export async function enrichSongsWithLanguage<T extends LanguageEnrichedSong>(songs: T[], signal?: AbortSignal): Promise<T[]> {
+  if (songs.length === 0) {
+    return songs;
+  }
+
+  const matches = await loadLanguageMatchesForSongs(songs, signal);
+  return songs.map((song) => {
+    const match = matches.get(buildLanguageLookupKey(song.title, song.artist));
+    if (!match) {
+      return song;
+    }
+
+    return {
+      ...song,
+      languages: match.languages,
+      lyricsUrl: match.lyricsUrl,
+    };
+  });
+}
+
+export function collectUniqueLanguagesFromSongs(songs: LanguageEnrichedSong[], limit: number) {
+  const seen = new Set<string>();
+  const results: string[] = [];
+
+  songs.slice(0, limit).forEach((song) => {
+    (song.languages ?? [])
+      .map(formatLanguageLabel)
+      .filter((language) => language.length > 0 && language.toLowerCase() !== "unknown" && language.toLowerCase() !== "loading...")
+      .forEach((language) => {
+        const normalized = language.toLowerCase();
+        if (seen.has(normalized)) {
+          return;
+        }
+        seen.add(normalized);
+        results.push(language);
+      });
+  });
+
+  return results;
+}
+
+export function formatLanguageAndMore(languages: string[]) {
+  const seen = new Set<string>();
+  const cleaned = languages.map(formatLanguageLabel).filter((language) => {
+    if (language.length === 0) {
+      return false;
+    }
+    const normalized = language.toLowerCase();
+    if (seen.has(normalized)) {
+      return false;
+    }
+    seen.add(normalized);
+    return true;
+  });
+  if (cleaned.length >= 3) {
+    return `${cleaned.slice(0, 3).join(", ")}, and more`;
+  }
+  if (cleaned.length === 2) {
+    return `${cleaned[0]}, ${cleaned[1]} and more`;
+  }
+  if (cleaned.length === 1) {
+    return `${cleaned[0]} and more`;
+  }
+  return "";
+}

--- a/hidden-gem-music-app/src/screens/ComparisonResultsScreen.tsx
+++ b/hidden-gem-music-app/src/screens/ComparisonResultsScreen.tsx
@@ -21,8 +21,9 @@ import { GemIcon } from "../components/GemIcon";
 import { Panel } from "../components/Panel";
 import { ScreenScaffold } from "../components/ScreenScaffold";
 import { SecondarySurfaceFill } from "../components/SecondarySurfaceFill";
-import { getCachedCountryGenreSamples, loadAvailableYears, loadCountryHiddenGemsPreview, loadCountryProfile, loadCountrySongsPage } from "../data/countryApi";
+import { getCachedCountryGenreSamples, getCachedCountryLanguageSamples, loadAvailableYears, loadCountryHiddenGemsPreview, loadCountryProfile, loadCountrySongsPage } from "../data/countryApi";
 import { hasKnownSongTitle, mapApiCountryProfile, mapApiSong } from "../data/apiMappers";
+import { collectUniqueLanguagesFromSongs, enrichSongsWithLanguage, formatLanguageAndMore } from "../data/languageApi";
 import { useLoadingText, useStableLoadingText } from "../hooks/useLoadingText";
 import { isCountryWithAppData } from "../data/countryDisplay";
 import { Country } from "../types/content";
@@ -61,6 +62,8 @@ type SongPreview = {
   explicitLyrics?: boolean;
   explicitContentCover?: boolean;
   albumExplicitLyrics?: boolean;
+  languages?: string[];
+  lyricsUrl?: string;
 };
 
 type FavoriteArtistPreview = {
@@ -304,6 +307,8 @@ function createSongPreview(
     explicitLyrics?: boolean;
     explicitContentCover?: boolean;
     albumExplicitLyrics?: boolean;
+    languages?: string[];
+    lyricsUrl?: string;
   }
 ): SongPreview {
   return {
@@ -323,6 +328,8 @@ function createSongPreview(
     explicitLyrics: options?.explicitLyrics,
     explicitContentCover: options?.explicitContentCover,
     albumExplicitLyrics: options?.albumExplicitLyrics,
+    languages: Array.isArray(options?.languages) ? options.languages.filter((language) => typeof language === "string" && language.trim().length > 0) : [],
+    lyricsUrl: options?.lyricsUrl?.trim() ? options.lyricsUrl : undefined,
   };
 }
 
@@ -336,6 +343,8 @@ function createLoadingSongPreviews(count: number, fallbackYear: number): SongPre
       explicitLyrics: undefined,
       explicitContentCover: undefined,
       albumExplicitLyrics: undefined,
+      languages: ["Loading..."],
+      lyricsUrl: undefined,
     })
   );
 }
@@ -353,6 +362,8 @@ function toSongPreview(
     explicitLyrics?: boolean;
     explicitContentCover?: boolean;
     albumExplicitLyrics?: boolean;
+    languages?: string[];
+    lyricsUrl?: string;
   },
   detail: string,
   score: number,
@@ -371,6 +382,8 @@ function toSongPreview(
     explicitLyrics: song.explicitLyrics,
     explicitContentCover: song.explicitContentCover,
     albumExplicitLyrics: song.albumExplicitLyrics,
+    languages: song.languages,
+    lyricsUrl: song.lyricsUrl,
   });
 }
 
@@ -1459,34 +1472,39 @@ function ComparisonCountryPane({
     setPreviewSongs(createLoadingSongPreviews(13, selectedYear));
 
     loadCountryProfile(country.code, selectedYear, profileController.signal)
-      .then((profilePayload) => {
+      .then(async (profilePayload) => {
         if (latestRequestRef.current !== requestId) {
           return;
         }
         const mappedProfile = mapApiCountryProfile(profilePayload);
         setApiProfile(mappedProfile);
-        setUniqueSongs(
-          mappedProfile.topUniqueSongs
-            .map((song, index) => toDisplaySongPreview(song, `Feels especially loved in ${country.name}`, clamp(95 - index * 2, 34, 95), selectedYear))
-            .filter((song): song is SongPreview => song != null)
-        );
-        setSharedSongs(
-          mappedProfile.topSharedSongs
-            .map((song, index) =>
-              toDisplaySongPreview(
-                song,
-                "Loved in this country and echoed across other countries",
-                clamp(95 - index * 2, 34, 95),
-                selectedYear
-              )
-            )
-            .filter((song): song is SongPreview => song != null)
-        );
-        setUniquePage(1);
-        setSharedPage(1);
         setUniqueHasMore(mappedProfile.uniqueCount > mappedProfile.topUniqueSongs.length);
         setSharedHasMore(mappedProfile.sharedCount > mappedProfile.topSharedSongs.length);
         setInitialLoadingProfile(false);
+        const nextUniqueSongs = mappedProfile.topUniqueSongs
+          .map((song, index) => toDisplaySongPreview(song, `Feels especially loved in ${country.name}`, clamp(95 - index * 2, 34, 95), selectedYear))
+          .filter((song): song is SongPreview => song != null);
+        const nextSharedSongs = mappedProfile.topSharedSongs
+          .map((song, index) =>
+            toDisplaySongPreview(
+              song,
+              "Loved in this country and echoed across other countries",
+              clamp(95 - index * 2, 34, 95),
+              selectedYear
+            )
+          )
+          .filter((song): song is SongPreview => song != null);
+        const [enrichedUniqueSongs, enrichedSharedSongs] = await Promise.all([
+          enrichSongsWithLanguage(nextUniqueSongs, profileController.signal),
+          enrichSongsWithLanguage(nextSharedSongs, profileController.signal),
+        ]);
+        if (latestRequestRef.current !== requestId || profileController.signal.aborted) {
+          return;
+        }
+        setUniqueSongs(enrichedUniqueSongs);
+        setSharedSongs(enrichedSharedSongs);
+        setUniquePage(1);
+        setSharedPage(1);
         setInitialLoadingUnique(false);
         setInitialLoadingShared(false);
       })
@@ -1507,17 +1525,16 @@ function ComparisonCountryPane({
       });
 
     loadCountryHiddenGemsPreview(country.code, selectedYear, 13, previewController.signal)
-      .then((hiddenGemsPayload) => {
+      .then(async (hiddenGemsPayload) => {
         if (latestRequestRef.current !== requestId) {
           return;
         }
-        setPreviewSongs(
-          dedupeSongPreviews(
-            hiddenGemsPayload
-              .map((item) =>
-                createSongPreview(
-                  item.songName?.trim() ? item.songName : "Unknown Song",
-                  item.artistName?.trim() ? item.artistName : "Unknown Artist",
+        const nextPreviewSongs = dedupeSongPreviews(
+          hiddenGemsPayload
+            .map((item) =>
+              createSongPreview(
+                item.songName?.trim() ? item.songName : "Unknown Song",
+                item.artistName?.trim() ? item.artistName : "Unknown Artist",
                 "TrendScore preview",
                 Math.round(item.trendScore),
                 {
@@ -1535,10 +1552,14 @@ function ComparisonCountryPane({
                   albumExplicitLyrics: item.albumExplicitLyrics ?? undefined,
                 }
               )
-              )
-              .filter((song) => hasKnownSongTitle(song.title))
-          )
+            )
+            .filter((song) => hasKnownSongTitle(song.title))
         );
+        const enrichedPreviewSongs = await enrichSongsWithLanguage(nextPreviewSongs, previewController.signal);
+        if (latestRequestRef.current !== requestId || previewController.signal.aborted) {
+          return;
+        }
+        setPreviewSongs(enrichedPreviewSongs);
         setInitialLoadingPreview(false);
       })
       .catch((error) => {
@@ -1588,24 +1609,27 @@ function ComparisonCountryPane({
     loadMoreUniqueControllerRef.current = controller;
     setLoadingMoreUnique(true);
     loadCountrySongsPage(country.code, selectedYear, "unique", nextPage, songPageSize, controller.signal)
-      .then((payload) => {
+      .then(async (payload) => {
         if (latestRequestRef.current !== requestId || controller.signal.aborted || !isActiveRef.current) {
           return;
         }
-        setUniqueSongs((current) => {
-          const nextItems = payload.items
-            .map((song: ApiSongInput, index: number) => {
-              const mappedSong = mapApiSong(song);
-              return toDisplaySongPreview(
-                mappedSong,
-                `Feels especially loved in ${country.name}`,
-                clamp(95 - (current.length + index) * 2, 34, 95),
-                selectedYear
-              );
-            })
-            .filter((song: SongPreview | null): song is SongPreview => song != null);
-          return [...current, ...nextItems];
-        });
+        const currentLength = uniqueSongs.length;
+        const nextItems = payload.items
+          .map((song: ApiSongInput, index: number) => {
+            const mappedSong = mapApiSong(song);
+            return toDisplaySongPreview(
+              mappedSong,
+              `Feels especially loved in ${country.name}`,
+              clamp(95 - (currentLength + index) * 2, 34, 95),
+              selectedYear
+            );
+          })
+          .filter((song: SongPreview | null): song is SongPreview => song != null);
+        const enrichedItems = await enrichSongsWithLanguage(nextItems, controller.signal);
+        if (latestRequestRef.current !== requestId || controller.signal.aborted || !isActiveRef.current) {
+          return;
+        }
+        setUniqueSongs((current) => [...current, ...enrichedItems]);
         setUniquePage(nextPage);
         setUniqueHasMore(payload.hasMore);
       })
@@ -1635,24 +1659,27 @@ function ComparisonCountryPane({
     loadMoreSharedControllerRef.current = controller;
     setLoadingMoreShared(true);
     loadCountrySongsPage(country.code, selectedYear, "shared", nextPage, songPageSize, controller.signal)
-      .then((payload) => {
+      .then(async (payload) => {
         if (latestRequestRef.current !== requestId || controller.signal.aborted || !isActiveRef.current) {
           return;
         }
-        setSharedSongs((current) => {
-          const nextItems = payload.items
-            .map((song: ApiSongInput, index: number) => {
-              const mappedSong = mapApiSong(song);
-              return toDisplaySongPreview(
-                mappedSong,
-                "Loved in this country and echoed across other countries",
-                clamp(95 - (current.length + index) * 2, 34, 95),
-                selectedYear
-              );
-            })
-            .filter((song: SongPreview | null): song is SongPreview => song != null);
-          return [...current, ...nextItems];
-        });
+        const currentLength = sharedSongs.length;
+        const nextItems = payload.items
+          .map((song: ApiSongInput, index: number) => {
+            const mappedSong = mapApiSong(song);
+            return toDisplaySongPreview(
+              mappedSong,
+              "Loved in this country and echoed across other countries",
+              clamp(95 - (currentLength + index) * 2, 34, 95),
+              selectedYear
+            );
+          })
+          .filter((song: SongPreview | null): song is SongPreview => song != null);
+        const enrichedItems = await enrichSongsWithLanguage(nextItems, controller.signal);
+        if (latestRequestRef.current !== requestId || controller.signal.aborted || !isActiveRef.current) {
+          return;
+        }
+        setSharedSongs((current) => [...current, ...enrichedItems]);
         setSharedPage(nextPage);
         setSharedHasMore(payload.hasMore);
       })
@@ -1718,15 +1745,20 @@ function ComparisonCountryPane({
         ? []
         : country.genres.filter((genre) => genre.trim().length > 0 && genre.trim().toLowerCase() !== "unknown");
   const isCoreLoading = initialLoadingProfile || initialLoadingUnique || initialLoadingShared;
+  const areProfileStatsLoading = initialLoadingProfile;
   const loadingText = useLoadingText(isCoreLoading || initialLoadingPreview);
   const sectionLoadingText = useStableLoadingText(isCoreLoading || initialLoadingPreview);
-  const lovedGenres = useMemo(
+  const lovedLanguages = useMemo(
     () => [
-      ...collectUniqueGenresFromSongs(profileStats.uniqueSongs, 5),
-      ...collectUniqueGenresFromSongs(profileStats.sharedSongs, 5),
-    ].filter((genre, index, source) => source.indexOf(genre) === index),
-    [profileStats.sharedSongs, profileStats.uniqueSongs]
+      ...getCachedCountryLanguageSamples(country.code, selectedYear),
+      ...collectUniqueLanguagesFromSongs(profileStats.uniqueSongs, 8),
+      ...collectUniqueLanguagesFromSongs(profileStats.sharedSongs, 8),
+      ...collectUniqueLanguagesFromSongs(hiddenGemSongs, 8),
+    ].filter((language, index, source) => source.indexOf(language) === index),
+    [country.code, hiddenGemSongs, profileStats.sharedSongs, profileStats.uniqueSongs, selectedYear]
   );
+  const languageSampleText = formatLanguageAndMore(lovedLanguages);
+  const areInsightSectionsLoading = initialLoadingProfile && !languageSampleText && sampleGenres.length === 0;
 
   const generalDescriptionText = useMemo(() => {
     const genreA = sampleGenres[0] ?? "Unknown Genre";
@@ -1743,19 +1775,20 @@ function ComparisonCountryPane({
   }, [country.name, favoriteArtists, profileStats.sharedSongs, profileStats.uniqueSongs, sampleGenres, sectionLoadingText, selectedYear]);
 
   const genreLanguageMixText = useMemo(() => {
-    const genreSummary = formatGenreSummary(lovedGenres.length > 0 ? lovedGenres : sampleGenres);
+    const genreSummary = formatGenreSummary(sampleGenres);
+    const languageSummary = languageSampleText || sectionLoadingText;
     if (!genreSummary) {
-      return `Some of ${country.name}'s loved genres include ${sectionLoadingText}. Languages in lyrics of songs loved in ${country.name} are coming soon.`;
+      return `Some of ${country.name}'s loved genres include ${sectionLoadingText}. Some languages featured in ${country.name}'s loved songs include ${languageSummary}`;
     }
 
-    return `Some of ${country.name}'s loved genres include ${genreSummary}. Languages in lyrics of songs loved in ${country.name} are coming soon.`;
-  }, [country.name, lovedGenres, sampleGenres, sectionLoadingText]);
+    return `Some of ${country.name}'s loved genres include ${genreSummary}. Some languages featured in ${country.name}'s loved songs include ${languageSummary}`;
+  }, [country.name, languageSampleText, sampleGenres, sectionLoadingText]);
   const lovedGenresSectionText = useMemo(() => {
-    if (lovedGenres.length > 0) {
-      return `Some of the loved genres in ${country.name} include ${formatListWithAnd(lovedGenres)}.`;
+    if (sampleGenres.length > 0) {
+      return `Some of the loved genres in ${country.name} include ${formatListWithAnd(sampleGenres)}.`;
     }
     return `Some of the loved genres in ${country.name} include ${sectionLoadingText}.`;
-  }, [country.name, lovedGenres, sectionLoadingText]);
+  }, [country.name, sampleGenres, sectionLoadingText]);
 
   return (
     <Panel style={styles.paneShell}>
@@ -1820,18 +1853,18 @@ function ComparisonCountryPane({
         />
 
         <View style={styles.statStripRow}>
-          <StatSquare label="Songs in This View" value={isCoreLoading ? loadingText : `${profileStats.totalCharted}`} note="songs" style={styles.statStripItem} />
-          <StatSquare label="Loved in This Country" value={isCoreLoading ? loadingText : `${profileStats.uniqueCount}`} note="songs" style={styles.statStripItem} />
+          <StatSquare label="Songs in This View" value={areProfileStatsLoading ? loadingText : `${profileStats.totalCharted}`} note="songs" style={styles.statStripItem} />
+          <StatSquare label="Loved in This Country" value={areProfileStatsLoading ? loadingText : `${profileStats.uniqueCount}`} note="songs" style={styles.statStripItem} />
           <StatSquare
             label="Loved Here and Elsewhere"
-            value={isCoreLoading ? loadingText : `${profileStats.sharedCount}`}
+            value={areProfileStatsLoading ? loadingText : `${profileStats.sharedCount}`}
             note="songs"
             style={styles.statStripItem}
           />
           <StatSquare
             label={isMobileStack ? "% Loved Here and Elsewhere" : "Loved Here and Elsewhere"}
             value={
-              isCoreLoading ? (
+              areProfileStatsLoading ? (
                 loadingText
               ) : (
                 <Text style={styles.statSquareValue}>
@@ -1843,13 +1876,16 @@ function ComparisonCountryPane({
             note="% of this view"
             style={styles.statStripItem}
           />
-          <SectionLoadingVeil visible={isCoreLoading} />
+          <SectionLoadingVeil visible={areProfileStatsLoading} />
         </View>
 
         <View style={styles.genreAndLanguageSections}>
           <GenreSection title={`${country.name}'s Loved Genres`} bodyText={lovedGenresSectionText} />
-          <LanguageSection title={`${country.name}'s Language(s) in Music`} bodyText="Language information coming soon." />
-          <SectionLoadingVeil visible={isCoreLoading} />
+          <LanguageSection
+            title={`${country.name}'s Language(s) in Music`}
+            bodyText={languageSampleText ? `Languages in songs loved in ${country.name} include ${languageSampleText}` : "Loading..."}
+          />
+          <SectionLoadingVeil visible={areInsightSectionsLoading} />
         </View>
 
         <HiddenSongsCarouselSection

--- a/hidden-gem-music-app/src/screens/CountryScreen.tsx
+++ b/hidden-gem-music-app/src/screens/CountryScreen.tsx
@@ -20,8 +20,9 @@ import { GemIcon } from "../components/GemIcon";
 import { Panel } from "../components/Panel";
 import { ScreenScaffold } from "../components/ScreenScaffold";
 import { SecondarySurfaceFill } from "../components/SecondarySurfaceFill";
-import { getCachedCountryGenreSamples, loadAvailableYears, loadCountryHiddenGemsPreview, loadCountryProfile, loadCountrySongsPage } from "../data/countryApi";
+import { getCachedCountryGenreSamples, getCachedCountryLanguageSamples, loadAvailableYears, loadCountryHiddenGemsPreview, loadCountryProfile, loadCountrySongsPage } from "../data/countryApi";
 import { hasKnownSongTitle, mapApiCountryProfile, mapApiSong } from "../data/apiMappers";
+import { collectUniqueLanguagesFromSongs, enrichSongsWithLanguage, formatLanguageAndMore } from "../data/languageApi";
 import { useLoadingText, useStableLoadingText } from "../hooks/useLoadingText";
 import { Country } from "../types/content";
 import { colors } from "../theme/colors";
@@ -55,6 +56,8 @@ type SongPreview = {
   explicitLyrics?: boolean;
   explicitContentCover?: boolean;
   albumExplicitLyrics?: boolean;
+  languages?: string[];
+  lyricsUrl?: string;
 };
 
 type FavoriteArtistPreview = {
@@ -298,6 +301,8 @@ function createSongPreview(
     explicitLyrics?: boolean;
     explicitContentCover?: boolean;
     albumExplicitLyrics?: boolean;
+    languages?: string[];
+    lyricsUrl?: string;
   }
 ): SongPreview {
   return {
@@ -317,6 +322,8 @@ function createSongPreview(
     explicitLyrics: options?.explicitLyrics,
     explicitContentCover: options?.explicitContentCover,
     albumExplicitLyrics: options?.albumExplicitLyrics,
+    languages: Array.isArray(options?.languages) ? options.languages.filter((language) => typeof language === "string" && language.trim().length > 0) : [],
+    lyricsUrl: options?.lyricsUrl?.trim() ? options.lyricsUrl : undefined,
   };
 }
 
@@ -330,6 +337,8 @@ function createLoadingSongPreviews(count: number, fallbackYear: number): SongPre
       explicitLyrics: undefined,
       explicitContentCover: undefined,
       albumExplicitLyrics: undefined,
+      languages: ["Loading..."],
+      lyricsUrl: undefined,
     })
   );
 }
@@ -347,6 +356,8 @@ function toSongPreview(
     explicitLyrics?: boolean;
     explicitContentCover?: boolean;
     albumExplicitLyrics?: boolean;
+    languages?: string[];
+    lyricsUrl?: string;
   },
   detail: string,
   score: number,
@@ -365,6 +376,8 @@ function toSongPreview(
     explicitLyrics: song.explicitLyrics,
     explicitContentCover: song.explicitContentCover,
     albumExplicitLyrics: song.albumExplicitLyrics,
+    languages: song.languages,
+    lyricsUrl: song.lyricsUrl,
   });
 }
 
@@ -1686,35 +1699,40 @@ export function CountryScreen({
     setPreviewSongs(createLoadingSongPreviews(13, selectedYear));
 
     loadCountryProfile(country.code, selectedYear, profileController.signal)
-      .then((profilePayload) => {
+      .then(async (profilePayload) => {
         if (latestRequestRef.current !== requestId) {
           return;
         }
 
         const mappedProfile = mapApiCountryProfile(profilePayload);
         setApiProfile(mappedProfile);
-        setUniqueSongs(
-          mappedProfile.topUniqueSongs
-            .map((song, index) => toDisplaySongPreview(song, `Feels especially loved in ${country.name}`, clamp(95 - index * 2, 34, 95), selectedYear))
-            .filter((song): song is SongPreview => song != null)
-        );
-        setSharedSongs(
-          mappedProfile.topSharedSongs
-            .map((song, index) =>
-              toDisplaySongPreview(
-                song,
-                "Loved in this country and echoed across other countries",
-                clamp(95 - index * 2, 34, 95),
-                selectedYear
-              )
-            )
-            .filter((song): song is SongPreview => song != null)
-        );
-        setUniquePage(1);
-        setSharedPage(1);
         setUniqueHasMore(mappedProfile.uniqueCount > mappedProfile.topUniqueSongs.length);
         setSharedHasMore(mappedProfile.sharedCount > mappedProfile.topSharedSongs.length);
         setInitialLoadingProfile(false);
+        const nextUniqueSongs = mappedProfile.topUniqueSongs
+          .map((song, index) => toDisplaySongPreview(song, `Feels especially loved in ${country.name}`, clamp(95 - index * 2, 34, 95), selectedYear))
+          .filter((song): song is SongPreview => song != null);
+        const nextSharedSongs = mappedProfile.topSharedSongs
+          .map((song, index) =>
+            toDisplaySongPreview(
+              song,
+              "Loved in this country and echoed across other countries",
+              clamp(95 - index * 2, 34, 95),
+              selectedYear
+            )
+          )
+          .filter((song): song is SongPreview => song != null);
+        const [enrichedUniqueSongs, enrichedSharedSongs] = await Promise.all([
+          enrichSongsWithLanguage(nextUniqueSongs, profileController.signal),
+          enrichSongsWithLanguage(nextSharedSongs, profileController.signal),
+        ]);
+        if (latestRequestRef.current !== requestId || profileController.signal.aborted) {
+          return;
+        }
+        setUniqueSongs(enrichedUniqueSongs);
+        setSharedSongs(enrichedSharedSongs);
+        setUniquePage(1);
+        setSharedPage(1);
         setInitialLoadingUnique(false);
         setInitialLoadingShared(false);
       })
@@ -1737,18 +1755,17 @@ export function CountryScreen({
       });
 
     loadCountryHiddenGemsPreview(country.code, selectedYear, 13, previewController.signal)
-      .then((hiddenGemsPayload) => {
+      .then(async (hiddenGemsPayload) => {
         if (latestRequestRef.current !== requestId) {
           return;
         }
 
-        setPreviewSongs(
-          dedupeSongPreviews(
-            hiddenGemsPayload
-              .map((item) =>
-                createSongPreview(
-                  item.songName?.trim() ? item.songName : "Unknown Song",
-                  item.artistName?.trim() ? item.artistName : "Unknown Artist",
+        const nextPreviewSongs = dedupeSongPreviews(
+          hiddenGemsPayload
+            .map((item) =>
+              createSongPreview(
+                item.songName?.trim() ? item.songName : "Unknown Song",
+                item.artistName?.trim() ? item.artistName : "Unknown Artist",
                 "TrendScore preview",
                 Math.round(item.trendScore),
                 {
@@ -1766,10 +1783,14 @@ export function CountryScreen({
                   albumExplicitLyrics: item.albumExplicitLyrics ?? undefined,
                 }
               )
-              )
-              .filter((song) => hasKnownSongTitle(song.title))
-          )
+            )
+            .filter((song) => hasKnownSongTitle(song.title))
         );
+        const enrichedPreviewSongs = await enrichSongsWithLanguage(nextPreviewSongs, previewController.signal);
+        if (latestRequestRef.current !== requestId || previewController.signal.aborted) {
+          return;
+        }
+        setPreviewSongs(enrichedPreviewSongs);
         setInitialLoadingPreview(false);
       })
       .catch((error) => {
@@ -1825,25 +1846,28 @@ export function CountryScreen({
     setLoadingMoreUnique(true);
 
     loadCountrySongsPage(country.code, selectedYear, "unique", nextPage, songPageSize, controller.signal)
-      .then((payload) => {
+      .then(async (payload) => {
         if (latestRequestRef.current !== requestId || controller.signal.aborted || !isActiveRef.current) {
           return;
         }
 
-        setUniqueSongs((current) => {
-          const nextItems = payload.items
-            .map((song: ApiSongInput, index: number) => {
-              const mappedSong = mapApiSong(song);
-              return toDisplaySongPreview(
-                mappedSong,
-                `Feels especially loved in ${country.name}`,
-                clamp(95 - (current.length + index) * 2, 34, 95),
-                selectedYear
-              );
-            })
-            .filter((song: SongPreview | null): song is SongPreview => song != null);
-          return [...current, ...nextItems];
-        });
+        const currentLength = uniqueSongs.length;
+        const nextItems = payload.items
+          .map((song: ApiSongInput, index: number) => {
+            const mappedSong = mapApiSong(song);
+            return toDisplaySongPreview(
+              mappedSong,
+              `Feels especially loved in ${country.name}`,
+              clamp(95 - (currentLength + index) * 2, 34, 95),
+              selectedYear
+            );
+          })
+          .filter((song: SongPreview | null): song is SongPreview => song != null);
+        const enrichedItems = await enrichSongsWithLanguage(nextItems, controller.signal);
+        if (latestRequestRef.current !== requestId || controller.signal.aborted || !isActiveRef.current) {
+          return;
+        }
+        setUniqueSongs((current) => [...current, ...enrichedItems]);
         setUniquePage(nextPage);
         setUniqueHasMore(payload.hasMore);
       })
@@ -1879,25 +1903,28 @@ export function CountryScreen({
     setLoadingMoreShared(true);
 
     loadCountrySongsPage(country.code, selectedYear, "shared", nextPage, songPageSize, controller.signal)
-      .then((payload) => {
+      .then(async (payload) => {
         if (latestRequestRef.current !== requestId || controller.signal.aborted || !isActiveRef.current) {
           return;
         }
 
-        setSharedSongs((current) => {
-          const nextItems = payload.items
-            .map((song: ApiSongInput, index: number) => {
-              const mappedSong = mapApiSong(song);
-              return toDisplaySongPreview(
-                mappedSong,
-                "Loved in this country and echoed across other countries",
-                clamp(95 - (current.length + index) * 2, 34, 95),
-                selectedYear
-              );
-            })
-            .filter((song: SongPreview | null): song is SongPreview => song != null);
-          return [...current, ...nextItems];
-        });
+        const currentLength = sharedSongs.length;
+        const nextItems = payload.items
+          .map((song: ApiSongInput, index: number) => {
+            const mappedSong = mapApiSong(song);
+            return toDisplaySongPreview(
+              mappedSong,
+              "Loved in this country and echoed across other countries",
+              clamp(95 - (currentLength + index) * 2, 34, 95),
+              selectedYear
+            );
+          })
+          .filter((song: SongPreview | null): song is SongPreview => song != null);
+        const enrichedItems = await enrichSongsWithLanguage(nextItems, controller.signal);
+        if (latestRequestRef.current !== requestId || controller.signal.aborted || !isActiveRef.current) {
+          return;
+        }
+        setSharedSongs((current) => [...current, ...enrichedItems]);
         setSharedPage(nextPage);
         setSharedHasMore(payload.hasMore);
       })
@@ -1974,15 +2001,20 @@ export function CountryScreen({
         ? []
         : country.genres.filter((genre) => genre.trim().length > 0 && genre.trim().toLowerCase() !== "unknown");
   const isCoreLoading = initialLoadingProfile || initialLoadingUnique || initialLoadingShared;
+  const areProfileStatsLoading = initialLoadingProfile;
   const loadingText = useLoadingText(isCoreLoading || initialLoadingPreview);
   const sectionLoadingText = useStableLoadingText(isCoreLoading || initialLoadingPreview);
-  const lovedGenres = useMemo(
+  const lovedLanguages = useMemo(
     () => [
-      ...collectUniqueGenresFromSongs(profileStats.uniqueSongs, 5),
-      ...collectUniqueGenresFromSongs(profileStats.sharedSongs, 5),
-    ].filter((genre, index, source) => source.indexOf(genre) === index),
-    [profileStats.sharedSongs, profileStats.uniqueSongs]
+      ...getCachedCountryLanguageSamples(country.code, selectedYear),
+      ...collectUniqueLanguagesFromSongs(profileStats.uniqueSongs, 8),
+      ...collectUniqueLanguagesFromSongs(profileStats.sharedSongs, 8),
+      ...collectUniqueLanguagesFromSongs(hiddenGemSongs, 8),
+    ].filter((language, index, source) => source.indexOf(language) === index),
+    [country.code, hiddenGemSongs, profileStats.sharedSongs, profileStats.uniqueSongs, selectedYear]
   );
+  const languageSampleText = formatLanguageAndMore(lovedLanguages);
+  const areInsightSectionsLoading = initialLoadingProfile && !languageSampleText && sampleGenres.length === 0;
 
   const generalDescriptionText = useMemo(() => {
     const genreA = sampleGenres[0] ?? "Unknown Genre";
@@ -2001,19 +2033,20 @@ export function CountryScreen({
   }, [country.name, favoriteArtists, profileStats.sharedSongs, profileStats.uniqueSongs, sampleGenres, sectionLoadingText, selectedYear]);
 
   const genreLanguageMixText = useMemo(() => {
-    const genreSummary = formatGenreSummary(lovedGenres.length > 0 ? lovedGenres : sampleGenres);
+    const genreSummary = formatGenreSummary(sampleGenres);
+    const languageSummary = languageSampleText || sectionLoadingText;
     if (!genreSummary) {
-      return `Some of ${country.name}'s loved genres include ${sectionLoadingText}. Languages in lyrics of songs loved in ${country.name} are coming soon.`;
+      return `Some of ${country.name}'s loved genres include ${sectionLoadingText}. Some languages featured in ${country.name}'s loved songs include ${languageSummary}`;
     }
 
-    return `Some of ${country.name}'s loved genres include ${genreSummary}. Languages in lyrics of songs loved in ${country.name} are coming soon.`;
-  }, [country.name, lovedGenres, sampleGenres, sectionLoadingText]);
+    return `Some of ${country.name}'s loved genres include ${genreSummary}. Some languages featured in ${country.name}'s loved songs include ${languageSummary}`;
+  }, [country.name, languageSampleText, sampleGenres, sectionLoadingText]);
   const lovedGenresSectionText = useMemo(() => {
-    if (lovedGenres.length > 0) {
-      return `Some of the loved genres in ${country.name} include ${formatListWithAnd(lovedGenres)}.`;
+    if (sampleGenres.length > 0) {
+      return `Some of the loved genres in ${country.name} include ${formatListWithAnd(sampleGenres)}.`;
     }
     return `Some of the loved genres in ${country.name} include ${sectionLoadingText}.`;
-  }, [country.name, lovedGenres, sectionLoadingText]);
+  }, [country.name, sampleGenres, sectionLoadingText]);
 
   const handlePageScroll = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
     setPageScrollY(event.nativeEvent.contentOffset.y);
@@ -2134,30 +2167,30 @@ export function CountryScreen({
             <View style={[styles.statSquaresGrid, statsTwoByTwo ? styles.statSquaresGridTwoByTwo : styles.statSquaresGridSingleRow]}>
               <StatSquare
                 label="Songs in This View"
-                value={isCoreLoading ? loadingText : `${profileStats.totalCharted}`}
+                value={areProfileStatsLoading ? loadingText : `${profileStats.totalCharted}`}
                 note="songs"
                 valueOffsetY={6}
-                useLoadingStyle={isCoreLoading}
+                useLoadingStyle={areProfileStatsLoading}
                 style={splitStatsAndInsights && !statsTwoByTwo ? styles.statSquareWide : statsTwoByTwo ? styles.statSquareHalf : null}
               />
               <StatSquare
                 label="Loved in This Country"
-                value={isCoreLoading ? loadingText : `${profileStats.uniqueCount}`}
+                value={areProfileStatsLoading ? loadingText : `${profileStats.uniqueCount}`}
                 note="songs"
                 valueOffsetY={6}
-                useLoadingStyle={isCoreLoading}
+                useLoadingStyle={areProfileStatsLoading}
                 style={splitStatsAndInsights && !statsTwoByTwo ? styles.statSquareWide : statsTwoByTwo ? styles.statSquareHalf : null}
               />
               <StatSquare
                 label="Loved Here and Elsewhere"
-                value={isCoreLoading ? loadingText : `${profileStats.sharedCount}`}
+                value={areProfileStatsLoading ? loadingText : `${profileStats.sharedCount}`}
                 note="songs"
-                useLoadingStyle={isCoreLoading}
+                useLoadingStyle={areProfileStatsLoading}
                 style={splitStatsAndInsights && !statsTwoByTwo ? styles.statSquareWide : statsTwoByTwo ? styles.statSquareHalf : null}
               />
               <StatSquare
                 label="Loved Here and Elsewhere"
-                value={isCoreLoading ? (
+                value={areProfileStatsLoading ? (
                   loadingText
                 ) : (
                   <>
@@ -2166,10 +2199,10 @@ export function CountryScreen({
                   </>
                 )}
                 note="% of this view"
-                useLoadingStyle={isCoreLoading}
+                useLoadingStyle={areProfileStatsLoading}
                 style={splitStatsAndInsights && !statsTwoByTwo ? styles.statSquareWide : statsTwoByTwo ? styles.statSquareHalf : null}
               />
-              <SectionLoadingVeil visible={isCoreLoading} />
+              <SectionLoadingVeil visible={areProfileStatsLoading} />
             </View>
           </View>
           <View
@@ -2185,9 +2218,9 @@ export function CountryScreen({
             />
             <LanguageSection
               title={`${country.name}'s Language(s) in Music`}
-              bodyText="Language information coming soon."
+              bodyText={languageSampleText ? `Languages in songs loved in ${country.name} include ${languageSampleText}` : "Loading..."}
             />
-            <SectionLoadingVeil visible={isCoreLoading} />
+            <SectionLoadingVeil visible={areInsightSectionsLoading} />
           </View>
         </View>
 

--- a/hidden-gem-music-app/src/screens/DiscoveryScreen.tsx
+++ b/hidden-gem-music-app/src/screens/DiscoveryScreen.tsx
@@ -11,7 +11,8 @@ import { Panel } from "../components/Panel";
 import { ScreenScaffold } from "../components/ScreenScaffold";
 import { SecondarySurfaceFill } from "../components/SecondarySurfaceFill";
 import { YearSlider } from "../components/YearSlider";
-import { loadCountryGenreSamples } from "../data/countryApi";
+import { loadCountryGenreSamples, loadCountryLanguageSamples } from "../data/countryApi";
+import { formatLanguageAndMore } from "../data/languageApi";
 import { useLoadingText } from "../hooks/useLoadingText";
 import { colors } from "../theme/colors";
 import { typefaces } from "../theme/typography";
@@ -30,6 +31,7 @@ export type Props = {
 };
 
 type SortOption = "a-z" | "z-a" | "gems-desc" | "gems-asc";
+const initialDiscoverySamplePrefetchCount = 24;
 const activeGradient = [colors.navGradient, colors.backgroundRaised, colors.backgroundRaised] as const;
 const popupBottomDepthGradient = ["rgba(108,119,142,0)", "rgba(108,119,142,0.12)", "rgba(108,119,142,0.3)"] as const;
 const normalizeContinent = (region: string) => {
@@ -43,7 +45,9 @@ const normalizeContinent = (region: string) => {
 };
 
 function formatGenreSummary(genres: string[]) {
-  const cleaned = genres.map((genre) => genre.trim()).filter((genre) => genre.length > 0);
+  const cleaned = genres
+    .map((genre) => genre.trim())
+    .filter((genre) => genre.length > 0 && genre.toLowerCase() !== "unknown" && genre.toLowerCase() !== "loading...");
   if (cleaned.length >= 3) {
     return `${cleaned[0]}, ${cleaned[1]}, ${cleaned[2]}, and others`;
   }
@@ -194,11 +198,15 @@ export function DiscoveryScreen({
   const [isClearHovered, setIsClearHovered] = useState(false);
   const [isClearPressed, setIsClearPressed] = useState(false);
   const [selectedFilterYears, setSelectedFilterYears] = useState<number[]>([selectedYear]);
-  const [genrePrefetchCount, setGenrePrefetchCount] = useState(8);
+  const [genrePrefetchCount, setGenrePrefetchCount] = useState(initialDiscoverySamplePrefetchCount);
   const [genreSummaryByCountryCode, setGenreSummaryByCountryCode] = useState<Record<string, string>>({});
   const [genreLoadingByCountryCode, setGenreLoadingByCountryCode] = useState<Record<string, boolean>>({});
+  const [languageSummaryByCountryCode, setLanguageSummaryByCountryCode] = useState<Record<string, string>>({});
+  const [languageLoadingByCountryCode, setLanguageLoadingByCountryCode] = useState<Record<string, boolean>>({});
   const genreRequestControllersRef = useRef<AbortController[]>([]);
   const requestedGenreCodesRef = useRef<Set<string>>(new Set());
+  const languageRequestControllersRef = useRef<AbortController[]>([]);
+  const requestedLanguageCodesRef = useRef<Set<string>>(new Set());
   const timelineYears =
     availableYears && availableYears.length > 0
       ? Array.from(new Set([...availableYears, selectedYear])).sort((a, b) => a - b)
@@ -281,7 +289,27 @@ export function DiscoveryScreen({
     ? selectedCountryId
     : filteredCountries[0]?.id ?? selectedCountryId;
   const anyDiscoveryGenreLoading = Object.values(genreLoadingByCountryCode).some(Boolean);
-  const discoveryLoadingText = useLoadingText(anyDiscoveryGenreLoading);
+  const anyDiscoveryLanguageLoading = Object.values(languageLoadingByCountryCode).some(Boolean);
+  const discoveryLoadingText = useLoadingText(anyDiscoveryGenreLoading || anyDiscoveryLanguageLoading);
+  const discoveryLanguageLoadingText = useLoadingText(anyDiscoveryLanguageLoading);
+  const visibleSelectedCountryCode = filteredCountries.find((country) => country.id === visibleSelectedCountryId)?.code;
+  const selectedLanguageSummary =
+    visibleSelectedCountryCode && languageSummaryByCountryCode[visibleSelectedCountryCode]
+      ? languageSummaryByCountryCode[visibleSelectedCountryCode]
+      : visibleSelectedCountryCode && languageLoadingByCountryCode[visibleSelectedCountryCode]
+        ? discoveryLanguageLoadingText
+        : "Loading...";
+  const displayGenreSummaryByCountryCode = useMemo(() => {
+    const next: Record<string, string> = {};
+    filteredCountries.forEach((country) => {
+      const loadedSummary = genreSummaryByCountryCode[country.code];
+      const localSummary = formatGenreSummary(country.genres ?? []);
+      if (loadedSummary || localSummary) {
+        next[country.code] = loadedSummary || localSummary;
+      }
+    });
+    return next;
+  }, [filteredCountries, genreSummaryByCountryCode]);
 
   const ensureCountryGenreSamples = useCallback(
     (countryCodes: string[]) => {
@@ -294,6 +322,7 @@ export function DiscoveryScreen({
           countryCodes
             .map((code) => code.trim().toUpperCase())
             .filter((code) => code.length === 2)
+            .filter((code) => !displayGenreSummaryByCountryCode[code])
             .filter((code) => !requestedGenreCodesRef.current.has(code))
         )
       );
@@ -333,6 +362,7 @@ export function DiscoveryScreen({
           if (error instanceof Error && error.name === "AbortError") {
             return;
           }
+          nextCodes.forEach((code) => requestedGenreCodesRef.current.delete(code));
           console.warn(`Failed loading discovery genre samples for ${selectedYear}.`, error);
         })
         .finally(() => {
@@ -351,7 +381,82 @@ export function DiscoveryScreen({
           genreRequestControllersRef.current = genreRequestControllersRef.current.filter((entry) => entry !== controller);
         });
     },
-    [isActive, selectedYear]
+    [displayGenreSummaryByCountryCode, isActive, selectedYear]
+  );
+
+  const ensureCountryLanguageSamples = useCallback(
+    (countryCodes: string[]) => {
+      if (!isActive) {
+        return;
+      }
+
+      const nextCodes = Array.from(
+        new Set(
+          countryCodes
+            .map((code) => code.trim().toUpperCase())
+            .filter((code) => code.length === 2)
+            .filter((code) => !languageSummaryByCountryCode[code])
+            .filter((code) => !requestedLanguageCodesRef.current.has(code))
+        )
+      );
+
+      if (nextCodes.length === 0) {
+        return;
+      }
+
+      nextCodes.forEach((code) => requestedLanguageCodesRef.current.add(code));
+      setLanguageLoadingByCountryCode((current) => {
+        const next = { ...current };
+        nextCodes.forEach((code) => {
+          next[code] = true;
+        });
+        return next;
+      });
+
+      const controller = new AbortController();
+      languageRequestControllersRef.current.push(controller);
+
+      loadCountryLanguageSamples(nextCodes, selectedYear, controller.signal)
+        .then((payload) => {
+          if (controller.signal.aborted || !isActive) {
+            return;
+          }
+
+          setLanguageSummaryByCountryCode((current) => {
+            const next = { ...current };
+            payload.forEach((item) => {
+              const summary = formatLanguageAndMore(Array.isArray(item.languages) ? item.languages : []);
+              if (summary) {
+                next[item.countryCode] = summary;
+              }
+            });
+            return next;
+          });
+        })
+        .catch((error) => {
+          if (error instanceof Error && error.name === "AbortError") {
+            return;
+          }
+          nextCodes.forEach((code) => requestedLanguageCodesRef.current.delete(code));
+          console.warn(`Failed loading discovery language samples for ${selectedYear}.`, error);
+        })
+        .finally(() => {
+          if (controller.signal.aborted || !isActive) {
+            languageRequestControllersRef.current = languageRequestControllersRef.current.filter((entry) => entry !== controller);
+            return;
+          }
+
+          setLanguageLoadingByCountryCode((current) => {
+            const next = { ...current };
+            nextCodes.forEach((code) => {
+              delete next[code];
+            });
+            return next;
+          });
+          languageRequestControllersRef.current = languageRequestControllersRef.current.filter((entry) => entry !== controller);
+        });
+    },
+    [isActive, languageSummaryByCountryCode, selectedYear]
   );
 
   useEffect(() => {
@@ -360,7 +465,12 @@ export function DiscoveryScreen({
     requestedGenreCodesRef.current = new Set();
     setGenreSummaryByCountryCode({});
     setGenreLoadingByCountryCode({});
-    setGenrePrefetchCount(8);
+    languageRequestControllersRef.current.forEach((controller) => controller.abort());
+    languageRequestControllersRef.current = [];
+    requestedLanguageCodesRef.current = new Set();
+    setLanguageSummaryByCountryCode({});
+    setLanguageLoadingByCountryCode({});
+    setGenrePrefetchCount(initialDiscoverySamplePrefetchCount);
   }, [selectedYear]);
 
   useEffect(() => {
@@ -371,12 +481,17 @@ export function DiscoveryScreen({
     genreRequestControllersRef.current.forEach((controller) => controller.abort());
     genreRequestControllersRef.current = [];
     setGenreLoadingByCountryCode({});
+    languageRequestControllersRef.current.forEach((controller) => controller.abort());
+    languageRequestControllersRef.current = [];
+    setLanguageLoadingByCountryCode({});
   }, [isActive]);
 
   useEffect(() => {
     return () => {
       genreRequestControllersRef.current.forEach((controller) => controller.abort());
       genreRequestControllersRef.current = [];
+      languageRequestControllersRef.current.forEach((controller) => controller.abort());
+      languageRequestControllersRef.current = [];
     };
   }, []);
 
@@ -386,9 +501,9 @@ export function DiscoveryScreen({
     }
 
     const starterCodes = filteredCountries.slice(0, genrePrefetchCount).map((country) => country.code);
-    const selectedCountryCode = filteredCountries.find((country) => country.id === visibleSelectedCountryId)?.code;
-    ensureCountryGenreSamples(selectedCountryCode ? [...starterCodes, selectedCountryCode] : starterCodes);
-  }, [ensureCountryGenreSamples, filteredCountries, genrePrefetchCount, isActive, visibleSelectedCountryId]);
+    ensureCountryGenreSamples(visibleSelectedCountryCode ? [visibleSelectedCountryCode, ...starterCodes] : starterCodes);
+    ensureCountryLanguageSamples(visibleSelectedCountryCode ? [visibleSelectedCountryCode, ...starterCodes] : starterCodes);
+  }, [ensureCountryGenreSamples, ensureCountryLanguageSamples, filteredCountries, genrePrefetchCount, isActive, visibleSelectedCountryCode]);
 
   const handleGlobeFocus = (countryId: string) => {
     if (countryId === visibleSelectedCountryId) {
@@ -411,11 +526,14 @@ export function DiscoveryScreen({
         onOpenCountry={onOpenCountry}
         onHoverCountryChange={Platform.OS === "web" ? setHoveredListCountryId : undefined}
         autoScrollSignal={listAutoScrollSignal}
-        genreSummaryByCountryCode={genreSummaryByCountryCode}
+        genreSummaryByCountryCode={displayGenreSummaryByCountryCode}
         genreLoadingByCountryCode={genreLoadingByCountryCode}
-        loadingText={discoveryLoadingText}
+        languageSummaryByCountryCode={languageSummaryByCountryCode}
+        languageLoadingByCountryCode={languageLoadingByCountryCode}
+        loadingText="Loading..."
         onEnsureGenreSample={(countryCode) => ensureCountryGenreSamples([countryCode])}
-        onNearListEnd={() => setGenrePrefetchCount((current) => Math.min(filteredCountries.length, current + 6))}
+        onEnsureLanguageSample={(countryCode) => ensureCountryLanguageSamples([countryCode])}
+        onNearListEnd={() => setGenrePrefetchCount((current) => Math.min(filteredCountries.length, current + 12))}
       />
     </View>
   );
@@ -437,10 +555,11 @@ export function DiscoveryScreen({
           title="Discovery Map"
           onRightAction={() => setAllFiltersOpen(true)}
           showHeader={false}
-          genreSummaryByCountryCode={genreSummaryByCountryCode}
+          genreSummaryByCountryCode={displayGenreSummaryByCountryCode}
           genreLoadingByCountryCode={genreLoadingByCountryCode}
           loadingText={discoveryLoadingText}
           onEnsureGenreSample={(countryCode) => ensureCountryGenreSamples([countryCode])}
+          onEnsureLanguageSample={(countryCode) => ensureCountryLanguageSamples([countryCode])}
           isActive={isActive}
         />
       </View>
@@ -792,7 +911,7 @@ export function DiscoveryScreen({
                       <View style={styles.filterButtonContent}>
                         <View style={styles.filterButtonLead}>
                           <GemIcon size={16} />
-                          <Text style={styles.filterButtonText}>Coming Soon</Text>
+                          <Text style={styles.filterButtonText}>{selectedLanguageSummary}</Text>
                         </View>
                       </View>
                     </View>
@@ -809,7 +928,7 @@ export function DiscoveryScreen({
                       <View style={styles.filterButtonContent}>
                         <View style={styles.filterButtonLead}>
                           <GemIcon size={16} />
-                          <Text style={styles.filterButtonText}>Coming Soon</Text>
+                          <Text style={styles.filterButtonText}>{selectedLanguageSummary}</Text>
                         </View>
                       </View>
                     </View>

--- a/hidden-gem-music-app/src/screens/HiddenGemsScreen.tsx
+++ b/hidden-gem-music-app/src/screens/HiddenGemsScreen.tsx
@@ -4,6 +4,7 @@ import { ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import {
   ActivityIndicator,
   Image,
+  Linking,
   NativeScrollEvent,
   NativeSyntheticEvent,
   Platform,
@@ -28,6 +29,7 @@ import { SecondarySurfaceFill } from "../components/SecondarySurfaceFill";
 import { getCachedHiddenGemsPage, loadCountryProfile, loadHiddenGemsPage } from "../data/countryApi";
 import { isCountryWithHiddenGems } from "../data/countryDisplay";
 import { hasKnownSongTitle, mapApiCountryProfile, mapApiHiddenGemPage } from "../data/apiMappers";
+import { enrichSongsWithLanguage, formatLanguageLabel } from "../data/languageApi";
 import { useLoadingText } from "../hooks/useLoadingText";
 import { ApiHiddenGemResponse } from "../types/api";
 import { colors } from "../theme/colors";
@@ -159,7 +161,8 @@ function createLoadingHiddenGemSongs(countryCode: string, year: number, count = 
     artistAlbumCount: undefined,
     tracklist: undefined,
     genres: ["Loading..."],
-    languages: ["Coming Soon"],
+    languages: ["Loading..."],
+    lyricsUrl: undefined,
     year,
     duration: "",
     description: "Loading...",
@@ -209,6 +212,7 @@ function buildHiddenGemSongsFromResponse(response: ApiHiddenGemResponse | null |
               ? [item.genre]
               : [],
         languages: [],
+        lyricsUrl: undefined,
         year,
         duration: "",
         description: `Trending in ${item.countriesChartingCount} countries`,
@@ -235,7 +239,7 @@ function buildHiddenGemSongsFromResponse(response: ApiHiddenGemResponse | null |
   };
 }
 
-function useCustomScrollbar() {
+function useCustomScrollbar(trackInsets = { top: 10, bottom: 10 }) {
   const scrollRef = useRef<ScrollView>(null);
   const trackRef = useRef<View>(null);
   const [viewportHeight, setViewportHeight] = useState(0);
@@ -244,13 +248,13 @@ function useCustomScrollbar() {
   const [isDraggingScrollbar, setIsDraggingScrollbar] = useState(false);
   const scrollbarVisible = Platform.OS === "web" && viewportHeight > 0;
   const hasOverflow = scrollbarVisible && contentHeight > viewportHeight;
-  const trackHeight = Math.max(viewportHeight - 20, 1);
+  const trackHeight = Math.max(viewportHeight - trackInsets.top - trackInsets.bottom, 1);
   const thumbHeight = scrollbarVisible
     ? hasOverflow
-      ? Math.max((viewportHeight / contentHeight) * viewportHeight, 52)
+      ? Math.max((viewportHeight / contentHeight) * trackHeight, 52)
       : trackHeight
     : 0;
-  const thumbTop = hasOverflow ? (scrollY / (contentHeight - viewportHeight)) * (viewportHeight - thumbHeight) : 0;
+  const thumbTop = hasOverflow ? (scrollY / (contentHeight - viewportHeight)) * (trackHeight - thumbHeight) : 0;
 
   const scrollToTrackLocation = (locationY: number) => {
     if (!hasOverflow || contentHeight <= viewportHeight) {
@@ -515,87 +519,110 @@ function HiddenSongListPanel({
     <Panel style={styles.secondaryPanel}>
       <SecondarySurfaceFill />
       <View style={styles.secondaryPanelScrollFrame}>
-        <ScrollView
-          ref={scrollbar.scrollRef}
-          style={styles.secondaryPanelScroll}
-          contentContainerStyle={styles.songListContent}
-          showsVerticalScrollIndicator={false}
-          onLayout={(event) => scrollbar.setViewportHeight(event.nativeEvent.layout.height)}
-          onContentSizeChange={(_, height) => scrollbar.setContentHeight(height)}
-          onScroll={(event: NativeSyntheticEvent<NativeScrollEvent>) => scrollbar.setScrollY(event.nativeEvent.contentOffset.y)}
-          scrollEventThrottle={16}
-        >
-          {songs.map((song, index) => (
-            <Pressable
-              key={song.id}
-              onPress={() => {
-                if (!isLoading) {
-                  onSelectSong(song.id);
-                }
-              }}
-              onHoverIn={() => setHoveredSongId(song.id)}
-              onHoverOut={() => setHoveredSongId((current) => (current === song.id ? null : current))}
-              style={styles.songRowShell}
-            >
-              {({ pressed }) => {
-                const selected = selectedSongId === song.id;
-                const showGradient =
-                  selected || hoveredSongId === song.id || hoveredMiniCdSongId === song.id || pressed;
+        <View style={styles.songListScrollArea}>
+          <ScrollView
+            ref={scrollbar.scrollRef}
+            style={styles.secondaryPanelScroll}
+            contentContainerStyle={styles.songListContent}
+            showsVerticalScrollIndicator={false}
+            onLayout={(event) => scrollbar.setViewportHeight(event.nativeEvent.layout.height)}
+            onContentSizeChange={(_, height) => scrollbar.setContentHeight(height)}
+            onScroll={(event: NativeSyntheticEvent<NativeScrollEvent>) => scrollbar.setScrollY(event.nativeEvent.contentOffset.y)}
+            scrollEventThrottle={16}
+          >
+            {songs.map((song, index) => (
+              <Pressable
+                key={song.id}
+                onPress={() => {
+                  if (!isLoading) {
+                    onSelectSong(song.id);
+                  }
+                }}
+                onHoverIn={() => setHoveredSongId(song.id)}
+                onHoverOut={() => setHoveredSongId((current) => (current === song.id ? null : current))}
+                style={styles.songRowShell}
+              >
+                {({ pressed }) => {
+                  const selected = selectedSongId === song.id;
+                  const showGradient =
+                    selected || hoveredSongId === song.id || hoveredMiniCdSongId === song.id || pressed;
 
-                return (
-                  <>
-                    {showGradient ? (
-                      <LinearGradient
-                        colors={selected ? activeGradient : hoverGradient}
-                        locations={[0, 0.34, 1]}
-                        start={{ x: 0, y: 0.5 }}
-                        end={{ x: 1, y: 0.5 }}
-                        style={styles.songRowGradient}
-                      />
-                    ) : null}
-                    <View style={[styles.songRow, showGradient ? styles.songRowActive : null]}>
-                      <Text style={[styles.songRowRank, showGradient ? styles.songTextActive : null]}>{index + 1}.</Text>
-                      <View style={styles.songCopy}>
-                        <View style={styles.songTitleRow}>
-                          <Text style={[styles.songRowTitle, showGradient ? styles.songTextActive : null]}>
-                            {isLoading ? loadingText : song.title}
+                  return (
+                    <>
+                      {showGradient ? (
+                        <LinearGradient
+                          colors={selected ? activeGradient : hoverGradient}
+                          locations={[0, 0.34, 1]}
+                          start={{ x: 0, y: 0.5 }}
+                          end={{ x: 1, y: 0.5 }}
+                          style={styles.songRowGradient}
+                        />
+                      ) : null}
+                      <View style={[styles.songRow, showGradient ? styles.songRowActive : null]}>
+                        <Text style={[styles.songRowRank, showGradient ? styles.songTextActive : null]}>{index + 1}.</Text>
+                        <View style={styles.songCopy}>
+                          <View style={styles.songTitleRow}>
+                            <Text style={[styles.songRowTitle, showGradient ? styles.songTextActive : null]}>
+                              {isLoading ? loadingText : song.title}
+                            </Text>
+                          </View>
+                          <Text style={[styles.songRowArtist, showGradient ? styles.songTextActive : null]}>
+                            {isLoading ? loadingText : song.artist}
                           </Text>
                         </View>
-                        <Text style={[styles.songRowArtist, showGradient ? styles.songTextActive : null]}>
-                          {isLoading ? loadingText : song.artist}
-                        </Text>
+                        <View style={styles.songArtMetaWrap}>
+                          {!isLoading && songHasExplicitBadge(song) ? (
+                            <View style={styles.songExplicitBadgeWrap}>
+                              <ExplicitIndicator tooltip={getExplicitTooltip(song)} />
+                            </View>
+                          ) : null}
+                          <Pressable
+                            style={styles.miniCdHoverTarget}
+                            onHoverIn={() => setHoveredMiniCdSongId(song.id)}
+                            onHoverOut={() => setHoveredMiniCdSongId((current) => (current === song.id ? null : current))}
+                            onPress={(event) => {
+                              (event as any)?.stopPropagation?.();
+                              if (!isLoading) {
+                                onPlaySong(song.id);
+                              }
+                            }}
+                          >
+                            <MiniCdCase
+                              color={rowBackdropColors[index % rowBackdropColors.length]}
+                              artImageUrl={isLoading ? undefined : song.albumArtUrl}
+                              showPlayButton={!isLoading && hoveredMiniCdSongId === song.id}
+                            />
+                          </Pressable>
+                        </View>
                       </View>
-                      <View style={styles.songArtMetaWrap}>
-                        {!isLoading && songHasExplicitBadge(song) ? (
-                          <View style={styles.songExplicitBadgeWrap}>
-                            <ExplicitIndicator tooltip={getExplicitTooltip(song)} />
-                          </View>
-                        ) : null}
-                        <Pressable
-                          style={styles.miniCdHoverTarget}
-                          onHoverIn={() => setHoveredMiniCdSongId(song.id)}
-                          onHoverOut={() => setHoveredMiniCdSongId((current) => (current === song.id ? null : current))}
-                          onPress={(event) => {
-                            (event as any)?.stopPropagation?.();
-                            if (!isLoading) {
-                              onPlaySong(song.id);
-                            }
-                          }}
-                        >
-                          <MiniCdCase
-                            color={rowBackdropColors[index % rowBackdropColors.length]}
-                            artImageUrl={isLoading ? undefined : song.albumArtUrl}
-                            showPlayButton={!isLoading && hoveredMiniCdSongId === song.id}
-                          />
-                        </Pressable>
-                      </View>
-                    </View>
-                  </>
-                );
-              }}
-            </Pressable>
-          ))}
-        </ScrollView>
+                    </>
+                  );
+                }}
+              </Pressable>
+            ))}
+          </ScrollView>
+          {scrollbar.scrollbarVisible ? (
+            <View
+              ref={scrollbar.trackRef}
+              style={styles.scrollbarTrack}
+              onStartShouldSetResponder={() => true}
+              onMoveShouldSetResponder={() => true}
+              onResponderGrant={(event) => scrollbar.scrollToTrackLocation(event.nativeEvent.locationY)}
+              onResponderMove={(event) => scrollbar.scrollToTrackLocation(event.nativeEvent.locationY)}
+              {...(Platform.OS === "web"
+                ? ({
+                    onMouseDown: (event: any) => {
+                      event.preventDefault();
+                      scrollbar.setIsDraggingScrollbar(true);
+                      scrollbar.scrollToClientY(event.clientY);
+                    },
+                  } as any)
+                : {})}
+            >
+              <View style={[styles.scrollbarThumb, { height: scrollbar.thumbHeight, transform: [{ translateY: scrollbar.thumbTop }] }]} />
+            </View>
+          ) : null}
+        </View>
         <View style={styles.paginationBar}>
           <Pressable
             onPress={onPreviousPage}
@@ -613,27 +640,6 @@ function HiddenSongListPanel({
             <Text style={styles.paginationButtonText}>Next Page</Text>
           </Pressable>
         </View>
-        {scrollbar.scrollbarVisible ? (
-          <View
-            ref={scrollbar.trackRef}
-            style={styles.scrollbarTrack}
-            onStartShouldSetResponder={() => true}
-            onMoveShouldSetResponder={() => true}
-            onResponderGrant={(event) => scrollbar.scrollToTrackLocation(event.nativeEvent.locationY)}
-            onResponderMove={(event) => scrollbar.scrollToTrackLocation(event.nativeEvent.locationY)}
-            {...(Platform.OS === "web"
-              ? ({
-                  onMouseDown: (event: any) => {
-                    event.preventDefault();
-                    scrollbar.setIsDraggingScrollbar(true);
-                    scrollbar.scrollToClientY(event.clientY);
-                  },
-                } as any)
-              : {})}
-          >
-            <View style={[styles.scrollbarThumb, { height: scrollbar.thumbHeight, transform: [{ translateY: scrollbar.thumbTop }] }]} />
-          </View>
-        ) : null}
       </View>
       <SectionLoadingVeil visible={isLoading} />
     </Panel>
@@ -834,6 +840,14 @@ function PlayingSidePanel({
   const loadingText = useLoadingText(isLoading);
   const disablePrevious = isLoading || !hasPreviousSong;
   const disableNext = isLoading || !hasNextSong;
+  const isInstrumental = !isLoading && selectedSong.languages.some((language) => formatLanguageLabel(language) === "This song is an instrumental");
+  const displayLanguages = !isLoading
+    ? selectedSong.languages
+        .map(formatLanguageLabel)
+        .filter((language) => language.length > 0 && language.toLowerCase() !== "unknown" && language.toLowerCase() !== "loading...")
+    : [];
+  const hasLanguageRow = !isLoading && displayLanguages.length > 0;
+  const lyricsUrl = !isLoading && selectedSong.lyricsUrl?.trim() ? selectedSong.lyricsUrl.trim() : "";
 
   return (
     <Panel style={[styles.secondaryPanel, styles.playingPanel]}>
@@ -932,12 +946,14 @@ function PlayingSidePanel({
                 </Text>
               </Text>
             </View>
-            <View style={styles.playingMetaCard}>
-              <Text style={styles.playingMetaLine}>
-                <Text style={styles.playingMetaLabel}>Language(s): </Text>
-                <Text style={styles.playingMetaValue}>{isLoading ? "Coming Soon" : selectedSong.languages.join(", ")}</Text>
-              </Text>
-            </View>
+            {hasLanguageRow ? (
+              <View style={styles.playingMetaCard}>
+                <Text style={styles.playingMetaLine}>
+                  <Text style={styles.playingMetaLabel}>Language(s): </Text>
+                  <Text style={styles.playingMetaValue}>{isInstrumental ? "This song is an instrumental" : displayLanguages.join(", ")}</Text>
+                </Text>
+              </View>
+            ) : null}
             <View style={styles.playingMetaCard}>
               <Text style={styles.playingMetaLine}>
                 <Text style={styles.playingMetaLabel}>Explicit Lyrics in Song: </Text>
@@ -973,6 +989,23 @@ function PlayingSidePanel({
                 <Text style={styles.playingMetaValue}>Tracklist unavailable.</Text>
               )}
             </View>
+            {isInstrumental ? (
+              <View style={styles.playingMetaCard}>
+                <Text style={styles.playingMetaLine}>
+                  <Text style={styles.playingMetaLabel}>Lyrics: </Text>
+                  <Text style={styles.playingMetaValue}>This song is an instrumental</Text>
+                </Text>
+              </View>
+            ) : lyricsUrl ? (
+              <Pressable style={styles.playingMetaCard} onPress={() => Linking.openURL(lyricsUrl)}>
+                <Text style={styles.playingMetaLine}>
+                  <Text style={styles.playingMetaLabel}>Lyrics: </Text>
+                  <Text style={[styles.playingMetaValue, styles.playingLyricsLink]}>
+                    Click here to view lyrics for this song on the Genius website
+                  </Text>
+                </Text>
+              </Pressable>
+            ) : null}
           </View>
         </ScrollView>
         {scrollbar.scrollbarVisible ? (
@@ -1215,45 +1248,41 @@ export function HiddenGemsScreen({
       return;
     }
 
-    const cachedResponse = getCachedHiddenGemsPage(country.code, selectedYear, 2, page, hiddenGemsPageSize);
-    if (cachedResponse) {
-      const cachedPage = buildHiddenGemSongsFromResponse(cachedResponse, country.code, selectedYear, page);
-      setApiSongs(cachedPage.songs);
-      setHasNextPage(cachedPage.hasNextPage);
-      setTotalPages(cachedPage.totalPages);
-      setTotalHiddenGemsCount(cachedPage.totalCount);
-      setIsSongsLoading(false);
-      onSetLoading?.(false);
-      return;
-    }
-
     const controller = new AbortController();
     setApiSongs(createLoadingHiddenGemSongs(country.code, selectedYear));
     setTotalHiddenGemsCount(null);
     setIsSongsLoading(true);
     onSetLoading?.(true);
-    loadHiddenGemsPage(country.code, selectedYear, 2, page, hiddenGemsPageSize, controller.signal)
-      .then((response) => {
+
+    const loadSongs = async () => {
+      const cachedResponse = getCachedHiddenGemsPage(country.code, selectedYear, 2, page, hiddenGemsPageSize);
+      const response = cachedResponse ?? (await loadHiddenGemsPage(country.code, selectedYear, 2, page, hiddenGemsPageSize, controller.signal));
+      const nextPage = buildHiddenGemSongsFromResponse(response, country.code, selectedYear, page);
+      const enrichedSongs = await enrichSongsWithLanguage(nextPage.songs, controller.signal);
+
+      if (controller.signal.aborted) {
+        return;
+      }
+
+      setApiSongs(enrichedSongs);
+      setHasNextPage(nextPage.hasNextPage);
+      setTotalPages(nextPage.totalPages);
+      setTotalHiddenGemsCount(nextPage.totalCount);
+      setIsSongsLoading(false);
+      onSetLoading?.(false);
+    };
+
+    loadSongs()
+      .catch(() => {
         if (controller.signal.aborted) {
           return;
         }
-        const nextPage = buildHiddenGemSongsFromResponse(response, country.code, selectedYear, page);
-        setApiSongs(nextPage.songs);
-        setHasNextPage(nextPage.hasNextPage);
-        setTotalPages(nextPage.totalPages);
-        setTotalHiddenGemsCount(nextPage.totalCount);
+        setApiSongs([]);
+        setHasNextPage(false);
+        setTotalPages(1);
+        setTotalHiddenGemsCount(null);
         setIsSongsLoading(false);
         onSetLoading?.(false);
-      })
-      .catch(() => {
-        if (!controller.signal.aborted) {
-          setApiSongs([]);
-          setHasNextPage(false);
-          setTotalPages(1);
-          setTotalHiddenGemsCount(null);
-          setIsSongsLoading(false);
-          onSetLoading?.(false);
-        }
       });
 
     return () => {
@@ -1635,7 +1664,6 @@ export function HiddenGemsScreen({
                         enough yet to support trustworthy Hidden Gems filtering. Keep this note here
                         for a future normalized-genre iteration instead of deleting it. */}
                     {/* <Text style={styles.filtersModalLine}>Genre(s): Genre info coming soon.</Text> */}
-                    <Text style={styles.filtersModalLine}>Language(s): Language info coming soon.</Text>
                   </Panel>
                 ) : null}
                 </View>
@@ -2742,6 +2770,11 @@ const styles = StyleSheet.create({
     flex: 1,
     position: "relative",
   },
+  songListScrollArea: {
+    flex: 1,
+    position: "relative",
+    minHeight: 0,
+  },
   secondaryPanelScroll: {
     flex: 1,
     ...(Platform.OS === "web"
@@ -3204,6 +3237,9 @@ const styles = StyleSheet.create({
     fontFamily: typefaces.condensed,
     fontSize: 16,
     lineHeight: 22,
+  },
+  playingLyricsLink: {
+    textDecorationLine: "underline",
   },
   playingTracklistLine: {
     color: colors.textLight,

--- a/hidden-gem-music-app/src/types/api.ts
+++ b/hidden-gem-music-app/src/types/api.ts
@@ -138,6 +138,23 @@ export type ApiCountryGenreSample = {
   genres: string[];
 };
 
+export type ApiCountryLanguageSample = {
+  countryCode: string;
+  languages: string[];
+};
+
+export type ApiLanguageSongLookupItem = {
+  songName: string;
+  artistName: string;
+};
+
+export type ApiLanguageSongMatch = {
+  songName: string;
+  artistName: string;
+  lyricsUrl: string;
+  languages: string[];
+};
+
 export type ApiOverlapRate = {
   overlapPct: number;
   totalUniqueSongs: number;

--- a/hidden-gem-music-app/src/types/content.ts
+++ b/hidden-gem-music-app/src/types/content.ts
@@ -38,6 +38,7 @@ export type Song = {
   tracklist?: string[];
   genres: string[];
   languages: string[];
+  lyricsUrl?: string;
   year: number;
   duration: string;
   description: string;

--- a/tools/fill_discovery_samples_cache.py
+++ b/tools/fill_discovery_samples_cache.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Fill the backend Discovery samples cache through local API endpoints.
+
+Start the backend first, then run this from the repo root:
+
+  python3 tools/fill_discovery_samples_cache.py --base-url http://localhost:5140
+
+The backend writes results to:
+  backend/Capstone.API/Data/discovery_samples_cache.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any, Iterable
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CACHE_PATH = REPO_ROOT / "backend" / "Capstone.API" / "Data" / "discovery_samples_cache.json"
+
+
+def request_json(base_url: str, path: str, timeout: int) -> Any:
+    url = f"{base_url.rstrip('/')}{path}"
+    with urllib.request.urlopen(url, timeout=timeout) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def chunks(values: list[str], size: int) -> Iterable[list[str]]:
+    for index in range(0, len(values), size):
+        yield values[index:index + size]
+
+
+def load_cache() -> dict[str, dict[str, Any]]:
+    if not CACHE_PATH.exists():
+        return {}
+
+    with CACHE_PATH.open(encoding="utf-8") as file:
+        rows = json.load(file)
+
+    cache: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        country_code = str(row.get("countryCode", "")).strip().upper()
+        year = int(row.get("year", 0) or 0)
+        if country_code and year:
+            cache[f"{country_code}::{year}"] = row
+    return cache
+
+
+def has_values(cache: dict[str, dict[str, Any]], country_code: str, year: int, field: str) -> bool:
+    row = cache.get(f"{country_code.upper()}::{year}", {})
+    values = row.get(field, [])
+    return isinstance(values, list) and any(str(value).strip() for value in values)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Fill backend Discovery genre/language sample cache.")
+    parser.add_argument("--base-url", default="http://localhost:5140", help="Backend base URL.")
+    parser.add_argument("--years", nargs="*", type=int, help="Optional year list. Defaults to /api/metadata/years.")
+    parser.add_argument("--batch-size", type=int, default=8, help="Country codes per endpoint call. Max endpoint cap is 16.")
+    parser.add_argument("--timeout", type=int, default=120, help="HTTP timeout seconds.")
+    parser.add_argument("--sleep", type=float, default=0.1, help="Pause between endpoint calls.")
+    parser.add_argument("--force", action="store_true", help="Request samples even when cache already has values.")
+    parser.add_argument("--languages-only", action="store_true", help="Only fill language samples.")
+    parser.add_argument("--genres-only", action="store_true", help="Only fill genre samples.")
+    parser.add_argument("--favorite-artists-only", action="store_true", help="Only fill favorite artist samples.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    mode_flags = [args.languages_only, args.genres_only, args.favorite_artists_only]
+    if sum(1 for enabled in mode_flags if enabled) > 1:
+        raise SystemExit("Use only one of --languages-only, --genres-only, or --favorite-artists-only.")
+
+    batch_size = max(1, min(args.batch_size, 16))
+    years = args.years or [int(value) for value in request_json(args.base_url, "/api/metadata/years", args.timeout)]
+    years = sorted(set(years))
+
+    print(f"[cache] {CACHE_PATH}")
+    print(f"[years] {', '.join(str(year) for year in years)}")
+
+    for year in years:
+        countries = request_json(args.base_url, f"/api/discovery/countries?year={year}", args.timeout)
+        codes = sorted({
+            str(row.get("countryCode", "")).strip().upper()
+            for row in countries
+            if str(row.get("countryCode", "")).strip()
+        })
+        cache = load_cache()
+        missing_genres = [code for code in codes if args.force or not has_values(cache, code, year, "genres")]
+        missing_languages = [code for code in codes if args.force or not has_values(cache, code, year, "languages")]
+        missing_favorite_artists = [code for code in codes if args.force or not has_values(cache, code, year, "favoriteArtists")]
+
+        print(
+            f"[year {year}] countries={len(codes)} "
+            f"missing_genres={len(missing_genres)} "
+            f"missing_languages={len(missing_languages)} "
+            f"missing_favorite_artists={len(missing_favorite_artists)}"
+        )
+
+        if not args.languages_only and not args.favorite_artists_only:
+            for group in chunks(missing_genres, batch_size):
+                query = urllib.parse.urlencode({"year": year, "codes": ",".join(group)})
+                print(f"  [genres] {','.join(group)}")
+                request_json(args.base_url, f"/api/country/genre-samples?{query}", args.timeout)
+                time.sleep(args.sleep)
+
+        if not args.genres_only and not args.favorite_artists_only:
+            for group in chunks(missing_languages, batch_size):
+                query = urllib.parse.urlencode({"year": year, "codes": ",".join(group)})
+                print(f"  [languages] {','.join(group)}")
+                request_json(args.base_url, f"/api/country/language-samples?{query}", args.timeout)
+                time.sleep(args.sleep)
+
+        if not args.genres_only and not args.languages_only:
+            for code in missing_favorite_artists:
+                print(f"  [favorite-artists] {code}")
+                request_json(args.base_url, f"/api/country/{code}?year={year}", args.timeout)
+                time.sleep(args.sleep)
+
+    print("[done] Discovery samples cache fill requested.")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except urllib.error.URLError as exc:
+        raise SystemExit(f"Backend request failed: {exc}") from exc

--- a/tools/presentation_data_prep.py
+++ b/tools/presentation_data_prep.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Warm backend data needed for the presentation demo.
+
+Start the backend first, then run this from the repo root:
+
+  python3 tools/presentation_data_prep.py --base-url http://localhost:5140
+
+The tool prompts for the screen area, country range, and years to prep.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+AVAILABLE_YEAR_CHOICES = [2025, 2024, 2023, 2021, 2020, 2019, 2018, 2017]
+COUNTRY_RANGE_SIZE = 10
+
+
+def request_json(base_url: str, path: str, timeout: int) -> Any:
+    url = f"{base_url.rstrip('/')}{path}"
+    with urllib.request.urlopen(url, timeout=timeout) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Warm presentation data for selected countries and years.")
+    parser.add_argument("--base-url", default="http://localhost:5140", help="Backend base URL.")
+    parser.add_argument("--hidden-gems-pages", type=int, default=3, help="Hidden Gems pages to warm per country/year.")
+    parser.add_argument("--hidden-gems-page-size", type=int, default=13, help="Hidden Gems page size used by the UI.")
+    parser.add_argument("--country-song-page-size", type=int, default=50, help="Country page shared/unique song page size.")
+    parser.add_argument("--timeout", type=int, default=180, help="HTTP timeout seconds.")
+    parser.add_argument("--sleep", type=float, default=0.15, help="Pause between endpoint calls.")
+    return parser.parse_args()
+
+
+def unique_country_codes(rows: list[Any]) -> list[str]:
+    codes: list[str] = []
+    seen: set[str] = set()
+    for row in rows:
+        code = str(row.get("countryCode", "")).strip().upper() if isinstance(row, dict) else ""
+        if len(code) != 2 or code in seen:
+            continue
+        seen.add(code)
+        codes.append(code)
+    return codes
+
+
+def request_samples(base_url: str, year: int, codes: list[str], timeout: int, sleep: float) -> None:
+    if not codes:
+        return
+
+    query = urllib.parse.urlencode({"year": year, "codes": ",".join(codes)})
+    print(f"  [genre-samples] {','.join(codes)}")
+    request_json(base_url, f"/api/country/genre-samples?{query}", timeout)
+    time.sleep(sleep)
+
+    print(f"  [language-samples] {','.join(codes)}")
+    request_json(base_url, f"/api/country/language-samples?{query}", timeout)
+    time.sleep(sleep)
+
+
+def warm_discovery_map(args: argparse.Namespace, year: int, codes: list[str]) -> None:
+    request_samples(args.base_url, year, codes, args.timeout, args.sleep)
+
+
+def warm_country_pages(args: argparse.Namespace, year: int, code: str) -> None:
+    print(f"  [country-profile] {code}")
+    request_json(args.base_url, f"/api/country/{code}?year={year}", args.timeout)
+    time.sleep(args.sleep)
+
+    for list_type in ("unique", "shared"):
+        query = urllib.parse.urlencode({
+            "year": year,
+            "listType": list_type,
+            "page": 1,
+            "pageSize": args.country_song_page_size,
+        })
+        print(f"  [country-songs:{list_type}] {code}")
+        request_json(args.base_url, f"/api/country/{code}/songs?{query}", args.timeout)
+        time.sleep(args.sleep)
+
+    preview_query = urllib.parse.urlencode({"year": year, "limit": args.hidden_gems_page_size})
+    print(f"  [country-hidden-gems-preview] {code}")
+    request_json(args.base_url, f"/api/country/{code}/hidden-gems/preview?{preview_query}", args.timeout)
+    time.sleep(args.sleep)
+
+
+def warm_hidden_gems(args: argparse.Namespace, year: int, code: str) -> None:
+    for page in range(1, max(1, args.hidden_gems_pages) + 1):
+        query = urllib.parse.urlencode({
+            "year": year,
+            "minCountries": 2,
+            "page": page,
+            "pageSize": args.hidden_gems_page_size,
+        })
+        print(f"  [hidden-gems:p{page}] {code}")
+        request_json(args.base_url, f"/api/hidden-gems/{code}?{query}", args.timeout)
+        time.sleep(args.sleep)
+
+
+def print_welcome() -> None:
+    print()
+    print("Welcome to mp3li's Presentation Data Prep Tool")
+    print()
+
+
+def ask_number(prompt: str, valid_choices: set[int]) -> int:
+    while True:
+        value = input(prompt).strip()
+        try:
+            choice = int(value)
+        except ValueError:
+            print("Please enter one of the listed numbers.")
+            continue
+
+        if choice in valid_choices:
+            return choice
+
+        print("Please enter one of the listed numbers.")
+
+
+def ask_prep_mode() -> int:
+    print("1: Prep Discovery Map")
+    print("2: Prep Country Pages")
+    print("3: Prep Hidden Gems")
+    print()
+    return ask_number("Pick one: ", {1, 2, 3})
+
+
+def ask_country_range(max_country_count: int) -> int:
+    option_count = max(1, (max_country_count + COUNTRY_RANGE_SIZE - 1) // COUNTRY_RANGE_SIZE)
+    print()
+    print("Which countries?")
+    print()
+    print("0: All countries (will take a long time)")
+    for option in range(1, option_count + 1):
+        start = (option - 1) * COUNTRY_RANGE_SIZE
+        end = min(start + COUNTRY_RANGE_SIZE, max_country_count)
+        if start == 0:
+            print(f"{option}: First {end}")
+        else:
+            print(f"{option}: {start}th to {end}th")
+    print()
+    return ask_number("Pick one: ", set(range(0, option_count + 1)))
+
+
+def ask_years() -> list[int]:
+    print()
+    print("Which years:")
+    print()
+    print("0: All years (Will take a long time)")
+    for index, year in enumerate(AVAILABLE_YEAR_CHOICES, start=1):
+        print(f"{index}: {year}")
+    print()
+    choice = ask_number("Pick one: ", set(range(0, len(AVAILABLE_YEAR_CHOICES) + 1)))
+    if choice == 0:
+        return AVAILABLE_YEAR_CHOICES
+    return [AVAILABLE_YEAR_CHOICES[choice - 1]]
+
+
+def select_country_codes(codes: list[str], range_choice: int) -> list[str]:
+    if range_choice == 0:
+        return codes
+
+    start = (range_choice - 1) * COUNTRY_RANGE_SIZE
+    end = start + COUNTRY_RANGE_SIZE
+    return codes[start:end]
+
+
+def load_country_count_for_menu(args: argparse.Namespace) -> int:
+    countries = request_json(args.base_url, f"/api/discovery/countries?year={AVAILABLE_YEAR_CHOICES[0]}", args.timeout)
+    codes = unique_country_codes(countries if isinstance(countries, list) else [])
+    return len(codes)
+
+
+def main() -> int:
+    args = parse_args()
+    print_welcome()
+    prep_mode = ask_prep_mode()
+    max_country_count = load_country_count_for_menu(args)
+    country_range = ask_country_range(max_country_count)
+    years = ask_years()
+
+    mode_label = {
+        1: "Discovery Map",
+        2: "Country Pages",
+        3: "Hidden Gems",
+    }[prep_mode]
+
+    print()
+    print(f"[presentation-data-prep] {mode_label}")
+    print(f"[years] {', '.join(str(year) for year in years)}")
+
+    for year in years:
+        countries = request_json(args.base_url, f"/api/discovery/countries?year={year}", args.timeout)
+        all_codes = unique_country_codes(countries if isinstance(countries, list) else [])
+        codes = select_country_codes(all_codes, country_range)
+        print(f"[year {year}] {','.join(codes)}")
+
+        if prep_mode == 1:
+            warm_discovery_map(args, year, codes)
+            continue
+
+        for code in codes:
+            if prep_mode == 2:
+                warm_country_pages(args, year, code)
+            elif prep_mode == 3:
+                warm_hidden_gems(args, year, code)
+
+    print("[done] Presentation data prep requests completed.")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except urllib.error.URLError as exc:
+        raise SystemExit(f"Backend request failed: {exc}") from exc


### PR DESCRIPTION
# Implement Language Data Across the App and Create Presentation Data Prep Tool for Loading Optimization

## Summary

_This PR completes Issue 123: Implement Language Data Across the App._

The branch uses the finished `mp3li Additional Data Getter v2` language output to display real detected language data in the app without requiring a new database table yet. This is intentionally a presentation-ready first iteration. The long-term plan is still to move the finalized language dataset into the database and replace the file-backed lookup with database-backed queries.

This branch also adds a local presentation-data preparation path so the demo can run faster and more predictably for the highest-priority 2024 and 2025 flows. The preparation tool is able to warm all countries and all years, for all pages upon request and can also implement warming in small specific batches. Only warming 2024 and 2025 is not mandatory, and was only implemented as an example. If we decide we want to show different year(s) in the presentation, the tool is set up to prepare us to do so. 

The Discovery Map screen has been 100% prepared for years 2025 and 2024, and the first 20 countries for 2024 and 2025 are currently in the process of being prepared. 

_Also mentioned below: The larger generated CSV/JSON/TXT language output files are not included directly in this PR. They will be uploaded to a private file-sharing location, and the link will be provided privately to the project manager for review and future database-import planning._

## Important Implementation Context

Language detection is song-level data. It is not a full country-wide language average yet.

For this first iteration:

- the Genius matching workflow attempted validation across 232,388 de-duplicated input rows and recorded 349,310 URL-matching strategy steps, with up to 12 attempted match strategies for a song before skipping it. That produced 107,282 validated Genius lyrics URL rows. After lyrics retrieval, language detection, and app-facing cleanup/deduping, the committed language dataset contains 105,446 unique song + artist matches with both a Genius lyrics URL and detected language data, covering about 45% of the de-duplicated input list.
- the backend reads a compact language lookup generated from the completed language output
- the frontend displays language data where the relevant songs are already loaded
- Discovery Map language summaries are sample-based for the selected country/year
- Country Detail and Comparison View language summaries are sample-based and worded as examples from loved songs, not full statistical claims
- songs with no usable language result fail gracefully
- songs with valid Genius lyrics URLs expose a Genius lyrics link
- instrumental language results can display as instrumental instead of showing unavailable language text

## Work Performed

### 1) Added compact language data for app use

- Generated a compact backend language data file from the finished `language_ready_matches.csv` output.
- Kept only the fields the app needs:
  - normalized song title
  - normalized artist name
  - display song title
  - display artist name
  - Genius lyrics URL
  - detected language values
- Avoided loading the full CSV/JSON/TXT export directly in the frontend.

### 2) Added file-backed backend language lookup

- Added a backend lookup service that reads the compact language dataset once and caches it in memory.
- Matches songs by normalized song title and normalized artist name.
- Returns no result safely when a song is not in the language dataset.
- Keeps the first iteration separate from the future database-backed version.

### 3) Added backend language endpoints

- Added song language lookup for visible/paged song lists.
- Added country language sample lookup for Discovery Map summaries.
- Kept the route shape focused on what the current UI needs.

### 4) Implemented Discovery Map language display

- Added language sample loading beside the existing genre sample loading.
- Mirrored the existing genre-sample behavior by using selected country/year songs and preferred title prefixes.
- Skips duplicate language values while trying to collect up to three distinct languages.
- Accepts fewer than three values when the available sample keeps repeating.
- Formats language text without language detector codes, for example:
  - `English, Spanish, Bulgarian, and more`
  - `English, Spanish and more`
  - `English and more`
- Keeps hovered/selected countries prioritized so the country the user is interacting with resolves first.
- Prefetches visible list rows in chunks so cached Discovery language/genre data appears quickly instead of waiting for each row to be hovered.

### 5) Added Discovery sample persistence

- Added a backend file-backed sample cache for Discovery genre and language samples.
- The backend reads `Data/discovery_samples_cache.json` before recomputing samples.
- Normal app browsing can seed this local cache while the user lets Discovery Map load.
- The frontend still falls back to normal loading behavior when a sample has not been cached yet.
- Current local presentation prep focuses on preloading 2024 and 2025 Discovery Map samples.

### 6) Displayed language data in Country Detail and Comparison View

- Enriched loaded country/comparison song samples with language data.
- Replaced placeholder language copy with sample-based language text.
- Updated wording so the UI says languages are featured in loved songs rather than claiming a complete country-wide language breakdown.
- Decoupled the stat squares and summary subsections from slower page sections so they render as soon as their own data is ready.
- Updated the Genre + Language Mix copy to use the same sample-based genre/language behavior.

### 7) Added presentation response caching for country/comparison/demo pages

- Added a local backend presentation-data cache for endpoint responses that power:
  - Country Detail profile data
  - Country Detail shared/unique song pages
  - Country hidden-gems previews
  - Hidden Gems pages
- Country Detail and Comparison View use the same country profile and song-list endpoints, so both can benefit when presentation data has already been warmed.
- If cached data exists, the backend can return it from `Data/presentation_data_cache.json`.
- If cached data does not exist, the backend uses the normal live repository/provider path and saves the response for future reuse.
- This is preparation for the presentation and future database work; it does not replace the long-term database-backed architecture.

### 8) Added the presentation data prep tool

- Added `tools/presentation_data_prep.py`.
- The tool opens with:
  - `Welcome to mp3li's Presentation Data Prep Tool`
- It prompts for:
  - Discovery Map data
  - Country Pages data
  - Hidden Gems data
  - country range
  - year
- The tool can prep all countries or numbered country ranges such as first 10, 10th to 20th, and so on.
- The tool supports the currently relevant presentation years:
  - 2025
  - 2024
  - 2023
  - 2021
  - 2020
  - 2019
  - 2018
  - 2017
- Presentation plan:
  - preload Discovery Map samples for 2024 and 2025
  - preload the first 20 countries for 2024 and 2025 for Country Detail / Comparison View paths
  - preload the matching Hidden Gems pages needed for the live demo
- The tool is written so Leena can also use it later to warm or inspect data from app screens that still depend on external API/provider-backed enrichment before a database-backed version exists.

### 9) Displayed language data and lyrics links in Hidden Gems

- Enriched Hidden Gems page songs with language data.
- Shows real detected language values under the big CD only when a valid language result exists.
- Adds a final Lyrics row under the big CD metadata list when a valid Genius lyrics URL exists.
- Lyrics row text:
  - `Lyrics: Click here to view lyrics for this song on the Genius website`
- Clicking the Lyrics row opens the song's Genius lyrics page.
- Instrumental cases show:
  - `Language(s): This song is an instrumental`
  - `Lyrics: This song is an instrumental`
- Non-matches, 404s, not-transcribed pages, no-usable-lyrics pages, and failed language cases do not show language or lyrics rows under the big CD.

### 10) Loading and interaction fixes included in this branch

- Restored Discovery map-to-list hover behavior while preventing list-hover auto-scroll loops.
- Stopped loading ellipses from resizing list rows.
- Kept Discovery list rows stable while genre/language samples load.
- Increased initial Discovery sample prefetching and chunked requests so cached rows populate quickly after frontend reload.
- Kept year changes tied to the selected year so samples and language text update correctly.
- Adjusted Hidden Gems list scrolling so the scroll track stays out of the pagination controls.

## Presentation Reliability Plan

For the presentation, local data will be warmed ahead of time through the presentation prep tool where practical.

The presentation setup will also include three thumb-drive backups of the needed project files and local data files so the demo can recover if the main working copy has a machine or file issue during setup.

The larger generated CSV/JSON/TXT language output files are not included directly in this PR. They will be uploaded to a private file-sharing location, and the link will be provided privately to the project manager for review and future database-import planning.

## Not Included In This First Iteration

- No new database table.
- No database import script.
- No dedicated SQL language queries yet.
- No language filters.
- No full-country language averages.
- No rerun of the Genius matching workflow.

## Verification

- `python3 -m py_compile tools/fill_discovery_samples_cache.py tools/presentation_data_prep.py`
- `dotnet build Capstone.API.csproj`
- `npx tsc --noEmit`
- `git diff --check`

## Browser / Mobile Checks For Reviewer

- Discovery Map shows sampled language summaries instead of coming-soon language copy.
- Discovery Map cached genre/language samples populate quickly for visible rows.
- Discovery Map hover still focuses the country on the map and keeps the country visible in the list.
- Country Detail language sections show sample-based language text instead of placeholder-only copy.
- Comparison View language sections show sample-based language text instead of placeholder-only copy.
- Country Detail / Comparison summary stat squares and genre/language sections render independently from slower downstream sections.
- Hidden Gems selected song shows detected language values when a valid language match exists.
- Hidden Gems selected song shows the Lyrics row last under the big CD only when a Genius URL exists.
- Hidden Gems instrumental songs show instrumental text for both language and lyrics.
- Hidden Gems non-matches do not show language or lyrics rows under the big CD.
- Lyrics links open externally to Genius.
