### PR TITLE
136 Cross checking SP noted quirks against functionality

### DIFF
--- a/backend/Capstone.API/database/Documentation/sp-build-notes.md
+++ b/backend/Capstone.API/database/Documentation/sp-build-notes.md
@@ -226,7 +226,7 @@ EXEC sp_PopulateTopSongByCountryYear;     -- fast — independent; reads base ta
 ## Known Quirks for QA Reference
  
 - `sp_PopulateGlobalOverlapByYear` inserts a **synthetic gap row for 2022** with all NULL metric columns and `is_gap = 1`. This is intentional — Recharts uses it to render the dashed line segment across the 22-month data gap. Do not flag as a data error during QA.
-- `sp_GetCountryProfile` unique songs result set uses `NOT EXISTS` against `HiddenGems` as a proxy for local presence. If `sp_PopulateHiddenGems` has not been run, this result set will return incorrectly inflated results.
+- `sp_GetCountryProfile` **shared songs** result set uses `NOT EXISTS` against `HiddenGems` (filtered by country_id) to exclude songs already categorised as hidden gems for this country from the shared list. If `sp_PopulateHiddenGems` has not been run, the shared songs result set will include those songs. The unique songs result set also has a `NOT EXISTS` against `HiddenGems`, but it is dead code — `country_count = 1` songs can never appear in `HiddenGems` (which requires `country_count >= @MinCountries = 3`), so that filter never matches anything.
 - All read procedures assume population procedures have been run. Running read procedures against empty summary tables will return empty result sets, not errors.
 - `sp_PopulateHiddenGems` accepts `@MinCountries INT = 3` — default threshold is 3 countries. Can be re-run with a different threshold: `EXEC sp_PopulateHiddenGems @MinCountries = 5`
 - Audio feature columns on `DIM_Song` are NULL for all DS1-only songs that were never matched to a DS2 entry. Any component using audio features must handle NULL values. 24,983 songs have audio features populated — all from DS2 coverage.

--- a/backend/Capstone.API/database/Documentation/stored-procedures-reference.md
+++ b/backend/Capstone.API/database/Documentation/stored-procedures-reference.md
@@ -446,7 +446,7 @@ EXEC sp_GetGlobalOverlapTrend
  
 - `GlobalOverlapByYear` contains a synthetic row for 2022 with `is_gap = 1` and all metric columns `NULL`. This is intentional for Recharts gap rendering — do not flag as a data error during QA.
 - All read procedures assume population procedures have been run. Running read procedures against empty summary tables returns empty result sets, not errors.
-- `sp_GetCountryProfile` shared and unique song result sets use `NOT EXISTS` against `HiddenGems` as a proxy for local chart presence. Results will be incorrect if `sp_PopulateHiddenGems` has not been run.
+- `sp_GetCountryProfile` **shared songs** result set uses `NOT EXISTS` against `HiddenGems` (filtered by country_id) to exclude songs already categorised as hidden gems for this country. If `sp_PopulateHiddenGems` has not been run, those songs will appear in the shared list. The unique songs result set also has a `NOT EXISTS` against `HiddenGems`, but it is dead code — `country_count = 1` songs can never be in `HiddenGems` (which requires `country_count >= @MinCountries = 3`), so that filter never matches anything.
 - `sp_PopulateHiddenGems` can be re-run independently with a different `@MinCountries` threshold without re-running any other population procedure.
 - Audio feature columns on `DIM_Song` are NULL for all DS1-only songs. Any component using audio features must handle NULL values gracefully.
 - `TopSongByCountryYear` uses `TRUNCATE` before each repopulation — running `sp_PopulateTopSongByCountryYear` twice is safe. If the table is empty, `sp_GetDiscoverPageInfo` still returns rows but `top_album_name` and `top_artist_name` will be `NULL` for all countries.


### PR DESCRIPTION
## Summary

Closes #136. Reviewed all known quirks in the stored procedure build notes against the actual SQL files and corrected inaccurate documentation for `sp_GetCountryProfile`.

**Finding:** The quirk for `sp_GetCountryProfile` incorrectly described the `NOT EXISTS` against `HiddenGems` as applying to both the shared and unique songs result sets, and warned that unpopulated `HiddenGems` would inflate unique song results. After checking the SQL:

- The **shared songs** `NOT EXISTS` (filtered by `country_id`) is meaningful — it prevents songs already categorised as hidden gems for this country from also appearing in the shared list
- The **unique songs** `NOT EXISTS` is dead code — `country_count = 1` songs can never appear in `HiddenGems`, which requires `country_count >= @MinCountries = 3`, so the filter never matches anything

All other quirks were verified against the stored procedures and are accurate. No SP logic changes required.

**Files updated**
- `backend/Capstone.API/database/Documentation/sp-build-notes.md` — corrected quirk 2
- `backend/Capstone.API/database/Documentation/stored-procedures-reference.md` — corrected matching quirk

## Test plan
- [ ] Read the updated quirk in both files and confirm the shared/unique distinction is clear
- [ ] Confirm no other references to the old wording exist in the database documentation
