### PR TITLE
Completed Issue 135 Add 2023 Data Disclaimer

### DIFF
--- a/Documentation/QA-log.md
+++ b/Documentation/QA-log.md
@@ -3,6 +3,44 @@
 
 ---
 
+## 2026-05-21 — Issue #135: 2023 Limited Data Disclaimer
+
+**Tester:** mp3li / Codex-assisted verification
+**Fix owner:** mp3li / Codex-assisted implementation
+**Branch:** `135-debug-add-2023-data-disclaimer-anywhere-2023-is-an-option`
+**Scope:** `YearDataDisclaimer`, Discovery Map, Country Detail, Hidden Gems, Comparison Mode, Comparison View
+
+### What was fixed
+
+- Added a small reusable `YearDataDisclaimer` component for the 2023 limited-data notice.
+- The notice renders only when the actively viewed year is `2023`.
+- Added the notice to the main year-driven app views:
+  - Discovery Map
+  - Country Detail
+  - Hidden Gems
+  - Comparison Mode
+  - Comparison View country panes
+- Kept the copy concise: `2023 has limited data and may slightly skew results. New data coming soon.`
+- Styled the notice with the app's existing gem icon, gradient, border, typography, and compact callout treatment.
+- Right-aligned the notice on Discovery Map, Country Detail, Hidden Gems, and Comparison Mode.
+- In Comparison View, each pane evaluates its own selected year so only panes viewing 2023 show the notice.
+
+### How to test
+
+1. Open Discovery Map, select 2023, and confirm the notice appears on the right side of the page.
+2. Change Discovery Map to a non-2023 year and confirm the notice disappears.
+3. Open Country Detail, select 2023, and confirm the notice appears below the country/year header on the right.
+4. Open Hidden Gems, select 2023, and confirm the notice appears below the top blurb controls on the right.
+5. Open Comparison Mode, select 2023, and confirm the notice appears below the blurb on the right.
+6. Open Comparison View and set one pane to 2023; confirm the notice appears only in that pane.
+7. Resize web to a narrow/mobile width and confirm the notice wraps cleanly without overlapping the year controls.
+
+### Verification
+
+- `npm run typecheck` passed after the Issue #135 changes.
+
+---
+
 ## 2026-05-19 — Discovery Map Showing "No Song Data" for DS1 Years (Issue #148)
 
 **Tester:** Eli (reviewer, PR #137 — flagged in PR review comments, not in this log)

--- a/Documents/mp3li implementation timeline document.txt
+++ b/Documents/mp3li implementation timeline document.txt
@@ -1,6 +1,27 @@
 mp3li implementation timeline document
 
-Updated: May 17, 2026
+Updated: May 21, 2026
+
+Issue 135 - 2023 Data Disclaimer (May 21, 2026)
+- Objective:
+  - Add a visible, lightweight notice anywhere the user actively views 2023 because the 2023 dataset is incomplete and can skew results.
+  - Keep the notice small and consistent with the current app style instead of adding a large disruptive banner.
+
+- Frontend implementation completed:
+  - Added a reusable `YearDataDisclaimer` component that renders only when the active viewed year is `2023`.
+  - Used the app's existing gem icon, gradient, border, typography, and compact callout styling for the notice.
+  - Added the notice to Discovery Map, Country Detail, Hidden Gems, Comparison Mode, and Comparison View.
+  - Right-aligned the notice on Discovery Map, Country Detail, Hidden Gems, and Comparison Mode.
+  - In Comparison View, each country pane checks its own selected year so the warning appears only in panes currently viewing 2023.
+  - Kept the message concise: `2023 has limited data and may slightly skew results. New data coming soon.`
+
+- PR/documentation artifacts updated:
+  - Updated professional QA documentation with Issue 135 testing steps.
+  - Updated frontend architecture documentation to record the shared 2023 disclaimer component.
+  - Updated the PR markdown in `my txts/PR_Issue_135_2023_Data_Disclaimer.md`.
+
+- Verification completed:
+  - Ran frontend TypeScript checking after the Issue 135 changes.
 
 Credits Screen Content Completion for mp3li Portion (May 17, 2026)
 - Objective:

--- a/hidden-gem-music-app/Documentation/frontend-architecture.md
+++ b/hidden-gem-music-app/Documentation/frontend-architecture.md
@@ -2,7 +2,7 @@
 
 **Project:** Hidden Gem Music Discovery Platform — SOFT290 Capstone
 **Author:** mp3li
-**Date:** 2026-05-15
+**Date:** 2026-05-21
 **Status:** Current Working Frontend Architecture
 
 ---
@@ -115,6 +115,14 @@ Shared visual primitives are mostly in:
 - `src/components/CdCaseArt.tsx`
 - `src/components/GemIcon.tsx`
 - `src/components/YearSlider.tsx`
+- `src/components/YearDataDisclaimer.tsx`
+
+2023 data disclaimer behavior:
+
+- `src/components/YearDataDisclaimer.tsx` owns the small inline notice for 2023-limited data.
+- The component renders nothing unless the active viewed year is `2023`.
+- Discovery Map, Country Detail, Hidden Gems, Comparison Mode, and Comparison View all reuse the same component instead of duplicating warning copy.
+- Comparison View evaluates each pane's selected year independently, so a 2023 notice can appear in only one pane when the other pane is viewing a different year.
 
 Theme ownership lives in:
 

--- a/hidden-gem-music-app/src/components/YearDataDisclaimer.tsx
+++ b/hidden-gem-music-app/src/components/YearDataDisclaimer.tsx
@@ -1,0 +1,59 @@
+import { LinearGradient } from "expo-linear-gradient";
+import { StyleSheet, Text, View, ViewStyle } from "react-native";
+
+import { colors } from "../theme/colors";
+import { typefaces } from "../theme/typography";
+import { GemIcon } from "./GemIcon";
+
+type Props = {
+  year?: number | null;
+  style?: ViewStyle | ViewStyle[];
+};
+
+export function YearDataDisclaimer({ year, style }: Props) {
+  if (year !== 2023) {
+    return null;
+  }
+
+  return (
+    <View style={[styles.shell, style]}>
+      <LinearGradient
+        colors={["rgba(117,82,107,0.34)", "rgba(108,119,142,0.28)", "rgba(35,38,55,0.24)"]}
+        locations={[0, 0.58, 1]}
+        start={{ x: 0, y: 0.5 }}
+        end={{ x: 1, y: 0.5 }}
+        style={styles.fill}
+      />
+      <GemIcon size={13} />
+      <Text style={styles.text}>2023 has limited data and may slightly skew results. New data coming soon.</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  shell: {
+    alignSelf: "flex-start",
+    maxWidth: "100%",
+    minHeight: 32,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: "rgba(117,82,107,0.64)",
+    backgroundColor: "rgba(22,26,38,0.18)",
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 7,
+    paddingHorizontal: 10,
+    paddingVertical: 7,
+    overflow: "hidden",
+  },
+  fill: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  text: {
+    flexShrink: 1,
+    color: colors.textLight,
+    fontFamily: typefaces.body,
+    fontSize: 13,
+    lineHeight: 18,
+  },
+});

--- a/hidden-gem-music-app/src/screens/ComparisonResultsScreen.tsx
+++ b/hidden-gem-music-app/src/screens/ComparisonResultsScreen.tsx
@@ -21,6 +21,7 @@ import { GemIcon } from "../components/GemIcon";
 import { Panel } from "../components/Panel";
 import { ScreenScaffold } from "../components/ScreenScaffold";
 import { SecondarySurfaceFill } from "../components/SecondarySurfaceFill";
+import { YearDataDisclaimer } from "../components/YearDataDisclaimer";
 import { getCachedCountryGenreSamples, getCachedCountryLanguageSamples, loadAvailableYears, loadCountryHiddenGemsPreview, loadCountryProfile, loadCountrySongsPage } from "../data/countryApi";
 import { hasKnownSongTitle, mapApiCountryProfile, mapApiSong } from "../data/apiMappers";
 import { collectUniqueLanguagesFromSongs, enrichSongsWithLanguage, formatLanguageAndMore } from "../data/languageApi";
@@ -757,6 +758,7 @@ function ComparisonPaneDropdownStack({
           </Panel>
         ) : null}
       </View>
+      <YearDataDisclaimer year={selectedYear} style={styles.paneYearDisclaimer} />
     </View>
   );
 }
