### PR TITLE
Completed Issue 32 Frontend Mobile Adaptation Dashboard Screen

### DIFF
--- a/Documentation/QA-log.md
+++ b/Documentation/QA-log.md
@@ -3,6 +3,49 @@
 
 ---
 
+## 2026-05-17 — Discovery Dashboard Mobile Adaptation Follow-Up
+
+**Tester:** mp3li / Codex-assisted verification
+**Fix owner:** mp3li / Codex-assisted implementation
+**Scope:** Native/mobile Discovery Dashboard, compact web Dashboard behavior, Welcome routing/presentation, KPI flip-card sizing, Dashboard loading text
+
+### What I noticed
+
+The native/mobile Dashboard needed to match the narrow web Dashboard experience more completely. During mobile testing, several follow-up issues appeared around Welcome routing, KPI flip-card sizing, clipped large numbers, and loading copy.
+
+### What was fixed
+
+- Rebuilt the native/mobile Dashboard path so it includes the full Dashboard story structure instead of a simplified placeholder.
+- Replaced web-only Recharts charts on native/mobile with app-owned React Native chart components.
+- Preserved API-backed Dashboard data for mobile chart values.
+- Added tap-selected chart states so mobile users can inspect values without hover.
+- Fixed Welcome route selection so tapping Discovery Dashboard from Welcome does not briefly show Discovery Map first.
+- Updated compact/native Welcome behavior so the header, breadcrumb trail, and mobile bottom nav stay visible and usable.
+- Preserved wide-web Welcome behavior with the translucent overlay above the Discovery Globe.
+- Added feature-specific animated loading text: `Loading Discovery Dashboard...`.
+- Added right-side breathing room for large numeric Dashboard values that were clipping on mobile.
+- Fixed KPI flip cards so they keep the same size before and after being flipped on native mobile and compact web widths.
+
+### How to test
+
+1. Open the app in Expo native mobile.
+2. Open Welcome and confirm the header, breadcrumb trail, and mobile bottom nav remain visible.
+3. Tap Discovery Dashboard from Welcome and confirm it does not flash Discovery Map first.
+4. Confirm every Dashboard section appears on mobile: hero, selector, KPI cards, Chapters 1-4, chart cards, conclusion, and About This Data.
+5. Tap KPI cards and confirm they flip without changing height.
+6. Tap chart bars/rows and confirm selected-value states work.
+7. Confirm large values such as percentages, point values, and ceiling country counts are not clipped.
+8. Resize web to mobile width and confirm compact web KPI flip cards also keep the same height.
+
+### Verification
+
+- User verified the native/mobile Welcome behavior worked after the compact/native presentation fix.
+- User verified the mobile Dashboard sections, chart values, selected states, and scrolling behavior.
+- User verified the KPI flip-card height fix on native mobile and then requested the same compact-web fix.
+- `npm run typecheck` passed after the final Dashboard/Welcome changes.
+
+---
+
 ## 2026-05-15 — Dashboard Issue 128 Frontend Fixes and Discovery Dashboard Rename
 
 **Tester:** mp3li / Codex-assisted verification

--- a/Documents/mp3li implementation timeline document.txt
+++ b/Documents/mp3li implementation timeline document.txt
@@ -1,6 +1,96 @@
 mp3li implementation timeline document
 
-Updated: May 15, 2026
+Updated: May 17, 2026
+
+Discovery Dashboard Mobile Adaptation and Welcome Routing Fixes (May 17, 2026)
+- Objective:
+  - Adapt the Discovery Dashboard for mobile/native use without changing the intended desktop web dashboard experience.
+  - Preserve the narrow-web dashboard structure on mobile while replacing web-only Recharts charts with mobile-native chart components.
+  - Fix mobile welcome/dashboard navigation issues found during hands-on Expo testing.
+
+- Mobile Discovery Dashboard implementation completed:
+  - Rebuilt the native `DashboardScreen.tsx` from the prior simplified mobile placeholder into a full mobile Discovery Dashboard experience.
+  - Matched the web dashboard's narrow layout structure, including hero, country selector, KPI cards, Chapters 1-4, chart cards, warning tags, CTA rows, Chapter 4 song/CD reference, conclusion cards, and About This Data.
+  - Implemented native chart components with React Native views and gradients instead of Recharts.
+  - Added vertical bar/histogram and horizontal ranking chart behavior for the mobile dashboard chapters.
+  - Added tap-based selected states and value panels so mobile users can inspect chart values without hover.
+  - Preserved real API-backed dashboard data instead of introducing fake mobile-only chart data.
+
+- Mobile interaction and layout fixes completed:
+  - Added Dashboard CTA callbacks so mobile dashboard buttons can open Discovery Map, Hidden Gems, and Comparison paths.
+  - Fixed Welcome button routing so choosing Discovery Dashboard no longer flashes through Discovery Map first.
+  - Updated compact/native Welcome presentation so the header, breadcrumbs, and mobile bottom nav remain visible and usable while the Welcome panel is active.
+  - Kept wide web Welcome behavior as the approved translucent modal over the Discovery Globe.
+  - Added animated `Loading Discovery Dashboard...` loading text for both native/mobile and web dashboard loading paths.
+  - Fixed clipped dashboard numbers by adding breathing room to large display-number styles.
+  - Fixed KPI flip-card resizing by giving KPI cards fixed heights on native mobile and resized/mobile-width web.
+
+- Documentation updated:
+  - Updated personal timeline with the mobile dashboard adaptation and follow-up testing fixes.
+  - Updated frontend architecture documentation to record the Dashboard web/native split and compact Welcome behavior.
+  - Updated screen data-flow documentation to describe native mobile Dashboard chart/data behavior.
+  - Updated interaction/loading documentation to record the compact/native Welcome rules and feature-specific Dashboard loading text.
+  - Updated the QA log with the mobile dashboard verification pass.
+
+- Verification completed:
+  - User tested on Expo native mobile.
+  - User tested resized-to-mobile web behavior.
+  - Ran frontend TypeScript checking after the final fixes.
+
+Language Data UI Integration, Discovery Sample Caching, and Presentation Prep Tool (May 17, 2026)
+- Objective:
+  - Complete the first presentation-ready app integration for the language dataset produced by `mp3li Additional Data Getter v2`.
+  - Keep the first iteration file-backed instead of adding a database table before presentation.
+  - Add local presentation-prep support so the demo can use warmed data for the highest-priority 2024 and 2025 flows while preserving the long-term plan to move stable data into the database.
+
+- Backend language integration completed:
+  - Added a compact file-backed language dataset under the backend `Data/` path.
+  - Added a language lookup service that loads the compact language file once and matches by normalized song title plus normalized artist name.
+  - Added backend language endpoints for visible song lookup and country/year language samples.
+  - Kept missing language matches, missing lyrics, failed Genius pages, and detection failures non-blocking.
+
+- Discovery Map language and loading behavior completed:
+  - Replaced coming-soon language copy with sampled country/year language summaries.
+  - Matched the existing genre sample behavior by using preferred title prefixes and skipping duplicate language values where possible.
+  - Removed detector-code display from the UI wording, so summaries display as language names.
+  - Added backend file-backed Discovery sample caching for genre/language/favorite-artist samples.
+  - Updated Discovery list loading so cached genre/language samples can populate visible rows quickly after a frontend restart instead of waiting for each row to be hovered.
+  - Kept hovered/selected countries prioritized so user interaction still resolves first.
+  - Preserved globe-to-list focus behavior while preventing list-hover auto-scroll loops.
+
+- Country Detail and Comparison View updates completed:
+  - Replaced language placeholder text with sample-based language copy.
+  - Updated wording so language sections describe languages featured in loved songs rather than claiming complete country-wide language averages.
+  - Changed loved-genre wording to use sample genres consistently.
+  - Decoupled stat squares and genre/language summary sections from slower downstream data so those sections render as soon as their own data is available.
+  - Added backend presentation-cache support for country profile, country song-list, and country hidden-gem preview payloads so warmed country/comparison demo data can be reused when present.
+
+- Hidden Gems updates completed:
+  - Enriched loaded Hidden Gems rows with language data.
+  - Added the Genius lyrics row as the last metadata item under the big CD when a valid lyrics URL exists.
+  - Hid the language and lyrics rows for failed/no-match language cases.
+  - Preserved instrumental handling by showing "This song is an instrumental" for both language and lyrics when the language output marks the song as instrumental.
+  - Adjusted the Hidden Gems list scrollbar so it no longer interferes with pagination controls.
+  - Added backend presentation-cache support for warmed Hidden Gems page payloads.
+
+- Presentation prep and local reliability work completed:
+  - Added `tools/presentation_data_prep.py` as an interactive presentation data prep tool.
+  - The tool supports Discovery Map, Country Pages, and Hidden Gems prep modes.
+  - The tool prompts for country ranges and years so it can be used for 2024/2025 presentation prep or broader future data pulls.
+  - Current presentation plan is to preload Discovery Map data for 2024 and 2025 and preload the first 20 countries for 2024 and 2025 for Country Detail / Comparison View demo paths.
+  - The local presentation setup will include three thumb-drive backups of the required project and local data files as a fallback for presentation setup issues.
+
+- Documentation and PR artifacts updated:
+  - Updated the personal timeline with this language-data and presentation-prep work.
+  - Updated frontend screen data-flow documentation to record language endpoints, frontend/backend cache behavior, Discovery prefetching, and the presentation prep tool.
+  - Updated backend project integration endpoint documentation to record language endpoints, local file-backed language data, Discovery sample caching, presentation response caching, and the prep tool.
+  - Updated the PR markdown in `my txts/PR_Implement_Language_Data_Across_the_App.md`.
+
+- Verification completed:
+  - Ran Python compile checks for the presentation/cache helper scripts.
+  - Ran backend `dotnet build`.
+  - Ran frontend TypeScript checking.
+  - Ran `git diff --check`.
 
 Dashboard Issue 128 Frontend Polish, Discovery Dashboard Rename, and PR Handoff (May 15, 2026)
 - Objective:

--- a/hidden-gem-music-app/App.tsx
+++ b/hidden-gem-music-app/App.tsx
@@ -3,7 +3,7 @@ import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { useFonts } from "expo-font";
 import { StatusBar } from "expo-status-bar";
 import { Component, ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Pressable, StyleSheet, Text, View } from "react-native";
+import { Platform, Pressable, StyleSheet, Text, useWindowDimensions, View } from "react-native";
 
 import { AppHeader } from "./src/components/AppHeader";
 import { LoadingOverlay } from "./src/components/LoadingOverlay";