@@ -2122,6 +2124,11 @@ const styles = StyleSheet.create({
   },
   paneBottomYearDropdownWrap: {
     zIndex: 11,
+  },
+  paneYearDisclaimer: {
+    alignSelf: "flex-end",
+    width: 260,
+    maxWidth: 260,
   },
   paneDropdownShell: {
     borderRadius: 17,

--- a/hidden-gem-music-app/src/screens/ComparisonSelectScreen.tsx
+++ b/hidden-gem-music-app/src/screens/ComparisonSelectScreen.tsx
@@ -19,6 +19,7 @@ import { Panel } from "../components/Panel";
 import { ScreenScaffold } from "../components/ScreenScaffold";
 import { SecondarySurfaceFill } from "../components/SecondarySurfaceFill";
 import { GlobePanel } from "../components/globe/GlobePanel";
+import { YearDataDisclaimer } from "../components/YearDataDisclaimer";
 import { isCountryWithAppData } from "../data/countryDisplay";
 import { Country } from "../types/content";
 import { colors } from "../theme/colors";
@@ -903,6 +904,7 @@ export function ComparisonSelectScreen({
         }}
         onDone={handleDone}
       />
+      <YearDataDisclaimer year={comparisonYear} style={styles.comparisonYearDisclaimer} />
       <View
         style={[
           styles.layout,
@@ -927,6 +929,9 @@ const styles = StyleSheet.create({
   stack: {
     gap: 16,
     marginTop: -8,
+  },
+  comparisonYearDisclaimer: {
+    alignSelf: "flex-end",
   },
   blurbPanel: {
     minHeight: 80,

--- a/hidden-gem-music-app/src/screens/CountryScreen.tsx
+++ b/hidden-gem-music-app/src/screens/CountryScreen.tsx
@@ -20,6 +20,7 @@ import { GemIcon } from "../components/GemIcon";
 import { Panel } from "../components/Panel";
 import { ScreenScaffold } from "../components/ScreenScaffold";
 import { SecondarySurfaceFill } from "../components/SecondarySurfaceFill";
+import { YearDataDisclaimer } from "../components/YearDataDisclaimer";
 import { getCachedCountryGenreSamples, getCachedCountryLanguageSamples, loadAvailableYears, loadCountryHiddenGemsPreview, loadCountryProfile, loadCountrySongsPage } from "../data/countryApi";
 import { hasKnownSongTitle, mapApiCountryProfile, mapApiSong } from "../data/apiMappers";
 import { collectUniqueLanguagesFromSongs, enrichSongsWithLanguage, formatLanguageAndMore } from "../data/languageApi";
@@ -2131,6 +2132,7 @@ export function CountryScreen({
             />
           </View>
         </View>
+        <YearDataDisclaimer year={selectedYear} style={styles.countryYearDisclaimer} />
 
         <CountryPageSection style={styles.countrySummarySection} fillVariant="comparisonBlue">
           <Text style={[styles.countrySummarySectionHeader, styles.countrySummarySectionTextDark]}>Country Summary</Text>
@@ -2318,6 +2320,9 @@ const styles = StyleSheet.create({
     paddingBottom: 24,
     paddingRight: 18,
     overflow: "visible",
+  },
+  countryYearDisclaimer: {
+    alignSelf: "flex-end",
   },
   pageScrollbarTrack: {
     position: "absolute",

--- a/hidden-gem-music-app/src/screens/DiscoveryScreen.tsx
+++ b/hidden-gem-music-app/src/screens/DiscoveryScreen.tsx
@@ -11,6 +11,7 @@ import { Panel } from "../components/Panel";
 import { ScreenScaffold } from "../components/ScreenScaffold";
 import { SecondarySurfaceFill } from "../components/SecondarySurfaceFill";
 import { YearSlider } from "../components/YearSlider";
+import { YearDataDisclaimer } from "../components/YearDataDisclaimer";
 import { loadCountryGenreSamples, loadCountryLanguageSamples } from "../data/countryApi";
 import { formatLanguageAndMore } from "../data/languageApi";
 import { useLoadingText } from "../hooks/useLoadingText";
@@ -593,6 +594,7 @@ export function DiscoveryScreen({
       />
       */}
       <DiscoveryBlurb />
+      <YearDataDisclaimer year={selectedYear} style={styles.discoveryYearDisclaimer} />
       <View style={[styles.layout, isStacked ? styles.layoutStacked : null]}>
         {isStacked ? globeColumn : listColumn}
         {isStacked ? listColumn : globeColumn}
@@ -970,6 +972,9 @@ const styles = StyleSheet.create({
     paddingHorizontal: 20,
     paddingTop: 12,
     paddingBottom: 24,
+  },
+  discoveryYearDisclaimer: {
+    alignSelf: "flex-end",
   },
   layout: {
     flexDirection: "row",

--- a/hidden-gem-music-app/src/screens/HiddenGemsScreen.tsx
+++ b/hidden-gem-music-app/src/screens/HiddenGemsScreen.tsx
@@ -26,6 +26,7 @@ import { GemIcon } from "../components/GemIcon";
 import { Panel } from "../components/Panel";
 import { ScreenScaffold } from "../components/ScreenScaffold";
 import { SecondarySurfaceFill } from "../components/SecondarySurfaceFill";
+import { YearDataDisclaimer } from "../components/YearDataDisclaimer";
 import { getCachedHiddenGemsPage, loadCountryProfile, loadHiddenGemsPage } from "../data/countryApi";
 import { isCountryWithHiddenGems } from "../data/countryDisplay";
 import { hasKnownSongTitle, mapApiCountryProfile, mapApiHiddenGemPage } from "../data/apiMappers";
@@ -1906,6 +1907,7 @@ export function HiddenGemsScreen({
             </View>
           </View>
         </Panel>
+        <YearDataDisclaimer year={selectedYear} style={styles.hiddenGemsYearDisclaimer} />
         <View style={styles.layout}>
           <View style={[styles.primaryPanelsRow, isStacked ? styles.primaryPanelsRowStacked : null]}>
             {isStacked ? (
@@ -2737,6 +2739,9 @@ const styles = StyleSheet.create({
   layout: {
     gap: 12,
     alignItems: "stretch",
+  },
+  hiddenGemsYearDisclaimer: {
+    alignSelf: "flex-end",
   },
   primaryPanelsRow: {
     flexDirection: "row",


### PR DESCRIPTION
# PR: Issue 135 - Add 2023 Data Disclaimer

_This PR completes issue 135 - add 2023 data disclaimer._

## Completed In This PR

- Added a reusable `YearDataDisclaimer` component for the 2023 limited-data notice.
- The notice only renders when the active viewed year is `2023`.
- Added the notice to year-driven user flows:
  - Discovery Map
  - Country Detail
  - Hidden Gems
  - Comparison Mode
  - Comparison View country panes
- Styled the notice as a small inline callout using the app's existing gradient, border, typography, and gem icon treatment.
- Right-aligned the notice on Discovery Map, Country Detail, Hidden Gems, and Comparison Mode.
- Kept Comparison View pane dropdown placement unchanged while allowing the notice to align to the pane controls and wrap cleanly.
- Updated professional QA documentation, frontend architecture documentation, and mp3li's personal implementation timeline.
- Used text from Issue 135:

```text
2023 has limited data and may slightly skew results. New data coming soon.
```

## Behavior

- Selecting 2023 shows the notice near the relevant year-selection/header area.
- Selecting any other available year hides the notice.
- In Comparison View, each country pane checks its own selected year, so the notice can appear for only the pane currently viewing 2023.

## Verification

- `npm run typecheck`

## Reviewer Checks

- Open Discovery Map and select 2023; confirm the small notice appears.
- Change Discovery Map to a non-2023 year; confirm the notice disappears.
- Open Country Detail and select 2023; confirm the notice appears below the country/year header on the right.
- Open Hidden Gems and select 2023; confirm the notice appears below the top blurb controls on the right.
- Open Comparison Mode and select 2023; confirm the notice appears below the comparison blurb on the right.
- Open Comparison View and set one pane to 2023; confirm the notice appears only in that pane.
- Confirm Comparison View country/year dropdown placement did not shift.
- Resize web to mobile width and confirm the notice wraps cleanly without overlapping controls.