@@ -239,6 +239,8 @@ class AppErrorBoundary extends Component<{ children: ReactNode }, { hasError: bo
 }
 
 export default function App() {
+  const { width } = useWindowDimensions();
+  const shouldUseWelcomeModalPresentation = Platform.OS === "web" && width >= 980;
   const [fontsLoaded] = useFonts({
     "NyghtSerif-MediumItalic": require("./src/assets/fonts/nyght-serif-main/fonts/TTF/NyghtSerif-MediumItalic.ttf"),
     "NyghtSerif-Regular": require("./src/assets/fonts/nyght-serif-main/fonts/TTF/NyghtSerif-Regular.ttf"),
@@ -517,19 +519,82 @@ export default function App() {
       return;
     }
 
-    if (navigationRef.canGoBack()) {
-      navigationRef.goBack();
-    } else {
-      navigationRef.navigate("discovery", getRouteParams("discovery", selectedYear, selectedCountryId));
+    if (route === "hiddenGems") {
+      clearHiddenGemsHandoffMarker();
+      setShowHiddenGemsNavIntro(true);
+      setHiddenGemsFocusSelection(null);
     }
 
-    if (route === "discovery") {
-      return;
+    if (route === "comparisonSelect") {
+      setComparisonIds([]);
     }
 
-    globalThis.setTimeout(() => {
-      navigateToRoute(route);
-    }, 40);
+    switch (route) {
+      case "discovery":
+        navigationRef.dispatch(
+          CommonActions.reset({
+            index: 0,
+            routes: [{ name: "discovery", params: getRouteParams("discovery", selectedYear, selectedCountryId) }],
+          })
+        );
+        break;
+      case "country":
+        navigationRef.dispatch(
+          CommonActions.reset({
+            index: 0,
+            routes: [{ name: "country", params: getRouteParams("country", selectedYear, selectedCountryId) }],
+          })
+        );
+        break;
+      case "hiddenGems":
+        navigationRef.dispatch(
+          CommonActions.reset({
+            index: 0,
+            routes: [{ name: "hiddenGems" }],
+          })
+        );
+        break;
+      case "comparisonSelect":
+        navigationRef.dispatch(
+          CommonActions.reset({
+            index: 0,
+            routes: [{ name: "comparisonSelect", params: getRouteParams("comparisonSelect", selectedYear, selectedCountryId) }],
+          })
+        );
+        break;
+      case "comparisonResults":
+        navigationRef.dispatch(
+          CommonActions.reset({
+            index: 0,
+            routes: [{ name: "comparisonResults", params: getRouteParams("comparisonResults", selectedYear, selectedCountryId) }],
+          })
+        );
+        break;
+      case "dashboard":
+        navigationRef.dispatch(
+          CommonActions.reset({
+            index: 0,
+            routes: [{ name: "dashboard" }],
+          })
+        );
+        break;
+      case "credits":
+        navigationRef.dispatch(
+          CommonActions.reset({
+            index: 0,
+            routes: [{ name: "credits" }],
+          })
+        );
+        break;
+      default:
+        navigationRef.dispatch(
+          CommonActions.reset({
+            index: 0,
+            routes: [{ name: "discovery", params: getRouteParams("discovery", selectedYear, selectedCountryId) }],
+          })
+        );
+        break;
+    }
   };
 
   const openHiddenGems = (selection?: HiddenGemsFocusSelection) => {
@@ -1065,9 +1130,9 @@ export default function App() {
                 name="welcome"
                 options={{
                   title: "Welcome",
-                  presentation: "transparentModal",
-                  animation: "fade",
-                  contentStyle: { backgroundColor: "transparent" },
+                  presentation: shouldUseWelcomeModalPresentation ? "transparentModal" : "card",
+                  animation: shouldUseWelcomeModalPresentation ? "fade" : "none",
+                  contentStyle: { backgroundColor: shouldUseWelcomeModalPresentation ? "transparent" : colors.background },
                 }}
               >
                 {() => (
@@ -1183,7 +1248,27 @@ export default function App() {
               </Stack.Screen>
 
               <Stack.Screen name="dashboard" options={{ title: "Dashboard" }}>
-                {() => <DashboardScreen year={selectedYear} metrics={[]} countries={countries} />}
+                {() => (
+                  <DashboardScreen
+                    year={selectedYear}
+                    metrics={[]}
+                    countries={countries}
+                    onOpenDiscovery={(countryCode) => {
+                      if (countryCode) {
+                        setSelectedCountryId(countryCode);
+                      }
+                      navigateToRoute("discovery");
+                    }}
+                    onOpenHiddenGems={(countryCode) => {
+                      if (countryCode) {
+                        openHiddenGemsForCountry(countryCode);
+                        return;
+                      }
+                      openHiddenGems();
+                    }}
+                    onOpenComparison={() => navigateToRoute("comparisonSelect")}
+                  />
+                )}
               </Stack.Screen>
 
               <Stack.Screen name="credits" component={CreditsScreen} options={{ title: "Credits" }} />

--- a/hidden-gem-music-app/Documentation/frontend-architecture.md
+++ b/hidden-gem-music-app/Documentation/frontend-architecture.md
@@ -96,6 +96,9 @@ Current exception:
 
 - Dashboard still has a web-specific file because the web dashboard uses `recharts`
 - The Dashboard user-facing label is `Discovery Dashboard`; the route key remains `dashboard`.
+- `src/screens/DashboardScreen.tsx` owns the native/mobile Dashboard implementation and uses app-owned React Native chart components instead of Recharts.
+- `src/screens/DashboardScreen.web.tsx` owns the desktop/web Dashboard implementation and still uses Recharts.
+- Compact web widths may share some mobile behavior expectations, such as stable KPI flip-card sizing and compact Welcome shell behavior, but the desktop web Dashboard file remains the web chart owner.
 
 ## Shared layout and visual language
 
@@ -201,6 +204,12 @@ Current naming/order rule:
 - `Discovery Dashboard` should appear directly after `Discovery Map` in both web and mobile navigation.
 - Welcome screen action buttons should follow the same order.
 - The team has discussed wanting a catchier dashboard name, but `Discovery Dashboard` is the current applied label until a replacement is chosen.
+
+Current Welcome presentation rule:
+
+- Wide web keeps the Welcome screen as a translucent modal over the Discovery Globe.
+- Native/mobile and compact widths use an in-screen Welcome presentation so the header, breadcrumb trail, and mobile bottom nav remain visible and usable.
+- Welcome route buttons should reset directly to the chosen route instead of briefly returning through Discovery first.
 
 ## Data layer ownership
 

--- a/hidden-gem-music-app/Documentation/interaction-loading-and-overlay-rules.md
+++ b/hidden-gem-music-app/Documentation/interaction-loading-and-overlay-rules.md
@@ -34,6 +34,10 @@ Current rules:
 - clicking outside the welcome modal should behave like the `Discovery Map` action, not like a dangerous bare click-through
 - welcome modal route buttons should close through the guarded route-transition path rather than bypassing the modal state
 - navigating to Welcome from the header or breadcrumbs should reset to the normal Welcome-over-Discovery stack, not layer the Welcome modal over the current active page
+- wide web should keep the translucent Welcome-over-Discovery behavior
+- native/mobile and compact widths should keep the header, breadcrumb trail, and mobile bottom nav visible and usable while Welcome is active
+- native/mobile and compact widths should use a gradient in the screen content area behind the Welcome panel instead of requiring the Discovery Globe to appear underneath
+- Welcome route buttons should navigate directly to the selected destination instead of briefly showing Discovery first
 - welcome route buttons should show visible pressed styling on mobile before route work begins
 - welcome dismissal must check whether navigation can go back before calling `goBack`
 - if there is no route to pop, welcome dismissal should navigate to Discovery instead of dispatching an unhandled back action
@@ -105,7 +109,22 @@ Current rules:
 - loading text should remain visually stable enough that sections do not jump excessively
 - shared loading text helpers should be reused instead of rebuilding one-off animated loading strings in many screens
 - shared/app-level loading copy should stay neutral as `Loading...` unless a feature-specific message is intentionally required
+- Discovery Dashboard is an intentional feature-specific exception and should use `Loading Discovery Dashboard...` with animated dots while its screen data is loading
 - Hidden Gems should not use a separate app-wide `Loading hidden gems...` message when the screen already has section-level loading treatment
+
+## Discovery Dashboard mobile interaction rules
+
+Main files:
+
+- `src/screens/DashboardScreen.tsx`
+- `src/screens/DashboardScreen.web.tsx`
+
+Current rules:
+
+- native/mobile Dashboard charts should use tap-selected details instead of hover-only tooltips
+- KPI flip cards should stay the same size before and after being tapped/flipped
+- large Dashboard numbers need enough right-side padding to avoid clipping on mobile display fonts
+- compact web Dashboard behavior should preserve the same no-shrink KPI flip-card behavior used on native mobile
 
 ## Discovery scroll and sidebar rules
 

--- a/hidden-gem-music-app/Documentation/screen-data-flow.md
+++ b/hidden-gem-music-app/Documentation/screen-data-flow.md
@@ -269,6 +269,9 @@ Current flow:
 3. Isolation scores are displayed only for countries included in the current `isolation-ranking` response.
 4. Countries with app data but no returned isolation score stay selectable and use honest no-score messaging rather than fake ranking values.
 5. Chapter 4 peak reach uses `albumArtUrl` from the Dashboard peak-reach response when available.
+6. The native/mobile Dashboard loads the same dashboard API data as the web Dashboard.
+7. Native/mobile charts are rendered with app-owned React Native views and gradients instead of Recharts.
+8. Mobile chart inspection uses tap-selected value states instead of hover tooltips.
 
 Important current rules:
 
@@ -277,6 +280,8 @@ Important current rules:
 - The country selector and isolation ranking chart do not currently have the same source: the selector uses app-data countries, while the chart uses `sp_GetIsolationRanking`.
 - `sp_GetIsolationRanking` currently returns the stored procedure result as-is; if the graph needs all isolation-score countries, the stored procedure/data-owner path needs to remove its `SELECT TOP 20` limit.
 - Peak reach art should come from backend enrichment when possible; the frontend can use a known fallback only to avoid a blank CD for the current peak song.
+- KPI flip cards should stay the same height when tapped/flipped on native mobile and compact web widths.
+- Dashboard loading copy intentionally uses the feature-specific `Loading Discovery Dashboard...` text with animated dots.
 
 ## Fetch timeout and retry behavior
 

--- a/hidden-gem-music-app/src/components/MobileBottomNav.tsx
+++ b/hidden-gem-music-app/src/components/MobileBottomNav.tsx
@@ -170,6 +170,7 @@ const styles = StyleSheet.create({
     paddingTop: 4,
     paddingBottom: 4,
     position: "relative",
+    zIndex: 700,
   },
   activeGradientSlot: {
     position: "absolute",

--- a/hidden-gem-music-app/src/screens/DashboardScreen.tsx
+++ b/hidden-gem-music-app/src/screens/DashboardScreen.tsx
@@ -1,182 +1,1907 @@
 import { LinearGradient } from "expo-linear-gradient";
-import { StyleSheet, Text, View } from "react-native";
+import { ReactNode, useEffect, useMemo, useState } from "react";
+import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
 
-import { DiscoveryBlurb } from "../components/DiscoveryBlurb";
-import { Panel } from "../components/Panel";
+import { CdCaseArt } from "../components/CdCaseArt";
+import { GemIcon } from "../components/GemIcon";
 import { ScreenScaffold } from "../components/ScreenScaffold";
-import { SecondarySurfaceFill } from "../components/SecondarySurfaceFill";
-import { Country } from "../types/content";
+import { loadAvailableYears } from "../data/countryApi";
+import { isCountryWithAppData } from "../data/countryDisplay";
+import { useLoadingText } from "../hooks/useLoadingText";
+import {
+  loadDiscoveryGap,
+  loadGapDistribution,
+  loadIsolationLeader,
+  loadIsolationRanking,
+  loadOverlapRate,
+  loadOverlapTrend,
+  loadPeakReach,
+} from "../data/dashboardApi";
+import { loadDiscoveryCountries } from "../data/discoveryApi";
 import { colors } from "../theme/colors";
 import { typefaces } from "../theme/typography";
+import type {
+  ApiDiscoveryGap,
+  ApiGapBucket,
+  ApiIsolationEntry,
+  ApiIsolationLeader,
+  ApiOverlapRate,
+  ApiPeakReach,
+  ApiTrendPoint,
+} from "../types/api";
+import { Country } from "../types/content";
 
 export type Props = {
-  year: number;
-  metrics: Array<{
-    label: string;
-    value: string;
-    detail: string;
-  }>;
-  countries: Country[];
+  year?: number;
+  metrics?: Array<{ label: string; value: string; detail: string }>;
+  countries?: Country[];
+  onOpenDiscovery?: (countryCode?: string) => void;
+  onOpenHiddenGems?: (countryCode?: string) => void;
+  onOpenComparison?: () => void;
 };
 
-function DashboardSection({ children }: { children: React.ReactNode }) {
+type CountrySelectorOption = {
+  isoCode: string;
+  countryName: string;
+  isolationScore: number | null;
+  isolationTier: "high" | "mid" | "low" | null;
+};
+
+type VerticalBarDatum = {
+  label: string;
+  value: number;
+  valueLabel: string;
+  isGap?: boolean;
+  isDimmed?: boolean;
+};
+
+const rowBackdropColors = ["#B86A72", "#8B9BC0", "#8B5E7A", "#627F8A", "#C28C5E", "#7A7EB0"];
+const heroGradient = ["#1a0a2e", "#0f0e17", "#1a1030"] as const;
+const globalAverageIsolation = 56;
+
+const kpiBar = {
+  purple: colors.accent,
+  blue: "#63b3ed",
+  red: "#f87171",
+  green: "#4ade80",
+};
+
+const isolationColors: Record<"high" | "mid" | "low", readonly [string, string]> = {
+  high: ["#f87171", "#B86A72"],
+  mid: ["#fb923c", "#C28C5E"],
+  low: ["#4ade80", "#627F8A"],
+};
+
+const knownPeakReachArt: Record<string, string> = {
+  "stay (with justin bieber)|the kid laroi":
+    "https://coverartarchive.org/release/9edb549d-b9cd-47b8-8b33-523b0bf8e301/front-500",
+};
+
+const aboutEntries = [
+  {
+    icon: "!",
+    iconType: "orange" as const,
+    title: "22-month data gap (Dec 2021-Oct 2023)",
+    body: "No data exists for this period. Trend lines are broken, not interpolated.",
+  },
+  {
+    icon: "!",
+    iconType: "orange" as const,
+    title: "2023 data covers Oct 17-Dec 31 only",
+    body: "Heavily Q4-weighted. Affects Hidden Gems, Country Profile, and any chart scoped to 2023.",
+  },
+  {
+    icon: "i",
+    iconType: "blue" as const,
+    title: "2017-2021 and 2023-2025 use different chart depths",
+    body: "2017-2021 data draws from the Top 200 chart. 2023-2025 data draws from the Top 50 chart. Both are streams-based demand charts, but 2017-2021 has deeper per-country coverage.",
+  },
+  {
+    icon: "i",
+    iconType: "blue" as const,
+    title: "Chart scope differs between time periods",
+    body: "Viral 50 entries are excluded from all calculations. Values are not directly comparable across the data gap.",
+  },
+  {
+    icon: "i",
+    iconType: "blue" as const,
+    title: "How isolation score is calculated",
+    body: "Isolation score = the percentage of a country's charting songs that appeared in no other country's charts during the same year.",
+  },
+];
+
+const iconColors = {
+  orange: "#fb923c",
+  blue: "#63b3ed",
+};
+
+function getKnownPeakReachArtUrl(songTitle?: string | null, artistName?: string | null) {
+  const key = `${songTitle ?? ""}|${artistName ?? ""}`.trim().toLowerCase();
+  return knownPeakReachArt[key];
+}
+
+async function loadDashboardCountriesWithAppData(fallbackCountries: Country[] = []) {
+  const years = await loadAvailableYears().catch(() => [2025]);
+  const countrySets = await Promise.all(
+    years.map((year) => loadDiscoveryCountries(year, fallbackCountries).catch(() => []))
+  );
+  const countriesByCode = new Map<string, Country>();
+
+  countrySets.flat().forEach((country) => {
+    if (!isCountryWithAppData(country)) {
+      return;
+    }
+
+    const code = country.code.toUpperCase();
+    const existing = countriesByCode.get(code);
+    if (!existing || country.hiddenSongs > existing.hiddenSongs) {
+      countriesByCode.set(code, country);
+    }
+  });
+
+  return Array.from(countriesByCode.values());
+}
+
+function CountrySelector({
+  data,
+  selectedCountry,
+  onSelect,
+  onClear,
+}: {
+  data: CountrySelectorOption[];
+  selectedCountry: CountrySelectorOption | null;
+  onSelect: (entry: CountrySelectorOption) => void;
+  onClear: () => void;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const tierLabel = (entry: CountrySelectorOption) => {
+    if (entry.isolationScore === null) {
+      return null;
+    }
+    if (entry.isolationScore > 65) {
+      return "highly isolated - most of your charts stay local";
+    }
+    if (entry.isolationScore >= 40) {
+      return "moderately isolated - some crossover, a lot still stays home";
+    }
+    return "well connected - your market overlaps heavily with global trends";
+  };
+
+  const rank = selectedCountry
+    ? data
+        .filter((entry) => entry.isolationScore !== null)
+        .findIndex((entry) => entry.isoCode === selectedCountry.isoCode) + 1
+    : null;
+  const selectedTierLabel = selectedCountry ? tierLabel(selectedCountry) : null;
+
   return (
-    <Panel style={styles.sectionPanel}>
-      <SecondarySurfaceFill />
-      <View style={styles.sectionContent}>{children}</View>
-    </Panel>
+    <View style={styles.countrySelectorWrap}>
+      <Pressable
+        style={({ pressed }) => [
+          styles.countrySelectorPill,
+          pressed ? styles.pressablePressed : null,
+        ]}
+        onPress={() => setIsOpen((current) => !current)}
+      >
+        <Text style={styles.countrySelectorText}>
+          {selectedCountry ? `Viewing: ${selectedCountry.countryName}` : "See where your country fits in"}
+        </Text>
+        <Text style={styles.countrySelectorChevron}>{isOpen ? "▲" : "▼"}</Text>
+      </Pressable>
+
+      {isOpen ? (
+        <ScrollView style={styles.countryDropdown} nestedScrollEnabled showsVerticalScrollIndicator={false}>
+          {data.map((entry) => (
+            <Pressable
+              key={entry.isoCode}
+              style={({ pressed }) => [
+                styles.countryDropdownItem,
+                selectedCountry?.isoCode === entry.isoCode ? styles.countryDropdownItemSelected : null,
+                pressed ? styles.pressablePressed : null,
+              ]}
+              onPress={() => {
+                onSelect(entry);
+                setIsOpen(false);
+              }}
+            >
+              <Text style={styles.countryDropdownName}>{entry.countryName}</Text>
+              {entry.isolationScore !== null ? (
+                <View style={styles.countryDropdownMeta}>
+                  <Text style={styles.countryDropdownScore}>{Math.round(entry.isolationScore)}%</Text>
+                  <Text style={styles.countryDropdownCaption}>isolation score</Text>
+                </View>
+              ) : null}
+            </Pressable>
+          ))}
+        </ScrollView>
+      ) : null}
+
+      {selectedCountry ? (
+        <View style={styles.countryBanner}>
+          <View style={styles.countryBannerLeft}>
+            <View style={styles.countryBannerDot} />
+            <Text style={styles.countryBannerText}>
+              <Text style={styles.countryBannerName}>{selectedCountry.countryName}</Text>
+              {selectedCountry.isolationScore !== null && selectedTierLabel ? (
+                <>
+                  {" "}has an isolation score of{" "}
+                  <Text style={styles.countryBannerName}>{Math.round(selectedCountry.isolationScore)}%</Text>
+                  {" - "}
+                  {selectedTierLabel}.
+                  {rank
+                    ? ` It's ranked #${rank} of ${data.filter((entry) => entry.isolationScore !== null).length} countries in the current isolation ranking.`
+                    : ""}
+                </>
+              ) : (
+                " is available in the app data. Isolation ranking data was not returned for this country."
+              )}
+            </Text>
+          </View>
+          <Pressable style={({ pressed }) => [styles.countryBannerClear, pressed ? styles.pressablePressed : null]} onPress={onClear}>
+            <Text style={styles.countryBannerClearText}>x clear</Text>
+          </Pressable>
+        </View>
+      ) : null}
+    </View>
   );
 }
 
-function KpiCard({ label, value, detail }: { label: string; value: string; detail: string }) {
+function ChapterLabel({ num, title }: { num: number; title: string }) {
   return (
-    <Panel style={styles.kpiCard}>
+    <View style={styles.chapterLabelRow}>
+      <View style={styles.chapterCircle}>
+        <Text style={styles.chapterNumber}>{num}</Text>
+      </View>
+      <Text style={styles.chapterTitle}>{title}</Text>
+    </View>
+  );
+}
+
+function PullStat({ number, unit, context }: { number: string; unit?: string; context: string }) {
+  return (
+    <View style={styles.pullStat}>
+      <View style={styles.pullStatDisplay}>
+        <Text style={styles.pullStatNumber}>{number}</Text>
+        {unit ? <Text style={styles.pullStatUnit}>{unit}</Text> : null}
+      </View>
+      <Text style={styles.pullStatContext}>{context}</Text>
+    </View>
+  );
+}
+
+function ArgumentText({ children }: { children: ReactNode }) {
+  return <Text style={styles.argument}>{children}</Text>;
+}
+
+function CtaButton({ label, primary, onPress }: { label: string; primary?: boolean; onPress: () => void }) {
+  return (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.ctaButton,
+        primary ? styles.ctaButtonPrimary : styles.ctaButtonSecondary,
+        pressed ? styles.ctaButtonPressed : null,
+      ]}
+    >
+      {primary ? (
+        <LinearGradient
+          colors={["rgba(117,82,107,0.36)", "rgba(108,119,142,0.2)"]}
+          start={{ x: 0, y: 0 }}
+          end={{ x: 1, y: 1 }}
+          style={StyleSheet.absoluteFillObject}
+        />
+      ) : null}
+      <Text style={[styles.ctaButtonText, primary ? styles.ctaButtonTextPrimary : styles.ctaButtonTextSecondary]}>
+        {label}
+      </Text>
+    </Pressable>
+  );
+}
+
+function CtaRow({ children }: { children: ReactNode }) {
+  return <View style={styles.ctaRow}>{children}</View>;
+}
+
+function WarningTag({ type, label }: { type: "orange" | "blue"; label: string }) {
+  return (
+    <View style={[styles.warningTag, type === "orange" ? styles.warningTagOrange : styles.warningTagBlue]}>
+      <Text style={[styles.warningTagText, { color: type === "orange" ? "#fb923c" : "#63b3ed" }]}>
+        {label}
+      </Text>
+    </View>
+  );
+}
+
+function ChapterCard({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <View style={styles.chapterCard}>
+      <Text style={styles.chapterCardLabel}>{label}</Text>
+      {children}
+    </View>
+  );
+}
+
+function KpiCard({ barColor, front, back }: { barColor: string; front: ReactNode; back: ReactNode }) {
+  const [flipped, setFlipped] = useState(false);
+  return (
+    <Pressable
+      style={({ pressed }) => [
+        styles.kpiCard,
+        flipped ? styles.kpiCardFlipped : null,
+        pressed ? styles.pressablePressed : null,
+      ]}
+      onPress={() => setFlipped((current) => !current)}
+    >
       <LinearGradient
-        colors={[colors.backgroundSoft, "#74819B", "#70536A"]}
-        locations={[0, 0.38, 1]}
-        start={{ x: 0.5, y: 0 }}
-        end={{ x: 0.5, y: 1 }}
-        style={styles.kpiFill}
+        colors={["rgba(255,255,255,0.055)", "rgba(117,82,107,0.075)", "rgba(108,119,142,0.055)"]}
+        style={StyleSheet.absoluteFillObject}
       />
-      <Text style={styles.kpiLabel}>{label}</Text>
-      <Text style={styles.kpiValue}>{value}</Text>
-      <Text style={styles.kpiDetail}>{detail}</Text>
-    </Panel>
+      <View style={[styles.kpiAccentBar, { backgroundColor: barColor }]} />
+      <View style={styles.kpiContent}>
+        {flipped ? (
+          back
+        ) : (
+          <View style={styles.kpiFrontShell}>
+            {front}
+            <Text style={styles.kpiFlipHint}>tap to flip</Text>
+          </View>
+        )}
+      </View>
+    </Pressable>
   );
 }
 
-export function DashboardScreen({ year, metrics, countries }: Props) {
-  const topCountries = countries.slice(0, 5);
+function VerticalBarChart({
+  data,
+  colors: gradientColors,
+  maxValue,
+  suffix = "",
+}: {
+  data: VerticalBarDatum[];
+  colors: readonly [string, string];
+  maxValue?: number;
+  suffix?: string;
+}) {
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  const computedMax = Math.max(maxValue ?? 0, ...data.map((item) => item.value), 1);
+  const selected = selectedIndex === null ? null : data[selectedIndex];
+
+  return (
+    <View style={styles.chartShell}>
+      <View style={styles.verticalChart}>
+        {data.map((item, index) => {
+          const height = item.isGap ? 100 : Math.max(8, (item.value / computedMax) * 140);
+          return (
+            <Pressable
+              key={`${item.label}-${index}`}
+              style={styles.verticalBarSlot}
+              onPress={() => setSelectedIndex((current) => (current === index ? null : index))}
+            >
+              <View style={styles.verticalBarValueWrap}>
+                {item.isGap ? (
+                  <View style={styles.gapMarker}>
+                    <View style={styles.gapLine} />
+                    <Text style={styles.gapLabel}>gap</Text>
+                  </View>
+                ) : (
+                  <View
+                    style={[
+                      styles.verticalBarOuter,
+                      {
+                        height,
+                        opacity: item.isDimmed ? 0.48 : 1,
+                        borderStyle: item.isDimmed ? "dashed" : "solid",
+                      },
+                    ]}
+                  >
+                    <LinearGradient
+                      colors={gradientColors}
+                      start={{ x: 0.5, y: 0 }}
+                      end={{ x: 0.5, y: 1 }}
+                      style={styles.verticalBarFill}
+                    />
+                  </View>
+                )}
+              </View>
+              <Text style={[styles.verticalBarLabel, item.isGap ? styles.gapText : null]} numberOfLines={2}>
+                {item.label}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </View>
+      <View style={styles.chartValuePanel}>
+        <Text style={styles.chartValueText}>
+          {selected ? `${selected.label}: ${selected.valueLabel}${suffix}` : "Tap a bar to view its value."}
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+function HorizontalIsolationChart({
+  data,
+  selectedCountry,
+}: {
+  data: ApiIsolationEntry[];
+  selectedCountry: CountrySelectorOption | null;
+}) {
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  const chartData = data.slice(0, 20);
+  const tapped = selectedIndex === null ? null : chartData[selectedIndex];
+
+  return (
+    <View style={styles.horizontalChartShell}>
+      <View style={styles.averageMarkerRow}>
+        <Text style={styles.averageMarkerText}>global avg {globalAverageIsolation}%</Text>
+      </View>
+      {chartData.map((entry, index) => {
+        const tier = entry.isolationTier ?? "mid";
+        const isSelectedCountry = selectedCountry?.isoCode === entry.isoCode;
+        const width = `${Math.max(6, Math.min(100, entry.isolationScore))}%` as const;
+        return (
+          <Pressable
+            key={entry.isoCode}
+            style={({ pressed }) => [
+              styles.horizontalBarRow,
+              isSelectedCountry ? styles.horizontalBarRowSelected : null,
+              pressed ? styles.pressablePressed : null,
+            ]}
+            onPress={() => setSelectedIndex((current) => (current === index ? null : index))}
+          >
+            <View style={styles.horizontalBarLabelWrap}>
+              <Text style={[styles.horizontalBarCountry, isSelectedCountry ? styles.selectedText : null]} numberOfLines={1}>
+                {entry.countryName}
+              </Text>
+              {isSelectedCountry ? <Text style={styles.youBadge}>you</Text> : null}
+            </View>
+            <View style={styles.horizontalBarTrack}>
+              <View style={styles.averageMarker} />
+              <View style={[styles.horizontalBarFillWrap, { width }]}>
+                <LinearGradient
+                  colors={isolationColors[tier]}
+                  start={{ x: 0, y: 0 }}
+                  end={{ x: 1, y: 0 }}
+                  style={styles.horizontalBarFill}
+                />
+              </View>
+            </View>
+            <Text style={styles.horizontalBarValue}>{Math.round(entry.isolationScore)}%</Text>
+          </Pressable>
+        );
+      })}
+      <View style={styles.chartLegendRow}>
+        <LegendSwatch color="#f87171" label="High isolation (> 65%)" />
+        <LegendSwatch color="#fb923c" label="Mid (40-65%)" />
+        <LegendSwatch color="#4ade80" label="Low (< 40%)" />
+      </View>
+      <Text style={styles.chartValueText}>
+        {tapped ? `${tapped.countryName}: ${Math.round(tapped.isolationScore)}% isolation` : "Tap a country row to focus a value."}
+      </Text>
+    </View>
+  );
+}
+
+function LegendSwatch({ color, label }: { color: string; label: string }) {
+  return (
+    <View style={styles.chartLegendItem}>
+      <View style={[styles.chartLegendSwatch, { backgroundColor: color }]} />
+      <Text style={styles.chartLegendText}>{label}</Text>
+    </View>
+  );
+}
+
+function DiscoveryGapHistogram({ data }: { data: ApiGapBucket[] }) {
+  const sorted = [...data].sort((left, right) => left.bucketOrder - right.bucketOrder);
+  return (
+    <VerticalBarChart
+      data={sorted.map((bucket) => ({
+        label: bucket.bucketLabel,
+        value: bucket.songCount,
+        valueLabel: bucket.songCount.toLocaleString(),
+      }))}
+      colors={["#8B9BC0", "#8B5E7A"]}
+    />
+  );
+}
+
+function trendChartData(data: ApiTrendPoint[], valueKey: "overlapPct" | "avgCountries") {
+  const ds1 = data.filter((point) => !point.isGap && point.periodYear <= 2021);
+  const ds2 = data.filter((point) => !point.isGap && point.periodYear >= 2023);
+  const gapEntry: ApiTrendPoint = {
+    periodYear: 2022,
+    periodLabel: "gap",
+    periodMonth: null,
+    overlapPct: 0,
+    avgCountries: 0,
+    totalUniqueSongs: 0,
+    songsIn2Plus: 0,
+    isGap: true,
+  };
+
+  return [...ds1, gapEntry, ...ds2].map((point) => ({
+    label: point.isGap ? "gap" : `${point.periodYear}${point.periodYear === 2023 ? "*" : ""}`,
+    value: point[valueKey],
+    valueLabel: point.isGap
+      ? "No data"
+      : valueKey === "overlapPct"
+        ? `${Math.round(point[valueKey])}%`
+        : Number(point[valueKey]).toFixed(2),
+    isGap: point.isGap,
+    isDimmed: point.periodYear >= 2023,
+  }));
+}
+
+function OverlapTrendChart({ data }: { data: ApiTrendPoint[] }) {
+  return (
+    <View style={styles.chartShell}>
+      <VerticalBarChart data={trendChartData(data, "overlapPct")} colors={["#C488A3", colors.accent]} />
+      <View style={styles.chartLegendRow}>
+        <LegendSwatch color={colors.accent} label="2017-2021 (Top 200 only)" />
+        <LegendSwatch color="transparent" label="2023-2025 dimmed (Top 50 only)" />
+        <Text style={[styles.chartLegendText, styles.warningLegend]}>* 2023 = Oct-Dec only</Text>
+      </View>
+    </View>
+  );
+}
+
+function GlobalReachChart({ data }: { data: ApiTrendPoint[] }) {
+  return (
+    <View style={styles.chartShell}>
+      <VerticalBarChart data={trendChartData(data, "avgCountries")} colors={["#4ade80", "#627F8A"]} />
+      <View style={styles.chartLegendRow}>
+        <LegendSwatch color="#4ade80" label="2017-2021" />
+        <LegendSwatch color="#627F8A" label="2023-2025 dimmed" />
+        <Text style={[styles.chartLegendText, styles.warningLegend]}>* 2023 = Oct-Dec only</Text>
+      </View>
+    </View>
+  );
+}
+
+function AboutThisData({ discoveryGap }: { discoveryGap: ApiDiscoveryGap | null }) {
+  const [open, setOpen] = useState(false);
+  const dynamicEntries = [
+    ...aboutEntries,
+    {
+      icon: "i",
+      iconType: "blue" as const,
+      title: "Discovery gap reflects first crossings only",
+      body: discoveryGap
+        ? `Mean (${discoveryGap.avgGapDays}d) and median (${discoveryGap.medianGapDays}d) diverge because crossover is bimodal. Songs that never crossed any border are excluded. Sample size: ${discoveryGap.sampleSize.toLocaleString()} songs.`
+        : "Mean and median diverge because crossover is bimodal. Songs that never crossed any border are excluded.",
+    },
+  ];
+
+  return (
+    <View style={styles.aboutSection}>
+      <Pressable style={({ pressed }) => [styles.aboutToggleRow, pressed ? styles.pressablePressed : null]} onPress={() => setOpen((current) => !current)}>
+        <Text style={styles.aboutToggleLabel}>About this data - sources, limitations & methodology</Text>
+        <Text style={styles.aboutChevron}>{open ? "▲" : "▼"}</Text>
+      </Pressable>
+      {open ? (
+        <View style={styles.aboutEntries}>
+          {dynamicEntries.map((entry, index) => (
+            <View key={`${entry.title}-${index}`} style={styles.aboutEntry}>
+              <View style={[styles.aboutIconWrap, { backgroundColor: `${iconColors[entry.iconType]}22` }]}>
+                <Text style={[styles.aboutIconText, { color: iconColors[entry.iconType] }]}>{entry.icon}</Text>
+              </View>
+              <View style={styles.aboutEntryContent}>
+                <Text style={styles.aboutEntryTitle}>{entry.title}</Text>
+                <Text style={styles.aboutEntryBody}>{entry.body}</Text>
+              </View>
+            </View>
+          ))}
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+export function DashboardScreen({
+  countries = [],
+  onOpenDiscovery,
+  onOpenHiddenGems,
+  onOpenComparison,
+}: Props) {
+  const [overlapRate, setOverlapRate] = useState<ApiOverlapRate | null>(null);
+  const [discoveryGap, setDiscoveryGap] = useState<ApiDiscoveryGap | null>(null);
+  const [isolationLeader, setIsolationLeader] = useState<ApiIsolationLeader | null>(null);
+  const [peakReach, setPeakReach] = useState<ApiPeakReach | null>(null);
+  const [trendData, setTrendData] = useState<ApiTrendPoint[]>([]);
+  const [isolationRanking, setIsolationRanking] = useState<ApiIsolationEntry[]>([]);
+  const [dashboardCountries, setDashboardCountries] = useState<Country[]>([]);
+  const [gapDistribution, setGapDistribution] = useState<ApiGapBucket[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+  const [selectedCountry, setSelectedCountry] = useState<CountrySelectorOption | null>(null);
+  const loadingText = useLoadingText(loading, "Loading Discovery Dashboard");
+
+  useEffect(() => {
+    const start = "2017-01-01";
+    const end = "2025-12-31";
+    Promise.all([
+      loadOverlapRate(start, end),
+      loadDiscoveryGap(start, end),
+      loadIsolationLeader(start, end),
+      loadPeakReach(start, end),
+      loadOverlapTrend(start, end),
+      loadIsolationRanking(start, end),
+      loadGapDistribution(start, end),
+    ])
+      .then(([rate, gap, leader, reach, trend, ranking, gapDist]) => {
+        setOverlapRate(rate);
+        setDiscoveryGap(gap);
+        setIsolationLeader(leader);
+        setPeakReach(reach);
+        setTrendData(trend);
+        setIsolationRanking(ranking);
+        setGapDistribution(gapDist);
+        setLoading(false);
+      })
+      .catch((err: unknown) => {
+        setFetchError(err instanceof Error ? err.message : "Failed to load dashboard data");
+        setLoading(false);
+      });
+
+    loadDashboardCountriesWithAppData(countries)
+      .then(setDashboardCountries)
+      .catch(() => setDashboardCountries([]));
+  }, [countries]);
+
+  const notCrossingPct = useMemo(
+    () => (overlapRate ? Math.round(100 - overlapRate.overlapPct) : null),
+    [overlapRate]
+  );
+
+  const isolationSpread = useMemo(() => {
+    if (isolationRanking.length < 2) {
+      return null;
+    }
+    const scores = isolationRanking.map((entry) => entry.isolationScore);
+    return Math.round(Math.max(...scores) - Math.min(...scores));
+  }, [isolationRanking]);
+
+  const countryOptions = useMemo<CountrySelectorOption[]>(() => {
+    const isolationByCode = new Map(isolationRanking.map((entry) => [entry.isoCode.toUpperCase(), entry]));
+    if (dashboardCountries.length === 0) {
+      return isolationRanking.map((entry) => ({
+        isoCode: entry.isoCode,
+        countryName: entry.countryName,
+        isolationScore: entry.isolationScore,
+        isolationTier: entry.isolationTier,
+      }));
+    }
+
+    return dashboardCountries
+      .filter(isCountryWithAppData)
+      .map((country) => {
+        const isolationEntry = isolationByCode.get(country.code.toUpperCase());
+        return {
+          isoCode: country.code,
+          countryName: country.name,
+          isolationScore: isolationEntry?.isolationScore ?? null,
+          isolationTier: isolationEntry?.isolationTier ?? null,
+        };
+      })
+      .sort((left, right) => left.countryName.localeCompare(right.countryName));
+  }, [dashboardCountries, isolationRanking]);
+
+  const overlapChange = useMemo(() => {
+    const nonGap = trendData.filter((point) => !point.isGap && point.overlapPct > 0);
+    const pt2017 = nonGap.find((point) => point.periodYear === 2017);
+    const pt2021 = nonGap.find((point) => point.periodYear === 2021);
+    if (!pt2017 || !pt2021) {
+      return null;
+    }
+    return {
+      delta: Math.round(Math.abs(pt2021.overlapPct - pt2017.overlapPct)),
+      pct2017: Math.round(pt2017.overlapPct),
+      pct2021: Math.round(pt2021.overlapPct),
+      direction: pt2021.overlapPct >= pt2017.overlapPct ? "rose" : "fell",
+    };
+  }, [trendData]);
+
+  const selectedCountryHasIsolation = selectedCountry?.isolationScore !== null && selectedCountry?.isolationScore !== undefined;
+  const isolationCardScore = selectedCountry
+    ? selectedCountryHasIsolation
+      ? Math.round(selectedCountry.isolationScore as number)
+      : null
+    : isolationLeader
+      ? Math.round(isolationLeader.isolationScore)
+      : null;
+  const isolationCardName = selectedCountry?.countryName ?? isolationLeader?.countryName ?? "";
+  const isolationCardTierLabel = selectedCountryHasIsolation
+    ? (selectedCountry?.isolationScore as number) > 65
+      ? "highly isolated market"
+      : (selectedCountry?.isolationScore as number) >= 40
+        ? "moderately isolated"
+        : "well connected"
+    : selectedCountry
+      ? "app data available"
+      : "most isolated market";
+  const isolationCardBarColor = selectedCountryHasIsolation
+    ? (selectedCountry?.isolationScore as number) > 65
+      ? kpiBar.red
+      : (selectedCountry?.isolationScore as number) >= 40
+        ? "#fb923c"
+        : kpiBar.green
+    : selectedCountry
+      ? kpiBar.blue
+      : kpiBar.red;
+
+  const countryLabel = selectedCountry?.countryName ?? null;
+  const countryCode = selectedCountry?.isoCode;
+  const gemLabel = countryLabel ? `Find ${countryLabel}'s hidden gems` : "Find hidden gems";
+  const globeLabel = countryLabel ? `See ${countryLabel} on the map` : "Explore these gaps on the map";
+  const missingLabel = countryLabel ? `Find what ${countryLabel} is missing` : "Find what your country is missing";
+
+  const peakDateStr = peakReach?.peakDate
+    ? (() => {
+        const date = new Date(peakReach.peakDate);
+        return `peak ${date.toLocaleString("default", { month: "short" })} ${date.getFullYear()}`;
+      })()
+    : null;
+  const peakReachArtUrl = peakReach?.albumArtUrl ?? getKnownPeakReachArtUrl(peakReach?.songTitle, peakReach?.artistName);
+
+  const openDiscovery = () => onOpenDiscovery?.(countryCode);
+  const openHiddenGems = () => onOpenHiddenGems?.(countryCode);
+  const openComparison = () => onOpenComparison?.();
+
+  if (loading || fetchError) {
+    return (
+      <ScreenScaffold>
+        <View style={styles.statusShell}>
+          <Text style={[styles.statusText, fetchError ? styles.statusError : null]}>
+            {fetchError ?? loadingText}
+          </Text>
+        </View>
+      </ScreenScaffold>
+    );
+  }
 
   return (
     <ScreenScaffold>
-      <View style={styles.screen}>
-        <DiscoveryBlurb
-          heading="Discovery Dashboard"
-          body={`This dashboard summarizes discovery behavior for ${year}, including overlap, isolation, and hidden gem concentration across countries.`}
-        />
-
-        <DashboardSection>
-          <Text style={styles.sectionLabel}>KEY PERFORMANCE INDICATORS</Text>
-          <View style={styles.kpiGrid}>
-            {metrics.map((metric) => (
-              <KpiCard key={metric.label} label={metric.label} value={metric.value} detail={metric.detail} />
-            ))}
-          </View>
-        </DashboardSection>
-
-        <DashboardSection>
-          <Text style={styles.sectionLabel}>TREND ANALYSIS</Text>
-          <Text style={styles.sectionTitle}>Regional Isolation Scores</Text>
-          <Text style={styles.sectionBody}>
-            Countries with higher isolation scores have a larger share of songs that stay local rather than crossing into
-            other markets.
-          </Text>
-          <View style={styles.countryList}>
-            {topCountries.map((country, index) => (
-              <View key={`${country.id}-${index}`} style={styles.countryRow}>
-                <Text style={styles.countryName}>{country.name}</Text>
-                <Text style={styles.countryMeta}>{country.region}</Text>
+      <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
+        <View style={styles.heroWrap}>
+          <LinearGradient colors={heroGradient} start={{ x: 0.15, y: 0 }} end={{ x: 0.85, y: 1 }} style={StyleSheet.absoluteFillObject} />
+          <View style={styles.contentInner}>
+            <View style={styles.heroContent}>
+              <Text style={styles.heroOverline}>The discovery gap - a data story</Text>
+              <View style={styles.heroTitleRow}>
+                <Text style={styles.heroH1}>
+                  {"Most music never leaves "}
+                  <Text style={styles.heroH1Accent}>home.</Text>
+                </Text>
+                <GemIcon size={30} style={styles.heroGemIcon} />
               </View>
-            ))}
+              <Text style={styles.heroBody}>
+                A song can be charting in 30 countries and completely unknown in yours. This isn't a taste difference - it's a structural gap in how music travels.
+              </Text>
+              <CountrySelector data={countryOptions} selectedCountry={selectedCountry} onSelect={setSelectedCountry} onClear={() => setSelectedCountry(null)} />
+              <View style={styles.scrollHint}>
+                <View style={styles.scrollHintLine} />
+                <Text style={styles.scrollHintText}>scroll to explore</Text>
+              </View>
+            </View>
           </View>
-        </DashboardSection>
-      </View>
+        </View>
+
+        <View style={styles.chapterWrap}>
+          <View style={styles.contentInner}>
+            <ChapterLabel num={1} title="THE GAP EXISTS" />
+            <View style={styles.chapterStack}>
+              {notCrossingPct !== null ? (
+                <PullStat number={String(notCrossingPct)} unit="%" context="of all charting songs never appeared in a second country's charts." />
+              ) : null}
+              {notCrossingPct !== null && overlapRate ? (
+                <ArgumentText>
+                  Out of every 100 songs that charted anywhere in the world between 2017 and 2025,{" "}
+                  <Text style={styles.argBold}>{notCrossingPct} stayed home.</Text> They charted, they disappeared, and no other market ever heard of them. The remaining{" "}
+                  <Text style={styles.argBold}>{Math.round(overlapRate.overlapPct)} crossed at least one border</Text> - and a handful crossed dozens.
+                </ArgumentText>
+              ) : null}
+              <CtaRow>
+                <CtaButton label={globeLabel} primary onPress={openDiscovery} />
+                <CtaButton label={gemLabel} onPress={openHiddenGems} />
+              </CtaRow>
+            </View>
+
+            {gapDistribution.length > 0 ? (
+              <>
+                <ChapterCard label="DISCOVERY GAP DISTRIBUTION">
+                  <DiscoveryGapHistogram data={gapDistribution} />
+                </ChapterCard>
+                <Text style={[styles.pullQuote, styles.histogramPullQuote]}>
+                  Most songs that cross any border do so within two weeks. The long tail - songs that took months or never arrived at all - is what the discovery gap is made of.
+                </Text>
+              </>
+            ) : null}
+
+            <View style={styles.kpiGrid}>
+              {overlapRate ? (
+                <KpiCard
+                  barColor={kpiBar.purple}
+                  front={
+                    <View style={styles.kpiFront}>
+                      <Text style={styles.kpiLabel}>Global Overlap Rate</Text>
+                      <Text style={styles.kpiNumber}>{Math.round(overlapRate.overlapPct)}%</Text>
+                      <Text style={styles.kpiSublabel}>songs reached 2+ countries</Text>
+                    </View>
+                  }
+                  back={
+                    <View style={styles.kpiBack}>
+                      <Text style={styles.kpiBackTitle}>What this means</Text>
+                      <Text style={styles.kpiBackBody}>
+                        {Math.round(100 - overlapRate.overlapPct)}% of charting music stayed in exactly one country. The {Math.round(overlapRate.overlapPct)}% that crossed is what this app is built to help you find.
+                      </Text>
+                      <Pressable onPress={openDiscovery}>
+                        <Text style={styles.kpiCta}>Explore map</Text>
+                      </Pressable>
+                    </View>
+                  }
+                />
+              ) : null}
+
+              {discoveryGap ? (
+                <KpiCard
+                  barColor={kpiBar.blue}
+                  front={
+                    <View style={styles.kpiFront}>
+                      <Text style={styles.kpiLabel}>Discovery Gap</Text>
+                      <Text style={styles.kpiNumber}>{discoveryGap.medianGapDays}d</Text>
+                      <Text style={styles.kpiSublabel}>median to cross a border</Text>
+                      <Text style={styles.kpiSecondary}>mean: {discoveryGap.avgGapDays} days</Text>
+                    </View>
+                  }
+                  back={
+                    <View style={styles.kpiBack}>
+                      <Text style={styles.kpiBackTitle}>Why two numbers?</Text>
+                      <Text style={styles.kpiBackBody}>
+                        Most crossovers happen within days. A long tail of slow-movers pulls the mean to {discoveryGap.avgGapDays}. The median is the real signal.
+                      </Text>
+                    </View>
+                  }
+                />
+              ) : null}
+
+              {selectedCountry || isolationCardScore !== null ? (
+                <KpiCard
+                  barColor={isolationCardBarColor}
+                  front={
+                    <View style={styles.kpiFront}>
+                      <Text style={styles.kpiLabel}>{selectedCountry ? "Your Country" : "Most Isolated Market"}</Text>
+                      <Text style={styles.kpiNumber}>{isolationCardScore !== null ? `${isolationCardScore}%` : "-"}</Text>
+                      <Text style={styles.kpiSublabel}>{isolationCardName} - {isolationCardTierLabel}</Text>
+                    </View>
+                  }
+                  back={
+                    <View style={styles.kpiBack}>
+                      <Text style={styles.kpiBackTitle}>{selectedCountry ? "Your country in context" : "Isolation explained"}</Text>
+                      <Text style={styles.kpiBackBody}>
+                        {selectedCountry
+                          ? selectedCountry.isolationScore === null
+                            ? `${selectedCountry.countryName} is available in the app data, but the current isolation ranking response does not include a score for it.`
+                            : selectedCountry.isolationScore > 65
+                              ? `${selectedCountry.countryName} has an isolation score of ${Math.round(selectedCountry.isolationScore)}%. Most of its chart stays local - it has some of the most to discover.`
+                              : selectedCountry.isolationScore >= 40
+                                ? `${selectedCountry.countryName} has an isolation score of ${Math.round(selectedCountry.isolationScore)}%. Some global crossover, but still plenty of undiscovered music.`
+                                : `${selectedCountry.countryName} has an isolation score of ${Math.round(selectedCountry.isolationScore)}%. Its charts overlap heavily with global trends.`
+                          : isolationLeader
+                            ? `${Math.round(isolationLeader.isolationScore)}% of songs charting in ${isolationLeader.countryName} appeared nowhere else. These are the markets with the most to discover.`
+                            : ""}
+                      </Text>
+                      <Pressable onPress={openHiddenGems}>
+                        <Text style={styles.kpiCta}>{gemLabel}</Text>
+                      </Pressable>
+                    </View>
+                  }
+                />
+              ) : null}
+
+              {peakReach ? (
+                <KpiCard
+                  barColor={kpiBar.green}
+                  front={
+                    <View style={styles.kpiFront}>
+                      <Text style={styles.kpiLabel}>Peak Cross-Regional Reach</Text>
+                      <Text style={styles.kpiNumber}>{peakReach.peakCountryCount}</Text>
+                      <Text style={styles.kpiSublabel}>countries at once - peak reach</Text>
+                    </View>
+                  }
+                  back={
+                    <View style={styles.kpiBack}>
+                      <Text style={styles.kpiBackTitle}>The ceiling</Text>
+                      <Text style={styles.kpiBackBody}>
+                        {peakReach.songTitle} by {peakReach.artistName} charted in {peakReach.peakCountryCount} countries simultaneously. The average song reaches 3.
+                      </Text>
+                      <Pressable onPress={openDiscovery}>
+                        <Text style={styles.kpiCta}>Explore map</Text>
+                      </Pressable>
+                    </View>
+                  }
+                />
+              ) : null}
+            </View>
+          </View>
+        </View>
+
+        <View style={[styles.chapterWrap, styles.chapterElevated]}>
+          <View style={styles.contentInner}>
+            <ChapterLabel num={2} title="THE GAP IS GEOGRAPHIC" />
+            <View style={styles.chapterStack}>
+              {isolationSpread !== null ? (
+                <PullStat number={String(isolationSpread)} unit="pts" context="difference between the most and least isolated market in this dataset." />
+              ) : null}
+              <Text style={styles.isolationExplainer}>
+                Isolation score = % of a country's charting songs that appeared nowhere else in the world.
+              </Text>
+              <ArgumentText>
+                The gap isn't evenly distributed. Some markets are deeply wired into global trends. Others are almost entirely self-contained.{" "}
+                <Text style={styles.argBold}>Where your country falls determines how much music you're missing.</Text>
+              </ArgumentText>
+              <CtaRow>
+                <CtaButton label={countryLabel ? `See ${countryLabel} on the map` : "See this on the map"} primary onPress={openDiscovery} />
+                <CtaButton label="Compare two countries" onPress={openComparison} />
+              </CtaRow>
+            </View>
+            {isolationRanking.length > 0 ? (
+              <ChapterCard label="ISOLATION SCORES BY COUNTRY">
+                <HorizontalIsolationChart data={isolationRanking} selectedCountry={selectedCountry} />
+              </ChapterCard>
+            ) : null}
+          </View>
+        </View>
+
+        <View style={styles.chapterWrap}>
+          <View style={styles.contentInner}>
+            <ChapterLabel num={3} title="THE GAP IS MEASURABLE OVER TIME" />
+            <View style={styles.chapterStack}>
+              {overlapChange !== null ? (
+                <PullStat
+                  number={`${overlapChange.direction === "rose" ? "+" : "-"}${overlapChange.delta}`}
+                  unit="pts"
+                  context={`overlap ${overlapChange.direction} from ${overlapChange.pct2017}% to ${overlapChange.pct2021}% between 2017 and 2021.`}
+                />
+              ) : null}
+              <ArgumentText>
+                Global overlap was <Text style={styles.argBold}>improving through 2021.</Text> Then the data stops. When it resumes in late 2023, the picture looks different - <Text style={styles.argBold}>but that may be the data, not reality.</Text>
+              </ArgumentText>
+              <View style={styles.warningTagRow}>
+                <WarningTag type="orange" label="! 22-month gap - broken, not interpolated" />
+                <WarningTag type="blue" label="i 2017-2021 data vs 2023-2025 data uses different chart pools" />
+              </View>
+            </View>
+            {trendData.length > 0 ? (
+              <>
+                <ChapterCard label="GLOBAL OVERLAP RATE - 2017-2025">
+                  <OverlapTrendChart data={trendData} />
+                </ChapterCard>
+                <Text style={styles.pullQuote}>
+                  The dashed bars use a smaller chart pool. A visual dip after the gap doesn't mean music borders got worse - it partly means we're counting fewer songs per country.
+                </Text>
+              </>
+            ) : null}
+          </View>
+        </View>
+
+        <View style={[styles.chapterWrap, styles.chapterElevated]}>
+          <View style={styles.contentInner}>
+            <ChapterLabel num={4} title="THE CEILING" />
+            <View style={styles.chapterStack}>
+              {peakReach ? (
+                <PullStat number={String(peakReach.peakCountryCount)} context="countries at once. The most connected a song has ever been in this dataset." />
+              ) : null}
+              {peakReach ? (
+                <>
+                  <ArgumentText>
+                    The average charting song reaches <Text style={styles.argBold}>3 countries.</Text> The record is {peakReach.peakCountryCount}. Between those two numbers is{" "}
+                    <Text style={styles.argBold}>every song trending somewhere right now that hasn't reached you yet.</Text>
+                  </ArgumentText>
+                  <View style={styles.songRefCard}>
+                    <CdCaseArt size={74} placeholderColor={rowBackdropColors[0]} artImageUrl={peakReachArtUrl} loading={!peakReachArtUrl} />
+                    <View style={styles.songRefInfo}>
+                      <Text style={styles.songRefTitle}>{peakReach.songTitle}</Text>
+                      <Text style={styles.songRefArtist}>{peakReach.artistName}{peakDateStr ? ` · ${peakDateStr}` : ""}</Text>
+                    </View>
+                    <View style={styles.songRefCount}>
+                      <Text style={styles.songRefNumber}>{peakReach.peakCountryCount}</Text>
+                      <Text style={styles.songRefCountLabel}>countries at once</Text>
+                    </View>
+                  </View>
+                  <View style={styles.warningTagRow}>
+                    <WarningTag type="orange" label="! 2023 = Oct-Dec only" />
+                    <WarningTag type="blue" label="i 2023-2025 uses Top 50 charts only" />
+                  </View>
+                  <CtaRow>
+                    <CtaButton label={missingLabel} primary onPress={openHiddenGems} />
+                    <CtaButton label="Explore on the map" onPress={openDiscovery} />
+                  </CtaRow>
+                </>
+              ) : null}
+            </View>
+            {trendData.length > 0 ? (
+              <ChapterCard label="AVERAGE COUNTRIES PER SONG - 2017-2025">
+                <GlobalReachChart data={trendData} />
+              </ChapterCard>
+            ) : null}
+          </View>
+        </View>
+
+        <View style={styles.conclusionWrap}>
+          <LinearGradient colors={heroGradient} start={{ x: 0.15, y: 0 }} end={{ x: 0.85, y: 1 }} style={StyleSheet.absoluteFillObject} />
+          <View style={styles.contentInner}>
+            <View style={styles.conclusionStack}>
+              <Text style={styles.conclusionHeadline}>
+                {"The gap is real. The music is "}
+                <Text style={styles.conclusionAccent}>out there.</Text>
+              </Text>
+              <Text style={styles.conclusionBody}>
+                {notCrossingPct !== null ? `${notCrossingPct}%` : "-"} of charting songs never crossed a single border. The ones that did spread fast - most within days. A handful reached {peakReach ? peakReach.peakCountryCount : "-"} countries at once. Everything in between is waiting to be discovered.
+              </Text>
+              <View style={styles.conclusionCtas}>
+                <CtaButton label={missingLabel} primary onPress={openHiddenGems} />
+                <CtaButton label="Explore on the map" onPress={openDiscovery} />
+              </View>
+              <View style={styles.statGrid}>
+                <View style={styles.statCard}>
+                  <Text style={styles.statNumber}>{notCrossingPct !== null ? `${notCrossingPct}%` : "-"}</Text>
+                  <Text style={styles.statLabel}>of music never leaves its home market</Text>
+                </View>
+                <View style={styles.statCard}>
+                  <Text style={styles.statNumber}>{discoveryGap ? `${discoveryGap.medianGapDays}d` : "-"}</Text>
+                  <Text style={styles.statLabel}>median time to cross a border</Text>
+                </View>
+                <View style={styles.statCard}>
+                  <Text style={styles.statNumber}>{peakReach ? peakReach.peakCountryCount : "-"}</Text>
+                  <Text style={styles.statLabel}>countries - the ceiling one song ever reached</Text>
+                </View>
+                <View style={styles.statCard}>
+                  <Text style={styles.statNumber}>{isolationLeader ? `${Math.round(isolationLeader.isolationScore)}%` : "-"}</Text>
+                  <Text style={styles.statLabel}>isolation - the most self-contained market</Text>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+
+        <View style={styles.contentInner}>
+          <AboutThisData discoveryGap={discoveryGap} />
+        </View>
+      </ScrollView>
     </ScreenScaffold>
   );
 }
 
 const styles = StyleSheet.create({
-  screen: {
-    gap: 12,
+  scrollView: {
+    flex: 1,
   },
-  sectionPanel: {
-    padding: 0,
+  scrollContent: {
+    paddingBottom: 32,
+  },
+  contentInner: {
+    width: "100%",
+    paddingHorizontal: 18,
+  },
+  heroWrap: {
+    overflow: "hidden",
+    paddingTop: 54,
+    paddingBottom: 46,
+  },
+  heroContent: {
+    alignItems: "center",
+    gap: 18,
+  },
+  heroOverline: {
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 11,
+    letterSpacing: 2,
+    textTransform: "uppercase",
+    opacity: 0.38,
+    textAlign: "center",
+  },
+  heroTitleRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 10,
+    flexWrap: "wrap",
+  },
+  heroH1: {
+    color: colors.textStrong,
+    fontFamily: typefaces.display,
+    fontSize: 40,
+    fontWeight: "700",
+    textAlign: "center",
+    lineHeight: 46,
+  },
+  heroH1Accent: {
+    color: colors.accent,
+  },
+  heroGemIcon: {
+    opacity: 0.82,
+  },
+  heroBody: {
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 15,
+    lineHeight: 23,
+    opacity: 0.68,
+    textAlign: "center",
+  },
+  scrollHint: {
+    alignItems: "center",
+    gap: 6,
+    opacity: 0.34,
+  },
+  scrollHintLine: {
+    width: 1,
+    height: 20,
+    backgroundColor: "rgba(255,255,255,0.4)",
+  },
+  scrollHintText: {
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 11,
+  },
+  countrySelectorWrap: {
+    width: "100%",
+    gap: 8,
+  },
+  countrySelectorPill: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderRadius: 999,
+    borderWidth: 1,
+    borderColor: "rgba(117,82,107,0.5)",
+    backgroundColor: "rgba(255,255,255,0.04)",
+  },
+  countrySelectorText: {
+    flex: 1,
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 14,
+  },
+  countrySelectorChevron: {
+    color: colors.text,
+    fontSize: 11,
+    opacity: 0.6,
+  },
+  countryDropdown: {
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: "rgba(117,82,107,0.3)",
+    backgroundColor: colors.backgroundRaised,
+    maxHeight: 210,
     overflow: "hidden",
   },
-  sectionContent: {
+  countryDropdownItem: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 11,
+    borderBottomWidth: 1,
+    borderBottomColor: "rgba(117,130,160,0.1)",
+  },
+  countryDropdownItemSelected: {
+    backgroundColor: "rgba(117,82,107,0.15)",
+  },
+  countryDropdownName: {
+    flex: 1,
+    color: colors.textStrong,
+    fontFamily: typefaces.body,
+    fontSize: 13,
+  },
+  countryDropdownMeta: {
+    alignItems: "flex-end",
+    gap: 1,
+  },
+  countryDropdownScore: {
+    color: colors.accent,
+    fontFamily: typefaces.body,
+    fontSize: 12,
+    fontWeight: "600",
+  },
+  countryDropdownCaption: {
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 9,
+    opacity: 0.45,
+  },
+  countryBanner: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: "rgba(117,82,107,0.4)",
+    backgroundColor: "rgba(117,82,107,0.08)",
+    gap: 10,
+  },
+  countryBannerLeft: {
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: 8,
+  },
+  countryBannerDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: colors.accent,
+    marginTop: 5,
+  },
+  countryBannerText: {
+    flex: 1,
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 13,
+    lineHeight: 19,
+  },
+  countryBannerName: {
+    color: colors.accent,
+    fontWeight: "500",
+  },
+  countryBannerClear: {
+    paddingLeft: 8,
+  },
+  countryBannerClearText: {
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 12,
+    opacity: 0.65,
+  },
+  chapterWrap: {
+    paddingVertical: 50,
+  },
+  chapterElevated: {
+    backgroundColor: "rgba(255,255,255,0.018)",
+  },
+  chapterLabelRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    marginBottom: 34,
+  },
+  chapterCircle: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    borderWidth: 1.5,
+    borderColor: "rgba(117,82,107,0.6)",
+    backgroundColor: "rgba(117,82,107,0.08)",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  chapterNumber: {
+    color: colors.accent,
+    fontFamily: typefaces.body,
+    fontSize: 18,
+    fontWeight: "700",
+  },
+  chapterTitle: {
+    flex: 1,
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 16,
+    letterSpacing: 2,
+    textTransform: "uppercase",
+    fontWeight: "500",
+    opacity: 0.78,
+  },
+  chapterStack: {
+    gap: 18,
+    marginBottom: 28,
+  },
+  pullStat: {
+    gap: 8,
+  },
+  pullStatDisplay: {
+    flexDirection: "row",
+    alignItems: "baseline",
+    flexWrap: "wrap",
+    paddingRight: 6,
+  },
+  pullStatNumber: {
+    color: colors.accent,
+    fontFamily: typefaces.display,
+    fontSize: 86,
+    fontWeight: "700",
+    lineHeight: 92,
+    paddingRight: 4,
+  },
+  pullStatUnit: {
+    color: colors.accent,
+    fontFamily: typefaces.display,
+    fontSize: 50,
+    fontWeight: "700",
+    lineHeight: 56,
+    marginLeft: 2,
+    paddingRight: 4,
+  },
+  pullStatContext: {
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 14,
+    lineHeight: 21,
+    opacity: 0.48,
+  },
+  isolationExplainer: {
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 13,
+    lineHeight: 19,
+    opacity: 0.56,
+    fontStyle: "italic",
+  },
+  argument: {
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 16,
+    lineHeight: 27,
+  },
+  argBold: {
+    color: colors.textStrong,
+    fontWeight: "500",
+  },
+  ctaRow: {
+    flexDirection: "row",
+    gap: 10,
+    flexWrap: "wrap",
+    alignItems: "center",
+  },
+  ctaButton: {
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+    borderRadius: 999,
+    borderWidth: 1,
+    overflow: "hidden",
+  },
+  ctaButtonPrimary: {
+    borderColor: "rgba(117,82,107,0.6)",
+    backgroundColor: "rgba(117,82,107,0.12)",
+  },
+  ctaButtonSecondary: {
+    borderColor: "rgba(117,130,160,0.3)",
+    backgroundColor: "transparent",
+  },
+  ctaButtonPressed: {
+    transform: [{ scale: 0.98 }],
+    opacity: 0.86,
+  },
+  ctaButtonText: {
+    fontFamily: typefaces.body,
+    fontSize: 13,
+    fontWeight: "500",
+  },
+  ctaButtonTextPrimary: {
+    color: colors.accent,
+  },
+  ctaButtonTextSecondary: {
+    color: colors.text,
+    opacity: 0.78,
+  },
+  warningTagRow: {
+    flexDirection: "row",
+    gap: 8,
+    flexWrap: "wrap",
+  },
+  warningTag: {
+    borderRadius: 999,
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    borderWidth: 1,
+  },
+  warningTagOrange: {
+    backgroundColor: "rgba(251,146,60,0.12)",
+    borderColor: "rgba(251,146,60,0.35)",
+  },
+  warningTagBlue: {
+    backgroundColor: "rgba(99,179,237,0.12)",
+    borderColor: "rgba(99,179,237,0.35)",
+  },
+  warningTagText: {
+    fontFamily: typefaces.body,
+    fontSize: 11,
+    lineHeight: 15,
+  },
+  chapterCard: {
+    backgroundColor: "rgba(255,255,255,0.04)",
+    borderWidth: 1,
+    borderColor: "rgba(255,255,255,0.08)",
+    borderRadius: 12,
     padding: 16,
     gap: 12,
   },
-  sectionLabel: {
-    color: colors.textLight,
-    fontFamily: typefaces.display,
-    fontSize: 20,
-    lineHeight: 24,
-  },
-  sectionTitle: {
-    color: colors.textLight,
-    fontFamily: typefaces.display,
-    fontSize: 25,
-    lineHeight: 29,
-  },
-  sectionBody: {
-    color: colors.textLight,
+  chapterCardLabel: {
+    color: colors.text,
     fontFamily: typefaces.body,
-    fontSize: 15,
-    lineHeight: 21,
+    fontSize: 12,
+    letterSpacing: 0.8,
+    textTransform: "uppercase",
+    opacity: 0.3,
+  },
+  pullQuote: {
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 13,
+    lineHeight: 20,
+    fontStyle: "italic",
+    opacity: 0.42,
+    borderLeftWidth: 2,
+    borderLeftColor: "rgba(117,82,107,0.35)",
+    paddingLeft: 12,
+    marginTop: 12,
+  },
+  histogramPullQuote: {
+    marginBottom: 12,
   },
   kpiGrid: {
+    gap: 12,
+  },
+  kpiCard: {
+    flexDirection: "row",
+    backgroundColor: "rgba(255,255,255,0.04)",
+    borderWidth: 1,
+    borderColor: "rgba(255,255,255,0.08)",
+    borderRadius: 10,
+    height: 170,
+    overflow: "hidden",
+  },
+  kpiCardFlipped: {
+    backgroundColor: "rgba(117,82,107,0.08)",
+    borderColor: "rgba(117,82,107,0.25)",
+  },
+  kpiAccentBar: {
+    width: 4,
+    alignSelf: "stretch",
+  },
+  kpiContent: {
+    flex: 1,
+    height: 170,
+    padding: 16,
+  },
+  kpiFrontShell: {
+    flex: 1,
+    justifyContent: "space-between",
+    gap: 12,
+  },
+  kpiFront: {
+    gap: 6,
+  },
+  kpiBack: {
+    flex: 1,
+    gap: 8,
+    justifyContent: "space-between",
+  },
+  kpiLabel: {
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 13,
+    opacity: 0.64,
+  },
+  kpiNumber: {
+    color: colors.textStrong,
+    fontFamily: typefaces.display,
+    fontSize: 38,
+    fontWeight: "700",
+    lineHeight: 42,
+    paddingRight: 4,
+  },
+  kpiSublabel: {
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 13,
+    lineHeight: 18,
+  },
+  kpiSecondary: {
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 12,
+    opacity: 0.54,
+  },
+  kpiFlipHint: {
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 10,
+    opacity: 0.4,
+    textAlign: "right",
+    marginTop: 6,
+  },
+  kpiBackTitle: {
+    color: colors.textStrong,
+    fontFamily: typefaces.display,
+    fontSize: 15,
+    fontWeight: "600",
+  },
+  kpiBackBody: {
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 14,
+    lineHeight: 20,
+    opacity: 0.78,
+  },
+  kpiCta: {
+    color: colors.accent,
+    fontFamily: typefaces.body,
+    fontSize: 12,
+    fontWeight: "500",
+  },
+  chartShell: {
+    gap: 10,
+  },
+  verticalChart: {
+    minHeight: 190,
+    flexDirection: "row",
+    alignItems: "flex-end",
+    gap: 6,
+    paddingTop: 18,
+    paddingBottom: 8,
+  },
+  verticalBarSlot: {
+    flex: 1,
+    minWidth: 28,
+    alignItems: "center",
+    gap: 7,
+  },
+  verticalBarValueWrap: {
+    height: 150,
+    justifyContent: "flex-end",
+    alignItems: "center",
+    width: "100%",
+  },
+  verticalBarOuter: {
+    width: "68%",
+    minWidth: 14,
+    maxWidth: 28,
+    borderRadius: 5,
+    borderWidth: 1,
+    borderColor: "rgba(255,255,255,0.18)",
+    overflow: "hidden",
+  },
+  verticalBarFill: {
+    flex: 1,
+    borderRadius: 4,
+  },
+  verticalBarLabel: {
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 10,
+    lineHeight: 13,
+    opacity: 0.68,
+    textAlign: "center",
+  },
+  gapMarker: {
+    alignItems: "center",
+    height: 112,
+    justifyContent: "flex-end",
+    gap: 4,
+  },
+  gapLine: {
+    width: 1,
+    height: 92,
+    borderLeftWidth: 1,
+    borderColor: "#fb923c",
+    borderStyle: "dashed",
+  },
+  gapLabel: {
+    color: "#fb923c",
+    fontFamily: typefaces.body,
+    fontSize: 9,
+  },
+  gapText: {
+    color: "#fb923c",
+  },
+  chartValuePanel: {
+    minHeight: 28,
+    borderRadius: 8,
+    backgroundColor: "rgba(255,255,255,0.035)",
+    paddingHorizontal: 10,
+    paddingVertical: 7,
+  },
+  chartValueText: {
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 12,
+    lineHeight: 16,
+    opacity: 0.72,
+  },
+  chartLegendRow: {
+    flexDirection: "row",
+    gap: 12,
+    flexWrap: "wrap",
+    paddingTop: 4,
+    alignItems: "center",
+  },
+  chartLegendItem: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+  },
+  chartLegendSwatch: {
+    width: 14,
+    height: 14,
+    borderRadius: 3,
+    borderWidth: 1,
+    borderColor: "rgba(255,255,255,0.22)",
+  },
+  chartLegendText: {
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 11,
+    lineHeight: 15,
+    opacity: 0.62,
+  },
+  warningLegend: {
+    color: "#fb923c",
+  },
+  horizontalChartShell: {
+    gap: 8,
+  },
+  averageMarkerRow: {
+    alignItems: "flex-end",
+  },
+  averageMarkerText: {
+    color: "rgba(255,255,255,0.42)",
+    fontFamily: typefaces.body,
+    fontSize: 10,
+  },
+  horizontalBarRow: {
+    gap: 6,
+    paddingVertical: 7,
+    borderRadius: 8,
+  },
+  horizontalBarRowSelected: {
+    backgroundColor: "rgba(117,82,107,0.12)",
+  },
+  horizontalBarLabelWrap: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+  },
+  horizontalBarCountry: {
+    flex: 1,
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 12,
+    opacity: 0.85,
+  },
+  selectedText: {
+    color: colors.accent,
+  },
+  youBadge: {
+    color: colors.accent,
+    fontFamily: typefaces.body,
+    fontSize: 9,
+    borderWidth: 1,
+    borderColor: "rgba(117,82,107,0.5)",
+    borderRadius: 99,
+    paddingHorizontal: 7,
+    paddingVertical: 2,
+  },
+  horizontalBarTrack: {
+    height: 17,
+    borderRadius: 999,
+    backgroundColor: "rgba(255,255,255,0.05)",
+    overflow: "hidden",
+    position: "relative",
+  },
+  averageMarker: {
+    position: "absolute",
+    left: `${globalAverageIsolation}%`,
+    top: 0,
+    bottom: 0,
+    width: 1,
+    backgroundColor: "rgba(255,255,255,0.28)",
+    zIndex: 2,
+  },
+  horizontalBarFillWrap: {
+    height: "100%",
+    borderRadius: 999,
+    overflow: "hidden",
+  },
+  horizontalBarFill: {
+    flex: 1,
+  },
+  horizontalBarValue: {
+    color: colors.textStrong,
+    fontFamily: typefaces.body,
+    fontSize: 11,
+    textAlign: "right",
+    opacity: 0.76,
+  },
+  songRefCard: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    padding: 12,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: "rgba(255,255,255,0.08)",
+    backgroundColor: "rgba(255,255,255,0.04)",
+  },
+  songRefInfo: {
+    flex: 1,
+    gap: 2,
+  },
+  songRefTitle: {
+    color: colors.textStrong,
+    fontFamily: typefaces.body,
+    fontSize: 13,
+    fontWeight: "500",
+  },
+  songRefArtist: {
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 11,
+    opacity: 0.7,
+  },
+  songRefCount: {
+    alignItems: "flex-end",
+    gap: 1,
+  },
+  songRefNumber: {
+    color: colors.accent,
+    fontFamily: typefaces.display,
+    fontSize: 24,
+    fontWeight: "700",
+    lineHeight: 26,
+    paddingRight: 3,
+  },
+  songRefCountLabel: {
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 10,
+    opacity: 0.6,
+  },
+  conclusionWrap: {
+    overflow: "hidden",
+    paddingVertical: 56,
+  },
+  conclusionStack: {
+    gap: 20,
+  },
+  conclusionHeadline: {
+    color: colors.textStrong,
+    fontFamily: typefaces.display,
+    fontSize: 30,
+    fontWeight: "700",
+    lineHeight: 38,
+  },
+  conclusionAccent: {
+    color: colors.accent,
+  },
+  conclusionBody: {
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 15,
+    lineHeight: 24,
+    opacity: 0.78,
+  },
+  conclusionCtas: {
+    flexDirection: "row",
+    gap: 10,
+    flexWrap: "wrap",
+  },
+  statGrid: {
     flexDirection: "row",
     flexWrap: "wrap",
     gap: 10,
   },
-  kpiCard: {
+  statCard: {
     width: "48%",
-    minWidth: 150,
-    padding: 10,
-    borderRadius: 14,
-    overflow: "hidden",
-    borderWidth: 2,
-    borderColor: colors.border,
-    backgroundColor: "transparent",
-    gap: 4,
+    aspectRatio: 1,
+    backgroundColor: "rgba(255,255,255,0.04)",
+    borderWidth: 1,
+    borderColor: "rgba(255,255,255,0.08)",
+    borderRadius: 10,
+    padding: 13,
+    gap: 6,
   },
-  kpiFill: {
-    ...StyleSheet.absoluteFillObject,
+  statNumber: {
+    color: colors.accent,
+    fontFamily: typefaces.display,
+    fontSize: 34,
+    fontWeight: "700",
+    lineHeight: 39,
+    paddingRight: 4,
   },
-  kpiLabel: {
-    color: colors.textLight,
+  statLabel: {
+    color: colors.text,
     fontFamily: typefaces.body,
     fontSize: 12,
-    lineHeight: 15,
+    lineHeight: 17,
+    opacity: 0.68,
   },
-  kpiValue: {
-    color: colors.textLight,
-    fontFamily: typefaces.display,
-    fontSize: 25,
-    lineHeight: 29,
+  aboutSection: {
+    paddingTop: 24,
+    paddingBottom: 48,
+    gap: 4,
   },
-  kpiDetail: {
-    color: colors.textLight,
-    fontFamily: typefaces.body,
-    fontSize: 11,
-    lineHeight: 14,
-  },
-  countryList: {
-    gap: 8,
-  },
-  countryRow: {
-    borderWidth: 2,
-    borderColor: colors.border,
-    borderRadius: 12,
-    backgroundColor: "rgba(108,118,144,0.28)",
-    paddingHorizontal: 12,
-    paddingVertical: 8,
+  aboutToggleRow: {
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "center",
+    paddingVertical: 8,
+    gap: 12,
   },
-  countryName: {
-    color: colors.textLight,
-    fontFamily: typefaces.display,
-    fontSize: 17,
-    lineHeight: 21,
+  aboutToggleLabel: {
+    flex: 1,
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 14,
+    opacity: 0.78,
   },
-  countryMeta: {
-    color: colors.textLight,
+  aboutChevron: {
+    color: colors.text,
+    fontSize: 11,
+    opacity: 0.52,
+  },
+  aboutEntries: {
+    gap: 0,
+    marginTop: 8,
+  },
+  aboutEntry: {
+    flexDirection: "row",
+    gap: 12,
+    paddingVertical: 14,
+    borderBottomWidth: 1,
+    borderBottomColor: "rgba(117,130,160,0.12)",
+    alignItems: "flex-start",
+  },
+  aboutIconWrap: {
+    width: 22,
+    height: 22,
+    borderRadius: 11,
+    alignItems: "center",
+    justifyContent: "center",
+    marginTop: 1,
+  },
+  aboutIconText: {
+    fontFamily: typefaces.body,
+    fontSize: 11,
+    fontWeight: "700",
+  },
+  aboutEntryContent: {
+    flex: 1,
+    gap: 3,
+  },
+  aboutEntryTitle: {
+    color: colors.textStrong,
     fontFamily: typefaces.body,
     fontSize: 13,
-    lineHeight: 16,
+    fontWeight: "500",
+    lineHeight: 18,
+  },
+  aboutEntryBody: {
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 13,
+    lineHeight: 18,
+    opacity: 0.7,
+  },
+  statusShell: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    minHeight: 260,
+  },
+  statusText: {
+    color: colors.text,
+    fontFamily: typefaces.body,
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  statusError: {
+    color: "#f87171",
+  },
+  pressablePressed: {
+    opacity: 0.78,
   },
 });

--- a/hidden-gem-music-app/src/screens/DashboardScreen.web.tsx
+++ b/hidden-gem-music-app/src/screens/DashboardScreen.web.tsx
@@ -50,6 +50,7 @@ import type { Country } from "../types/content";
 import { CdCaseArt } from "../components/CdCaseArt";
 import { GemIcon } from "../components/GemIcon";
 import { ScreenScaffold } from "../components/ScreenScaffold";
+import { useLoadingText } from "../hooks/useLoadingText";
 import { colors } from "../theme/colors";
 import { typefaces } from "../theme/typography";
 
@@ -891,6 +892,7 @@ function DashboardScreenContent() {
   const [gapDistribution, setGapDistribution] = useState<ApiGapBucket[]>([]);
   const [loading, setLoading] = useState(true);
   const [fetchError, setFetchError] = useState<string | null>(null);
+  const loadingText = useLoadingText(loading, "Loading Discovery Dashboard");
   const [selectedCountry, setSelectedCountry] = useState<CountrySelectorOption | null>(null);
 
   useEffect(() => {
@@ -1108,7 +1110,7 @@ function DashboardScreenContent() {
         <View style={styles.pageScrollFrame}>
           <View style={styles.statusShell}>
             <Text style={[styles.statusText, fetchError ? styles.statusError : null]}>
-              {fetchError ?? "Loading…"}
+              {fetchError ?? loadingText}
             </Text>
           </View>
         </View>
@@ -2096,7 +2098,7 @@ const styles = StyleSheet.create({
     borderWidth: 0.5,
     borderColor: "rgba(255,255,255,0.08)",
     borderRadius: 10,
-    minHeight: 140,
+    height: 170,
     overflow: "hidden",
     cursor: "pointer" as any,
   },
@@ -2110,6 +2112,7 @@ const styles = StyleSheet.create({
   },
   kpiContent: {
     flex: 1,
+    height: 170,
     padding: 16,
   },
   kpiFrontShell: {
@@ -2121,7 +2124,9 @@ const styles = StyleSheet.create({
     gap: 6,
   },
   kpiBack: {
+    flex: 1,
     gap: 8,
+    justifyContent: "space-between",
   },
   kpiLabel: {
     color: colors.text,

--- a/hidden-gem-music-app/src/screens/WelcomeScreen.tsx
+++ b/hidden-gem-music-app/src/screens/WelcomeScreen.tsx
@@ -1,6 +1,6 @@
 import { LinearGradient } from "expo-linear-gradient";
 import { useEffect, useRef, useState } from "react";
-import { Platform, Pressable, StyleSheet, Text, View } from "react-native";
+import { Platform, Pressable, StyleSheet, Text, useWindowDimensions, View } from "react-native";
 
 import { ActionButton } from "../components/ActionButton";
 import { Panel } from "../components/Panel";
@@ -14,6 +14,7 @@ export type Props = {
 };
 
 const popupBottomDepthGradient = ["rgba(108,119,142,0)", "rgba(108,119,142,0.12)", "rgba(108,119,142,0.3)"] as const;
+const welcomeBackdropGradient = ["#181C2A", "#222639", "#3A3043", "#75526B"] as const;
 const welcomeTitleWebGradientStyle =
   Platform.OS === "web"
     ? ({
@@ -80,6 +81,9 @@ function WelcomeGradientTitle() {
 }
 
 export function WelcomeScreen({ onDismiss, onSelectRoute }: Props) {
+  const { width } = useWindowDimensions();
+  const isCompactWelcome = width < 980;
+  const useFullScreenBackdrop = Platform.OS === "web" && !isCompactWelcome;
   const [isClosing, setIsClosing] = useState(false);
   const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isClosingRef = useRef(false);
@@ -112,20 +116,24 @@ export function WelcomeScreen({ onDismiss, onSelectRoute }: Props) {
 
   return (
     <View
-      style={styles.overlay}
-      pointerEvents="auto"
-      onStartShouldSetResponder={() => true}
-      onMoveShouldSetResponder={() => true}
+      style={[styles.overlay, isCompactWelcome ? styles.overlayCompact : null]}
+      pointerEvents={useFullScreenBackdrop ? "auto" : "box-none"}
+      onStartShouldSetResponder={useFullScreenBackdrop ? () => true : undefined}
+      onMoveShouldSetResponder={useFullScreenBackdrop ? () => true : undefined}
     >
-      <Pressable
-        style={styles.overlayBackdropPressTarget}
-        onPress={(event) => {
-          event.stopPropagation();
-          dismissWithAction(onDismiss);
-        }}
-      >
-        <View style={styles.overlayBackdrop} />
-      </Pressable>
+      {useFullScreenBackdrop ? (
+        <Pressable
+          style={styles.overlayBackdropPressTarget}
+          onPress={(event) => {
+            event.stopPropagation();
+            dismissWithAction(onDismiss);
+          }}
+        >
+          <WelcomeBackdrop style={styles.overlayBackdrop} />
+        </Pressable>
+      ) : (
+        <WelcomeBackdrop style={styles.overlayBackdrop} pointerEvents="none" useGradient />
+      )}
       <Pressable style={styles.modalPressTarget} onPress={(event) => event.stopPropagation()}>
         <Panel style={styles.modal}>
           <LinearGradient
@@ -166,6 +174,22 @@ export function WelcomeScreen({ onDismiss, onSelectRoute }: Props) {
   );
 }
 
+function WelcomeBackdrop({ style, pointerEvents, useGradient = false }: { style: any; pointerEvents?: "none"; useGradient?: boolean }) {
+  if (!useGradient) {
+    return <View style={[style, styles.webOverlayBackdrop]} pointerEvents={pointerEvents} />;
+  }
+
+  return (
+    <LinearGradient
+      colors={welcomeBackdropGradient}
+      start={{ x: 0.1, y: 0 }}
+      end={{ x: 0.9, y: 1 }}
+      style={style}
+      pointerEvents={pointerEvents}
+    />
+  );
+}
+
 const styles = StyleSheet.create({
   overlay: {
     position: "absolute",
@@ -175,6 +199,9 @@ const styles = StyleSheet.create({
     padding: 24,
     zIndex: 9999,
   },
+  overlayCompact: {
+    zIndex: 10,
+  },
   closedOverlay: {
     ...StyleSheet.absoluteFillObject,
   },
@@ -183,6 +210,8 @@ const styles = StyleSheet.create({
   },
   overlayBackdrop: {
     ...StyleSheet.absoluteFillObject,
+  },
+  webOverlayBackdrop: {
     backgroundColor: "rgba(22,26,38,0.56)",
   },
   modalPressTarget: {


### PR DESCRIPTION
# PR: Frontend Mobile Adaptation - Discovery Dashboard

_This PR completes Issue 32 Frontend Mobile Adaptation Dashboard Screen._

## Completed In This PR

- Rebuilt the native/mobile Discovery Dashboard so it matches the narrow web Dashboard structure instead of using the previous simplified mobile placeholder.
- Preserved the full Dashboard story on mobile:
  - hero/intro
  - country selector
  - KPI flip cards
  - Chapters 1-4
  - pull stats
  - CTA buttons
  - warning/info tags
  - chart cards and legends
  - Chapter 4 CD/song reference
  - conclusion section
  - About This Data
- Replaced Recharts usage on native/mobile with app-owned React Native chart components.
- Added native/mobile chart support for:
  - Discovery Gap Distribution
  - Isolation Scores By Country
  - Global Overlap Rate
  - Average Countries Per Song
- Kept Dashboard chart values API-backed instead of adding fake mobile-only data.
- Added tap-selected chart behavior so mobile users can inspect values without hover tooltips.
- Used theme colors and gradient treatments across the native/mobile chart cards and bars.
- Added mobile Dashboard CTA wiring so Dashboard actions can open:
  - Discovery Map
  - Hidden Gems
  - Comparison Mode

## Welcome / Navigation Fixes

- Fixed Welcome route selection so tapping Discovery Dashboard does not briefly flash through Discovery Map first.
- Preserved wide-web Welcome behavior where the Discovery Globe can show behind the translucent Welcome modal.
- Updated native/mobile and compact-width Welcome behavior so the header, breadcrumbs, and mobile bottom nav remain visible and usable while Welcome is active.
- Kept mobile bottom nav order aligned with web:
  - Discovery Map
  - Discovery Dashboard
  - Compare
  - Hidden Gems
  - Credits

## Mobile UI Fixes

- Fixed KPI flip-card sizing so cards stay the same height before and after being tapped/flipped on native mobile.
- Applied the same no-shrink KPI flip-card behavior to compact/mobile-width web.
- Added breathing room to large Dashboard numbers so values such as percentages, point totals, and ceiling country counts do not clip on the right edge.
- Added animated Dashboard loading copy:

`Loading Discovery Dashboard...`

## Documentation Updated

- Updated the personal implementation timeline.
- Updated QA log documentation.
- Updated frontend architecture documentation.
- Updated screen data-flow documentation.
- Updated interaction/loading/overlay rules.

## Verification

- `npm run typecheck`
- User tested the Dashboard on Expo native mobile.
- User tested compact/mobile-width web behavior.

## Reviewer Checks

- Open the app in Expo native mobile.
- Open Welcome and confirm the header, breadcrumb trail, and mobile bottom nav remain visible.
- Tap Discovery Dashboard from Welcome and confirm it does not flash Discovery Map first.
- Confirm every Dashboard section appears on mobile.
- Tap KPI cards and confirm they flip without changing height.
- Tap chart bars/rows and confirm selected-value states work.
- Confirm large numeric values are not clipped.
- Resize web to mobile width and confirm compact web KPI flip cards also keep the same height.
