### PR TITLE
147 bug country pagescomparison

### DIFF
--- a/Documentation/QA-log.md
+++ b/Documentation/QA-log.md
@@ -3,6 +3,84 @@
 
 ---
 
+## 2026-05-21 — Discovery Map Genre/Language Sampling Fixes
+
+**Tester:** Leena Komenski
+**Fix owner:** Leena Komenski / Claude-assisted implementation
+**Scope:** `CountryRepository.cs`, `sp_GetCountrySongsPaged.sql`
+
+### What was noticed
+
+- Discovery Map showed identical genres (e.g. Alternative, R&B, Pop) for nearly every country in every year.
+- Country profile page genres did not match the genres of the country's own top songs — e.g. Australia 2023 showed "Classical" while none of its top songs were Classical.
+- Some countries (Egypt, Saudi Arabia, Morocco, Andorra) showed no genre or language at all.
+- Some variation in language across countries but far less than expected.
+
+### Root causes
+
+**1. `sp_GetCountrySongsPaged` not applied to database** — The SP was updated in this branch but not yet run in SSMS. The database still had the old query, which pulled from a global song pool with no country filter → same songs → same genres for all countries.
+
+**2. Deezer rate limiting from parallel prefix scans** — Commit `013b796` made the three genre prefix scans run in parallel. With 16 countries requested at once, this created up to 144 concurrent Deezer calls, exceeding the 50/4.9s rate limiter and causing Egypt, Saudi Arabia, Morocco, and Andorra to return no genre or language data. The rate limiter was known to handle individual call bursts correctly — the oversight was not accounting for how parallelizing the prefix scans multiplied the burst size when many countries load simultaneously.
+
+### Fixes applied
+
+- **Ran `sp_GetCountrySongsPaged.sql` in SSMS** — primary fix for identical genres across all countries.
+- **Reverted prefix scans to sequential** in `GetCountryGenreSampleAsync` — fixes missing genre/language data for non-Latin-alphabet countries.
+- **Deezer fallback investigated, not changed** — splitting `SelectBestTrackMatch` into strict (genre sampling) and permissive (Hidden Gems) paths was prototyped and reverted. The SP fix is the root cause; the original `FirstOrDefault()` fallback is preserved.
+
+### Steps to apply
+
+1. Run `sp_GetCountrySongsPaged.sql` in SSMS (required — root cause of same-genres-everywhere).
+2. Delete `backend\Capstone.API\Data\discovery_samples_cache.json` and restart the server.
+3. Delete `backend\Capstone.API\live_song_enrichment_cache\live_song_cache.json` if any bad fallback matches are cached from before this fix (optional but recommended for a clean slate).
+
+### ⚠️ Eli — profile page genre source: review requested
+
+`GetCountryProfileAsync` currently calls `GetCountryGenreSampleAsync` (your original prefix-based approach) for `SampleGenres`. During this investigation an alternative was prototyped and reverted — flagging for your review:
+
+**Option A (current — Eli's original):** `GetCountryGenreSampleAsync` — prefix heuristic samples from the full catalog for genre diversity. Costs extra Deezer calls on profile load; genres may not match the specific top songs shown on screen.
+
+**Option B (prototyped, reverted):** Derive `SampleGenres` from the already-enriched `TopSharedSongs` + `TopUniqueSongs` directly. Zero extra Deezer calls; genres always match the visible songs. Risk: top shared songs are ordered by `country_count DESC` (most globally popular), so genres may skew toward mainstream Pop/R&B and miss local genres that don't chart globally.
+
+Kept Option A on the assumption that genre diversity was intentional. Please confirm.
+
+### How to test
+
+1. Open Discovery Map for 2021 — confirm countries show different genres from each other.
+2. Open a country profile — confirm the listed genres match those on the visible top song cards.
+3. Check Egypt or Saudi Arabia — may show fewer genres than English-speaking countries due to Deezer match confidence on non-Latin titles; this is expected.
+
+---
+
+## 2026-05-21 — Country Profile KPI Card Label Improvements
+
+**Tester:** TBD
+**Fix owner:** ⚠️ Frontend change needed — flagged for Eli
+**Scope:** Frontend Country Detail page — KPI summary cards
+
+### What was noticed
+
+The KPI card labels on the country profile page don't clearly communicate what they're showing to a new viewer:
+
+| Current label | Suggested label | Notes |
+|---|---|---|
+| Songs in this view | **Total songs charted** | "In this view" is ambiguous — clarify it's the total for the country/year |
+| Loved in This Country | **X unique songs** | Show the actual count; "Loved in This Country" reads like a section heading, not a stat |
+| Loved Here and Elsewhere | **X shared songs** | Same — lead with the number, label describes what it counts |
+| _(overlap % card)_ | See options below | Currently shows `overlap_pct` with label "% of this view" — misleading |
+
+### ⚠️ Eli — overlap percentage card copy
+
+`overlap_pct` = `shared_count / total_charted` — the percentage of this country's charting songs that also appeared in at least one other country's charts that year. The current label "% of this view" doesn't explain this. Suggested options (or choose something else entirely):
+
+- **"of songs here also charted abroad"** — plain and accurate
+- **"international chart overlap"** — short, reads like a stat label
+- **"of this year's chart crossed borders"** — more expressive
+
+No backend changes needed — `overlap_pct` is already returned in the profile response from `CountryYearStats`.
+
+---
+
 ## 2026-05-21 — Issue #135: 2023 Limited Data Disclaimer
 
 **Tester:** mp3li / Codex-assisted verification
@@ -221,6 +299,7 @@ Index alone reduced cold-load time by ~2 s (~20 s → ~18 s). Retest with all th
 ---
 
 ## 2026-05-19 — CountryRepository Parallel Deezer Enrichment
+_(updated 2026-05-21 — items 3 and 4 revised; see 2026-05-21 Discovery Map Genre/Language Sampling Fixes)_
 
 **Tester:** Leena Komenski
 **Fix owner:** Leena Komenski / Claude-assisted implementation
@@ -234,19 +313,19 @@ Four changes were made to `CountryRepository.cs`:
 
 **1. `EnrichSongRowsAsync` — parallel enrichment**
 
-Changed from sequential `foreach await` to `Task.WhenAll`. All songs in a list now enrich concurrently. The `DeezerSongEnrichmentService` has a built-in sliding window rate limiter (50 req / 4.9 s) that prevents overloading the Deezer API.
+Changed from sequential `foreach await` to `Task.WhenAll`. All songs in a list now enrich concurrently. The `DeezerSongEnrichmentService` has a built-in sliding window rate limiter (50 req / 4.9 s), but this only throttles individual calls — it does not prevent burst overload when many countries are loaded simultaneously on the Discovery Map.
 
 **2. `GetHiddenGemsPreviewAsync` — parallel enrichment**
 
 Changed from sequential `foreach await` to `Task.WhenAll` over all raw rows, with deduplication and limit applied in a post-filter pass over the results.
 
-**3. `GetCountryGenreSampleAsync` — parallel prefix scans**
+**3. `GetCountryGenreSampleAsync` — parallel prefix scans** ⚠️ reverted 2026-05-21
 
-The three prefix scans ("B", "I", "Y") previously ran one after another. They now run concurrently with independent `seenGenres` sets; results are deduplicated after all tasks complete.
+The three prefix scans ("B", "I", "Y") were changed to run concurrently. In practice, with 16 countries loading simultaneously on the Discovery Map, this created up to 144 burst Deezer calls, exceeding the rate limiter window and causing countries at the back of the queue to return no genre or language data. **Reverted to sequential prefix scans** in the 2026-05-21 genre sampling fix.
 
 **4. `GetCountryProfileAsync` — parallel sub-operations**
 
-Shared songs enrichment, unique songs enrichment, and genre sample fetch previously ran sequentially. All three now start together via `Task.WhenAll`.
+Shared songs enrichment and unique songs enrichment run together via `Task.WhenAll`. Genre sampling was later removed from this `Task.WhenAll` (2026-05-21) — the profile now derives genres from the already-enriched top songs instead of making a separate sampling pass.
 
 **Dead code removed**
 

--- a/Documentation/QA-log.md
+++ b/Documentation/QA-log.md
@@ -3,6 +3,116 @@
 
 ---
 
+## 2026-05-19 — sp_GetCountryProfile Unique Songs Returning Wrong-Country Songs
+
+**Tester:** Leena Komenski
+**Fix owner:** Leena Komenski / Claude-assisted implementation
+**Scope:** `sp_GetCountryProfile.sql`, `presentation_data_cache.json`
+
+### What was noticed
+
+Country Profile pages for Japan (JP) and Brazil (BR) for 2020 displayed Swedish and Polish songs (Maximillian, Benjamin Ingrosso, Szpaku, TIX) as "top unique songs," with those artists listed as country favorites. These are regional Northern/Eastern European artists with no meaningful chart presence in Japan or Brazil.
+
+### Root cause
+
+The "Top 10 Unique Songs" query in `sp_GetCountryProfile` was missing a country filter on its `NOT EXISTS` clause:
+
+```sql
+-- Bug: no country_id filter — passes for ANY country
+AND NOT EXISTS (
+    SELECT 1 FROM HiddenGems hg3
+    WHERE hg3.song_id    = scp.song_id
+      AND hg3.chart_year = @Year
+)
+```
+
+`SongCountryPresence` contains all songs that chart globally. The query found songs with `country_count = 1` (charting in exactly one country) that are not in anyone's `HiddenGems` list — but never verified that the one country they chart in is actually the requested country. Every Swedish or Norwegian regional song qualified.
+
+Compare to the shared songs query above it, which correctly scopes the `NOT EXISTS` to `hg2.country_id = (SELECT country_id FROM Country WHERE iso_code = @CountryCode)`.
+
+### Fix applied
+
+Added the missing country filter to the unique songs `NOT EXISTS`:
+
+```sql
+AND NOT EXISTS (
+    SELECT 1 FROM HiddenGems hg3
+    WHERE hg3.country_id = (SELECT country_id FROM Country WHERE iso_code = @CountryCode)
+      AND hg3.song_id    = scp.song_id
+      AND hg3.chart_year = @Year
+)
+```
+
+### Known limitation (deferred)
+
+`sp_PopulateHiddenGems` uses `@MinCountries = 3`, so only songs charting in 3+ countries are written to `HiddenGems`. Songs with `country_count = 1` or `2` are never in `HiddenGems` for any country. This means "NOT IN HiddenGems for country X" is an imperfect proxy for "charts in country X" for low-count songs. Fixing this properly without querying `ChartEntry` (28M rows) directly is non-trivial and deferred.
+
+### Cache action required
+
+`presentation_data_cache.json` was already populated with the wrong data (wrong songs cached under `COUNTRY-PROFILE::JP::2020`, `COUNTRY-PROFILE::BR::2020`, and likely others). After applying the SP fix in SSMS, delete the file so profiles rebuild from the corrected SP:
+
+```
+backend\Capstone.API\Data\presentation_data_cache.json
+```
+
+### How to test
+
+1. Run the updated `sp_GetCountryProfile.sql` in SSMS.
+2. Delete `presentation_data_cache.json` and restart the server.
+3. Load Japan 2020 and Brazil 2020 country profiles — unique songs and favorite artists should now reflect locally charted artists, not Northern/Eastern European regional artists.
+4. Spot-check a known culturally distinct country (e.g. JP, AR, TR) to confirm its unique songs are plausibly from that market.
+
+---
+
+## 2026-05-19 — Controller Response Caching (Comparison, Discovery, Metadata)
+
+**Tester:** Leena Komenski
+**Fix owner:** Leena Komenski / Claude-assisted implementation
+**Scope:** `ComparisonController.cs`, `DiscoveryController.cs`, `MetadataController.cs`
+
+### What was investigated
+
+Network tab on the Discovery page showed `countries?year=2020` and `years` both taking ~3.78–3.79 s on cold load. Comparison page took ~20 s total for a first load despite `sp_GetCountryComparison` running near-instantly in SSMS after the performance fixes.
+
+Three controllers had no caching at all — every request hit the database directly:
+
+- **`DiscoveryController`** — called `GetAvailableYearsAsync` and `GetGlobeSummaryAsync` on every request with no caching. `GetGlobeSummaryAsync` returns 46.4 kB of globe summary data and was the source of the 3.79 s cold hit.
+- **`MetadataController`** — `GetAvailableYears` called `GetAvailableYearsAsync` directly on every request. No caching.
+- **`ComparisonController`** — `IsAvailableYearAsync` called `GetAvailableYearsAsync` on every comparison request with no cache. The comparison result itself was never cached — every `/api/comparison` hit ran the full SP.
+
+Compare to `CountryController`, which caches available years in `IMemoryCache` (5-minute TTL) and caches full profile responses in `IPresentationDataCacheService` (file-backed, survives restarts).
+
+### Fixes applied
+
+**`DiscoveryController`:**
+- Added `IMemoryCache` dependency.
+- Available years check: `IMemoryCache.GetOrCreateAsync` with 5-minute TTL.
+- Globe summary result: `IMemoryCache.GetOrCreateAsync` with 30-minute TTL keyed by year (`discovery-globe::{year}`).
+
+**`MetadataController`:**
+- Added `IMemoryCache` dependency.
+- Years response: `IMemoryCache.GetOrCreateAsync` with 5-minute TTL.
+
+**`ComparisonController`:**
+- Added `IMemoryCache` and `IPresentationDataCacheService` dependencies.
+- `IsAvailableYearAsync`: now uses `IMemoryCache.GetOrCreateAsync` with 5-minute TTL (same pattern as `CountryController`).
+- `GetCountryComparison`: checks `IPresentationDataCacheService` before hitting the SP; writes result to file-backed cache after first load.
+- `GetComparisonHiddenGems`: same file-backed cache check/write.
+
+### Expected behavior after fix
+
+- **Second load** of any comparison pair or discovery globe year: near-instant (file-backed cache for comparison, memory cache for globe/years).
+- **First load after server restart**: `countries?year=X` and `years` still hit DB once per year per restart (~3.8 s), then serve from memory. Comparison pairs still hit DB once, then serve from file-backed cache across restarts.
+
+### How to test
+
+1. Restart server with a cleared `presentation_data_cache.json`.
+2. Load the Discovery page — `countries?year=X` will be slow on first load; navigate away and back — should be near-instant on second load.
+3. Load a comparison pair (e.g. SE/VN 2020) — first load slow; second load should be instant regardless of server restart.
+4. Confirm `/api/metadata/years` returns the same data as before.
+
+---
+
 ## 2026-05-19 — sp_GetCountryComparison Performance Analysis
 
 **Tester:** Leena Komenski

--- a/Documentation/QA-log.md
+++ b/Documentation/QA-log.md
@@ -41,64 +41,67 @@
 
 ---
 
-## 2026-05-19 — sp_GetCountryProfile Unique Songs Returning Wrong-Country Songs
+## 2026-05-19 / 2026-05-21 — Wrong-Country Songs in Country Profile and Comparison Pages
 
-**Tester:** Leena Komenski
+**Tester:** Leena Komenski; Eli (independent confirmation for USA 2025)
 **Fix owner:** Leena Komenski / Claude-assisted implementation
-**Scope:** `sp_GetCountryProfile.sql`, `presentation_data_cache.json`
+**Scope:** `sp_GetCountryProfile.sql`, `sp_GetCountrySongsPaged.sql`, `sp_GetCountryComparison.sql`, `SongCountryChart` (new table), `sp_PopulateSongCountryChart.sql`, `presentation_data_cache.json`
 
 ### What was noticed
 
-Country Profile pages for Japan (JP) and Brazil (BR) for 2020 displayed Swedish and Polish songs (Maximillian, Benjamin Ingrosso, Szpaku, TIX) as "top unique songs," with those artists listed as country favorites. These are regional Northern/Eastern European artists with no meaningful chart presence in Japan or Brazil.
+Country Profile pages for Japan (JP) and Brazil (BR) for 2020 displayed Swedish and Polish songs (Maximillian, Benjamin Ingrosso, Szpaku, TIX) as "top unique songs," with those artists listed as country favorites. Eli independently flagged that USA 2025 showed unrecognized artists in "Favorite Artists" and songs he didn't recognize in the "Loved Here" section — he noted the results appeared "more year/global SongCountryPresence based rather than explicitly songs that charted in this selected country."
 
 ### Root cause
 
-The "Top 10 Unique Songs" query in `sp_GetCountryProfile` was missing a country filter on its `NOT EXISTS` clause:
+`SongCountryPresence` tracks `(song_id, chart_year, country_count)` — a global count with no `country_id` column. There is no way to ask "did this song chart in Japan?" from that table. All three SPs used `HiddenGems` as a proxy: if a song is not in country X's HiddenGems list, treat it as charting in X. This proxy is fundamentally broken for unique songs.
+
+`sp_PopulateHiddenGems` uses `@MinCountries = 3`, so only songs charting in 3+ countries are written to `HiddenGems`. Songs with `country_count = 1` or `2` are never in HiddenGems for any country. For the unique songs queries (`country_count = 1`), the `NOT EXISTS (HiddenGems)` clause was always true for every country — it never filtered anything. Every globally-unique regional song qualified as "unique to" any requested country.
+
+Additionally, `sp_GetCountrySongsPaged` (the paginated "Loved Here" / "Loved Here and Elsewhere" source) had the same structural flaw in its unique branch. `sp_GetCountryComparison` RS4 and RS5 ("unique to A" / "unique to B") used the same HiddenGems anti-join pattern with the same limitation.
+
+An earlier partial fix (2026-05-19) added a `country_id` filter to the `NOT EXISTS` clause in `sp_GetCountryProfile`, but this did not change the results — since `country_count = 1` songs are never in HiddenGems regardless, the filter was a no-op.
+
+### Fix applied (2026-05-21)
+
+Created `SongCountryChart (song_id, country_id, chart_year)` — a pre-computed lookup table derived from `ChartEntry` (Top 200 only, `chart_type_id != 2` for Viral 50 exclusion, consistent with `sp_PopulateSongCountryPresence`). Populated by `sp_PopulateSongCountryChart`.
+
+Replaced the HiddenGems proxy with a direct join/exists on `SongCountryChart` in all three SPs:
 
 ```sql
--- Bug: no country_id filter — passes for ANY country
-AND NOT EXISTS (
-    SELECT 1 FROM HiddenGems hg3
-    WHERE hg3.song_id    = scp.song_id
-      AND hg3.chart_year = @Year
+-- sp_GetCountryProfile (shared and unique songs):
+JOIN SongCountryChart scc
+    ON scc.song_id    = scp.song_id
+   AND scc.country_id = @CountryId
+   AND scc.chart_year = @Year
+
+-- sp_GetCountrySongsPaged (both branches):
+AND EXISTS (
+    SELECT 1 FROM SongCountryChart scc
+    WHERE scc.song_id    = scp.song_id
+      AND scc.country_id = @CountryId
+      AND scc.chart_year = @Year
 )
+
+-- sp_GetCountryComparison RS4/RS5 (anti-join via LEFT JOIN / WHERE IS NULL):
+WITH InA AS (SELECT scc.song_id FROM SongCountryChart scc WHERE scc.country_id = @CountryIdA ...)
+WITH NotInB AS (SELECT scc.song_id FROM SongCountryChart scc WHERE scc.country_id = @CountryIdB ...)
 ```
 
-`SongCountryPresence` contains all songs that chart globally. The query found songs with `country_count = 1` (charting in exactly one country) that are not in anyone's `HiddenGems` list — but never verified that the one country they chart in is actually the requested country. Every Swedish or Norwegian regional song qualified.
+`SongCountryChart` has a clustered PK on `(song_id, country_id, chart_year)` for song-first joins, and `IX_SongCountryChart_Country_Year` on `(country_id, chart_year)` for country-first lookups in the comparison SP CTEs.
 
-Compare to the shared songs query above it, which correctly scopes the `NOT EXISTS` to `hg2.country_id = (SELECT country_id FROM Country WHERE iso_code = @CountryCode)`.
+### Steps to apply
 
-### Fix applied
-
-Added the missing country filter to the unique songs `NOT EXISTS`:
-
-```sql
-AND NOT EXISTS (
-    SELECT 1 FROM HiddenGems hg3
-    WHERE hg3.country_id = (SELECT country_id FROM Country WHERE iso_code = @CountryCode)
-      AND hg3.song_id    = scp.song_id
-      AND hg3.chart_year = @Year
-)
-```
-
-### Known limitation (deferred)
-
-`sp_PopulateHiddenGems` uses `@MinCountries = 3`, so only songs charting in 3+ countries are written to `HiddenGems`. Songs with `country_count = 1` or `2` are never in `HiddenGems` for any country. This means "NOT IN HiddenGems for country X" is an imperfect proxy for "charts in country X" for low-count songs. Fixing this properly without querying `ChartEntry` (28M rows) directly is non-trivial and deferred.
-
-### Cache action required
-
-`presentation_data_cache.json` was already populated with the wrong data (wrong songs cached under `COUNTRY-PROFILE::JP::2020`, `COUNTRY-PROFILE::BR::2020`, and likely others). After applying the SP fix in SSMS, delete the file so profiles rebuild from the corrected SP:
-
-```
-backend\Capstone.API\Data\presentation_data_cache.json
-```
+1. In SSMS, uncomment and run the `CREATE TABLE` + `CREATE INDEX` block from `sp_PopulateSongCountryChart.sql`.
+2. Run the rest of that file to create the SP, then `EXEC sp_PopulateSongCountryChart;`
+3. Run `sp_GetCountryProfile.sql`, `sp_GetCountrySongsPaged.sql`, and `sp_GetCountryComparison.sql` in SSMS.
+4. Delete `backend\Capstone.API\Data\presentation_data_cache.json` and restart the server.
 
 ### How to test
 
-1. Run the updated `sp_GetCountryProfile.sql` in SSMS.
-2. Delete `presentation_data_cache.json` and restart the server.
-3. Load Japan 2020 and Brazil 2020 country profiles — unique songs and favorite artists should now reflect locally charted artists, not Northern/Eastern European regional artists.
-4. Spot-check a known culturally distinct country (e.g. JP, AR, TR) to confirm its unique songs are plausibly from that market.
+1. Load Japan 2020 and Brazil 2020 country profiles — unique songs and favorite artists should reflect locally charted artists.
+2. Load USA 2025 — "Loved Here" and "Favorite Artists" should show recognizable US chart artists.
+3. Load a comparison pair with culturally distinct countries (e.g. JP vs. BR 2020) — "unique to A" and "unique to B" lists should contain artists plausibly from those markets.
+4. Spot-check a DS2 year (2024 or 2025) for a non-English-speaking country (e.g. TR, AR, KR) to confirm local artists appear.
 
 ---
 

--- a/Documentation/QA-log.md
+++ b/Documentation/QA-log.md
@@ -3,10 +3,166 @@
 
 ---
 
+## 2026-05-19 — sp_GetCountryComparison Performance Analysis
+
+**Tester:** Leena Komenski
+**Fix owner:** Leena Komenski
+**Scope:** `sp_GetCountryComparison.sql`, `HiddenGems` table indexes
+
+### What was investigated
+
+Comparison page cold-first-load was taking ~20 seconds for uncached country pairs (e.g. SE/VN 2020). Unlike Country Profile, `ComparisonController` and `ComparisonRepository` use no presentation data cache and no Deezer enrichment — the full 20 seconds is pure DB query time for `sp_GetCountryComparison`.
+
+### Issues identified in the SP
+
+**1. `NOT EXISTS` correlated subqueries with likely missing index (highest impact)**
+
+Result sets 3, 4, and 5 all use this pattern for every row scanned from `SongCountryPresence`:
+
+```sql
+AND NOT EXISTS (
+    SELECT 1 FROM HiddenGems hg
+    WHERE hg.country_id = @CountryIdA
+      AND hg.song_id    = scp.song_id
+      AND hg.chart_year = @Year
+)
+```
+
+Without a composite index on `HiddenGems (country_id, chart_year, song_id)`, SQL Server scans the table for each row. Adding the index turns this into a seek.
+
+**2. Double join to `SongCountryPresence` in result set 3**
+
+`InA` already reads from `SongCountryPresence`, but the main SELECT joins it again to get `country_count` for `ORDER BY`. Carrying `country_count` through the CTE eliminates the second scan:
+
+```sql
+WITH InA AS (
+    SELECT scp.song_id, scp.country_count  -- add country_count here
+    FROM SongCountryPresence scp
+    WHERE ...
+)
+-- then remove the second JOIN to SongCountryPresence in the SELECT
+```
+
+**3. Optional: rewrite `NOT EXISTS` as anti-join**
+
+SQL Server usually handles these equivalently, but an explicit `LEFT JOIN / WHERE IS NULL` sometimes produces a better plan when the optimizer is uncertain about selectivity.
+
+### Recommended fixes (in order of impact)
+
+```sql
+-- 1. Add covering index (run in SSMS)
+CREATE INDEX IX_HiddenGems_Country_Year_Song
+    ON HiddenGems (country_id, chart_year, song_id);
+
+-- 2. Update the SP — carry country_count through InA CTE, drop the second SongCountryPresence join in result set 3
+-- 3. Optional — rewrite NOT EXISTS as LEFT JOIN anti-join in result sets 3, 4, 5
+```
+
+### Status
+
+All three fixes applied (2026-05-19):
+- Index `IX_HiddenGems_Country_Year_Song` added to `HiddenGems`
+- `country_count` carried through `InA` CTE; redundant `SongCountryPresence` join removed from result set 3
+- `NOT EXISTS` rewritten as `LEFT JOIN / WHERE IS NULL` anti-join in result sets 3, 4, and 5
+
+Index alone reduced cold-load time by ~2 s (~20 s → ~18 s). Retest with all three changes applied to confirm total improvement.
+
+---
+
+## 2026-05-19 — CountryRepository Parallel Deezer Enrichment
+
+**Tester:** Leena Komenski
+**Fix owner:** Leena Komenski / Claude-assisted implementation
+**Scope:** `CountryRepository.cs`
+
+### What was fixed
+
+Cold-cache Country Profile page loads were taking 15–20 seconds. Unlike Comparison, Country Profile enriches song results with Deezer API data (artist images, album art, genres, preview URLs). This enrichment was sequential — each song awaited its own Deezer calls before the next one started. With ~20 songs across the shared and unique lists, each requiring up to 3 Deezer API calls (~200 ms each), the enrichment alone accounted for 8–12 seconds per request.
+
+Four changes were made to `CountryRepository.cs`:
+
+**1. `EnrichSongRowsAsync` — parallel enrichment**
+
+Changed from sequential `foreach await` to `Task.WhenAll`. All songs in a list now enrich concurrently. The `DeezerSongEnrichmentService` has a built-in sliding window rate limiter (50 req / 4.9 s) that prevents overloading the Deezer API.
+
+**2. `GetHiddenGemsPreviewAsync` — parallel enrichment**
+
+Changed from sequential `foreach await` to `Task.WhenAll` over all raw rows, with deduplication and limit applied in a post-filter pass over the results.
+
+**3. `GetCountryGenreSampleAsync` — parallel prefix scans**
+
+The three prefix scans ("B", "I", "Y") previously ran one after another. They now run concurrently with independent `seenGenres` sets; results are deduplicated after all tasks complete.
+
+**4. `GetCountryProfileAsync` — parallel sub-operations**
+
+Shared songs enrichment, unique songs enrichment, and genre sample fetch previously ran sequentially. All three now start together via `Task.WhenAll`.
+
+**Dead code removed**
+
+`FindDistinctLanguageForPrefixAsync` and `FillRemainingDistinctLanguagesAsync` (~150 lines) were async duplicates of the synchronous language methods. They were never called — `GetCountryLanguageSampleAsync` uses the synchronous versions. Both deleted.
+
+### Expected improvement
+
+Cold-cache country profile enrichment: ~8–12 s (sequential) → ~1–2 s (parallel, rate-limited). The DB query time and any remaining Deezer bottleneck still apply — improvement is specifically to the song enrichment phase.
+
+### How to test
+
+1. Identify a country/year not in `presentation_data_cache.json` (e.g. a country not in Eli's warmed set).
+2. Load the Country Profile page and time the first load.
+3. Compare against the same country/year before this change (or against a cached country as a baseline for DB-only latency).
+4. Verify genre samples, hidden gems preview, and top songs all still display correctly.
+5. Check that hidden gems preview deduplication still works (no duplicate songs in the preview widget).
+
+### Verification
+
+- `dotnet build Capstone.API.csproj` passed with 0 C# errors.
+- Correctness testing: Leena Komenski (Windows) — pending.
+
+---
+
+## 2026-05-19 — CountryController Validation Outside try/catch Fix
+
+**Tester:** Leena Komenski
+**Fix owner:** Leena Komenski / Claude-assisted implementation
+**Scope:** `CountryController.cs`
+
+### What was fixed
+
+Three categories of issues in `CountryController.cs`:
+
+**1. `ValidateInputsAsync` called outside try/catch**
+
+In `GetCountryProfile`, `GetHiddenGemsPreview`, and `GetCountrySongs`, `ValidateInputsAsync` was called before the `try` block. `ValidateInputsAsync` calls `_metadataRepo.GetAvailableYearsAsync()` — a DB call. If that call threw, the exception was not caught by any handler, producing a silent (unlogged) 500 response. Moved inside the `try` block in all three methods.
+
+**2. Year validation outside try/catch in `GetCountryGenreSamples` and `GetCountryLanguageSamples`**
+
+These two endpoints had an inline `_memoryCache.GetOrCreateAsync` → `GetAvailableYearsAsync()` block before their `try` blocks. Same silent-500 risk. Moved inside `try`.
+
+**3. `GetAvailableYearsAsync()` called without `CancellationToken`**
+
+Every call to `GetAvailableYearsAsync()` throughout the controller was missing the request cancellation token. Cancelling the HTTP request would not abort the in-flight DB call.
+
+### How it was fixed
+
+Extracted a private `IsAvailableYearAsync(int year, CancellationToken)` helper that holds the single `IMemoryCache.GetOrCreateAsync` + `GetAvailableYearsAsync(cancellationToken)` call. `ValidateInputsAsync` now calls the helper (and also accepts a `CancellationToken`). `GetCountryGenreSamples` and `GetCountryLanguageSamples` call the helper directly inside their `try` blocks. All five action method call sites pass `cancellationToken`.
+
+### How to test
+
+1. Load a valid Country Profile page — should load normally.
+2. Load with an invalid year (e.g. `?year=1900`) — should return 400 with a year-unavailable message.
+3. Load with an invalid country code (e.g. `/api/country/ZZZ`) — should return 400 with country-code message.
+4. Confirm no regressions on genre-samples and language-samples endpoints.
+
+### Verification
+
+- `dotnet build Capstone.API.csproj` passed with 0 C# errors.
+
+---
+
 ## 2026-05-19 — Discovery Map Showing "No Song Data" for DS1 Years (Issue #148)
 
 **Tester:** Eli (reviewer, PR #137 — flagged in PR review comments, not in this log)
-**Fix owner:** Leena Komenski
+**Fix owner:** Leena Komenski / Claude-assisted implementation
 **Branch:** `148-bug-sp-unknown-song-with-unknown-album`
 **Scope:** `sp_PopulateTopSongByCountryYear`, `sp_GetDiscoverPageInfo`, `TopSongByCountryYear` table, `GlobeRepository.cs`, `CountryGlobeSummary.cs`, `api.ts`, `apiMappers.ts`, `discoveryApi.ts`, `GlobeView.tsx`, `CountryCard.tsx`
 
@@ -76,6 +232,130 @@ SELECT
 FROM DIM_Song
 WHERE song_id IN (SELECT DISTINCT song_id FROM ChartEntry WHERE YEAR(snapshot_date) BETWEEN 2017 AND 2021);
 ```
+
+## 2026-05-19 — Country/Comparison Slow First-Load Investigation (Mac / Docker SQL Server)
+
+**Tester:** Leena Komenski
+**Fix owner:** Pending (see long-term recommendations below)
+**Scope:** Country Profile and Comparison pages, `sp_GetCountryProfile`, Docker SQL Server execution plan cache, `FileBackedPresentationDataCacheService`, `SaveAsync` blocking pattern
+
+### What was investigated
+
+After the `05.15_HiddenGemMusic.bak` restore, Country Profile and Comparison pages loaded unusably slowly for mp3li on Mac — several minutes per page. mp3li noted this in his timeline document immediately after the restore on May 15 and built the file-backed cache services and presentation-data warmer tools (commit `6f4b76d`) as a workaround. The loading optimization branch (`cfe2fa7`) was suspected as the cause but investigation showed otherwise.
+
+### Root cause
+
+**The `.bak` restore wiped mp3li's Docker SQL Server execution plan cache.**
+
+SQL Server does not store execution plans in backup files. Plans live in-memory only and are cleared whenever a database is restored. Before the restore, mp3li's Docker SQL Server had warm, locally-compiled plans for `sp_GetCountryProfile` and related country/comparison stored procedures. Those plans had been adapted over time to his container's memory and CPU constraints.
+
+After restoring Leena's `.bak`, SQL Server recompiled all plans from cold using the statistics embedded in the Windows backup. Statistics generated on a native Windows SQL Server machine can lead the optimizer to choose memory-intensive plans (hash joins, large sort operations) that run efficiently on a full-RAM Windows installation but exceed Docker's constrained container memory — causing those operations to spill to disk and run orders of magnitude slower.
+
+This is why:
+
+- The Discovery page was **fast** after the restore — `sp_GetDiscoverPageInfo` was optimized in the same branch to read from the pre-computed `TopSongByCountryYear` table, so it is near-instant regardless of plan quality.
+- Country/Comparison pages were **slow** — `sp_GetCountryProfile` is a complex aggregation SP that is sensitive to plan choice and Docker memory limits on a cold compile.
+- The loading optimization branch code changes themselves (parallelizing genre-sample fetching in the backend, deduplicating the `loadAvailableYears` promise in the frontend) were **not** the cause.
+
+### Secondary issue: `SaveAsync` blocks HTTP responses
+
+The `FileBackedPresentationDataCacheService.SaveAsync` and `FileBackedDiscoverySampleCacheService.SaveFavoriteArtistsAsync` calls in `CountryController.cs` are `await`ed before `return Ok(result)`. This means every cold-cache request waits for both file writes to complete — and those writes serialize through a `SemaphoreSlim(1, 1)` — before the client gets a response. This adds latency on top of slow DB queries rather than running in the background.
+
+### Loading veil behavior (expected but worth noting)
+
+The glassy section loading covers added in `6f4b76d` are each tied to an individual loading state flag (`initialLoadingProfile`, `initialLoadingUnique`, `initialLoadingShared`, `initialLoadingPreview`). The veils are semi-transparent overlays, so underlying placeholder/skeleton content is visible through them while data loads. Veils do not clear until their controlling flag is set to `false`, which only happens when the HTTP response arrives. Because `SaveAsync` is awaited before the response is sent, slow DB queries + serialized file writes on a cold Docker instance compound into minutes of total wait — all veils remain up for the full duration.
+
+### Long-term recommendations
+
+**1. Increase Docker Desktop memory allocation (highest impact, no code change)**
+
+In Docker Desktop on macOS → Settings → Resources, increase the memory limit to 8 GB or more. SQL Server defaults to using up to 80% of available container memory for its buffer pool. More memory means hash joins and sort operations stay in RAM instead of spilling to disk, and cold plan compilation produces efficient plans even from cold start.
+
+**2. Run `sp_updatestats` after every `.bak` restore**
+
+After each database restore, run the following in SSMS before starting app work:
+
+```sql
+USE HiddenGemMusic;
+EXEC sp_updatestats;
+```
+
+This rebuilds statistics from the actual data in the Docker instance rather than using the Windows-generated statistics embedded in the backup. The optimizer then compiles plans suited to the Docker environment.
+
+**3. Fix `SaveAsync` to not block HTTP responses**
+
+In `CountryController.cs`, fire the cache-write calls as background tasks so the response returns immediately after the DB query completes:
+
+```csharp
+// Current (blocks response until writes finish):
+await _discoverySampleCache.SaveFavoriteArtistsAsync(normalizedCode, year, favoriteArtists, cancellationToken);
+await _presentationDataCache.SaveAsync(cacheKey, result, cancellationToken);
+return Ok(result);
+
+// Recommended (response returns immediately; cache writes complete in background):
+if (favoriteArtists.Count > 0)
+    _ = _discoverySampleCache.SaveFavoriteArtistsAsync(normalizedCode, year, favoriteArtists);
+_ = _presentationDataCache.SaveAsync(cacheKey, result);
+return Ok(result);
+```
+
+The same pattern applies to the hidden gems preview and songs endpoints in the same file. This does not fix slow DB queries but removes the extra serialized file-write latency stacked on top of them on every cold-cache request.
+
+### Current workaround
+
+The presentation-data warmer scripts (`tools/presentation_data_prep.py`, `tools/fill_discovery_samples_cache.py`) pre-populate the file-backed cache JSON files before a session. With warm cache files, country and comparison profile requests return from the JSON file without hitting the database at all, which is fast regardless of Docker plan quality. Warmers should be run after any `.bak` restore and before demo or testing sessions until the Docker memory and `sp_updatestats` fixes are in place.
+
+**Note:** The file-backed cache services and warmer tools exist solely as a workaround for the slow cold-query problem described above. If the root cause is resolved (Docker memory increased and/or `sp_updatestats` run after restores), Country and Comparison pages will load at normal speed directly from the database and the warmers become redundant. The `FileBackedPresentationDataCacheService`, `FileBackedDiscoverySampleCacheService`, and associated warmer scripts can be removed at that point.
+
+---
+
+## 2026-05-19 — CountryController `SaveAsync` Fire-and-Forget Fix
+
+**Tester:** Leena Komenski, pending mp3li
+**Fix owner:** Leena Komenski / Claude-assisted implementation
+**Scope:** `CountryController.cs` — `GetCountryProfile`, `GetHiddenGemsPreview`, `GetCountrySongs`, `GetCountryGenreSamples`, `GetCountryLanguageSamples`
+
+### What was fixed
+
+Per the investigation documented above, file-backed cache writes were `await`ed before returning HTTP responses, adding serialized file-write latency on top of every cold-cache DB query. All five save calls were changed to fire-and-forget using the `_ =` discard pattern so the response returns as soon as the DB result is ready.
+
+The `CancellationToken` parameter was also dropped from each fire-and-forget call. Passing a request-scoped token to a background write would cancel the write the moment the HTTP response completed, defeating the purpose of the background save.
+
+Changes made in `backend/Capstone.API/Controllers/CountryController.cs`:
+
+| Endpoint | Call changed |
+|---|---|
+| `GetCountryProfile` | `SaveFavoriteArtistsAsync` |
+| `GetCountryProfile` | `SaveAsync` (presentation cache) |
+| `GetHiddenGemsPreview` | `SaveAsync` (presentation cache) |
+| `GetCountrySongs` | `SaveAsync` (presentation cache) |
+| `GetCountryGenreSamples` | `SaveGenresAsync` (inside `GetOrCreateAsync` factory) |
+| `GetCountryLanguageSamples` | `SaveLanguagesAsync` (inside `GetOrCreateAsync` factory) |
+
+### How to test
+
+**Correctness (Leena — Windows):**
+
+Test against a country/year combination not already present in the cache (so a real DB fetch is triggered) rather than deleting the cache files — the cache files contain mp3li's warmed data and should not be cleared for this test.
+
+1. Identify a country/year that is not in `presentation_data_cache.json` (or use a fresh branch without the cache files).
+2. Open that Country Profile page — data should load normally.
+3. Navigate away, then back to the same country — second load should be instant, confirming the background write succeeded and the cache was populated.
+4. Confirm the JSON file now contains an entry for that country/year.
+
+If the second load is still slow, the fire-and-forget write failed silently and needs investigation.
+
+**Note on the warmers:** If the root cause fix (Docker memory / `sp_updatestats`) is in place before this test is run, the file-backed cache services may not be needed at all — see the note in the root cause investigation entry above.
+
+**Performance (mp3li — Mac / Docker SQL Server):**
+
+First load of a Country Profile or Comparison page on a cold cache should now return data as soon as the DB query completes, without the additional wait for serialized file writes on top. Compare cold first-load time before and after pulling this change.
+
+### Verification
+
+- `dotnet build Capstone.API.csproj` passed with 0 warnings and 0 errors.
+- Correctness testing: Leena Komenski (Windows).
+- Performance testing: mp3li (Mac / Docker SQL Server) — pending.
 
 ---
 

--- a/Documentation/QA-log.md
+++ b/Documentation/QA-log.md
@@ -3,6 +3,65 @@
 
 ---
 
+## 2026-05-21 — Cache Clearing Required After Every Backend or SP Change
+
+**Tester:** Leena Komenski
+**Fix owner:** ⚠️ Flagged for Eli
+**Scope:** `FileBackedDiscoverySampleCacheService`, `FileBackedPresentationDataCacheService`, `DiscoveryController` (`IMemoryCache`)
+
+### What was noticed
+
+Every SP or backend code change requires manually deleting cache files and restarting the server before the effect is visible. The two-layer cache (file-backed JSON + `IMemoryCache`) is good for production performance but makes iterative QA and debugging significantly slower.
+
+### Cache locations to clear
+
+- `backend\Capstone.API\Data\discovery_samples_cache.json` (and `.tmp` if present)
+- `backend\Capstone.API\Data\presentation_data_cache.json`
+- `backend\Capstone.API\live_song_enrichment_cache\live_song_cache.json`
+- In-memory cache (`IMemoryCache`) — cleared only by server restart
+
+### ⚠️ Eli — consider a dev cache bypass
+
+A flag (e.g. environment variable or `appsettings.Development.json` setting) that disables or shortens cache TTLs in development would make local QA much faster without affecting production behavior.
+
+---
+
+## 2026-05-21 — Viral 50 Leaking into CountryYearStats for Top-200-Absent Countries
+
+**Tester:** Leena Komenski
+**Fix owner:** Leena Komenski / Claude-assisted implementation
+**Scope:** `sp_PopulateCountryYearStats.sql`
+
+### What was noticed
+
+Andorra's country profile KPI showed 682 total songs, 557 shared, 125 unique, 81% overlap — despite no songs ever loading in the shared or unique song lists. Andorra is the only country in the dataset with chart entries but no Top 200 data.
+
+### Root cause
+
+`sp_PopulateCountryYearStats` queried `ChartEntry` without filtering out Viral 50 (`chart_type_id = 2`). Countries like Andorra that have Viral 50 data but no Top 200 presence got inflated KPI numbers. The shared/unique classification comes from `SongCountryPresence` (Top 200 only), so those numbers don't describe the country's own charting behavior — they describe the global Top 200 popularity of songs that happened to trend virally there. The "unique" count in particular is meaningless: it counted songs unique to one other country's Top 200, not unique to Andorra.
+
+`SongCountryChart` correctly excludes Viral 50, so song lists were empty — producing the visible inconsistency of a non-zero KPI with no songs displayed.
+
+### Fix applied
+
+Added `AND ce.chart_type_id != 2` to `SongsPerCountryYear` CTE in `sp_PopulateCountryYearStats`, consistent with `sp_PopulateSongCountryPresence` and `sp_PopulateSongCountryChart`.
+
+### Steps to apply
+
+1. Run updated `sp_PopulateCountryYearStats.sql` in SSMS to update the SP.
+2. `EXEC sp_PopulateCountryYearStats;`
+3. Delete `presentation_data_cache.json` and restart the server.
+
+### Note on affected countries
+
+Andorra is the only country in the dataset with chart entries but no Top 200 data — all other countries either have Top 200 data or no chart entries at all. Andorra will now show no profile data, which is correct given its data is entirely Viral 50 and cannot support the app's Discovery Gap metrics.
+
+### ⚠️ Follow-up — verify raw data for Andorra
+
+Check the raw Kaggle CSV for `AD` rows with `chart_type_id = 1` (Top 200). If Top 200 rows exist in the source file but aren't in the database, the data can be ingested and Andorra will work correctly. If no Top 200 rows exist in the source, the current behavior is correct and no further action is needed.
+
+---
+
 ## 2026-05-21 — Discovery Map Genre/Language Sampling Fixes
 
 **Tester:** Leena Komenski
@@ -30,7 +89,7 @@
 
 ### Steps to apply
 
-1. Run `sp_GetCountrySongsPaged.sql` in SSMS (required — root cause of same-genres-everywhere).
+1. Run updated `sp_GetCountrySongsPaged.sql` in SSMS (required — root cause of same-genres-everywhere).
 2. Delete `backend\Capstone.API\Data\discovery_samples_cache.json` and restart the server.
 3. Delete `backend\Capstone.API\live_song_enrichment_cache\live_song_cache.json` if any bad fallback matches are cached from before this fix (optional but recommended for a clean slate).
 

--- a/backend/Capstone.API/Controllers/ComparisonController.cs
+++ b/backend/Capstone.API/Controllers/ComparisonController.cs
@@ -1,6 +1,7 @@
 using Capstone.API.Infrastructure.Interfaces;
 using Microsoft.Data.SqlClient;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Caching.Memory;
 using System.Text.RegularExpressions;
 
 namespace Capstone.API.Controllers
@@ -14,8 +15,12 @@ namespace Capstone.API.Controllers
     {
         private static readonly Regex CountryCodeRegex = new("^[A-Za-z]{2}$", RegexOptions.Compiled);
 
+        private const string AvailableYearsCacheKey = "comparison-controller-available-years";
+
         private readonly IComparisonRepository _repo;
         private readonly IMetadataRepository _metadataRepo;
+        private readonly IPresentationDataCacheService _presentationDataCache;
+        private readonly IMemoryCache _memoryCache;
         private readonly ILogger<ComparisonController> _logger;
 
         /// <summary>
@@ -24,10 +29,14 @@ namespace Capstone.API.Controllers
         public ComparisonController(
             IComparisonRepository repo,
             IMetadataRepository metadataRepo,
+            IPresentationDataCacheService presentationDataCache,
+            IMemoryCache memoryCache,
             ILogger<ComparisonController> logger)
         {
             _repo = repo;
             _metadataRepo = metadataRepo;
+            _presentationDataCache = presentationDataCache;
+            _memoryCache = memoryCache;
             _logger = logger;
         }
 
@@ -53,15 +62,19 @@ namespace Capstone.API.Controllers
                 if (!await IsAvailableYearAsync(year, cancellationToken))
                     return BadRequest(new { message = $"Year {year} is unavailable in this dataset." });
 
-                var result = await _repo.GetCountryComparisonAsync(
-                    countryA.ToUpperInvariant(),
-                    countryB.ToUpperInvariant(),
-                    year,
-                    cancellationToken);
+                var normalizedA = countryA.ToUpperInvariant();
+                var normalizedB = countryB.ToUpperInvariant();
+                var cacheKey = $"COMPARISON::{normalizedA}::{normalizedB}::{year}";
+                var cached = await _presentationDataCache.GetAsync(cacheKey, cancellationToken);
+                if (cached.HasValue)
+                    return Ok(cached.Value);
+
+                var result = await _repo.GetCountryComparisonAsync(normalizedA, normalizedB, year, cancellationToken);
 
                 if (result == null)
                     return NotFound();
 
+                _ = _presentationDataCache.SaveAsync(cacheKey, result);
                 return Ok(result);
             }
             catch (SqlException ex)
@@ -112,11 +125,15 @@ namespace Capstone.API.Controllers
                 if (!await IsAvailableYearAsync(year, cancellationToken))
                     return BadRequest(new { message = $"Year {year} is unavailable in this dataset." });
 
-                var result = await _repo.GetComparisonHiddenGemsAsync(
-                    countryA.ToUpperInvariant(),
-                    countryB.ToUpperInvariant(),
-                    year,
-                    cancellationToken);
+                var normalizedA = countryA.ToUpperInvariant();
+                var normalizedB = countryB.ToUpperInvariant();
+                var cacheKey = $"COMPARISON-HIDDEN-GEMS::{normalizedA}::{normalizedB}::{year}";
+                var cached = await _presentationDataCache.GetAsync(cacheKey, cancellationToken);
+                if (cached.HasValue)
+                    return Ok(cached.Value);
+
+                var result = await _repo.GetComparisonHiddenGemsAsync(normalizedA, normalizedB, year, cancellationToken);
+                _ = _presentationDataCache.SaveAsync(cacheKey, result);
                 return Ok(result);
             }
             catch (SqlException ex)
@@ -147,7 +164,11 @@ namespace Capstone.API.Controllers
 
         private async Task<bool> IsAvailableYearAsync(int year, CancellationToken cancellationToken)
         {
-            var availableYears = await _metadataRepo.GetAvailableYearsAsync(cancellationToken);
+            var availableYears = await _memoryCache.GetOrCreateAsync(AvailableYearsCacheKey, async entry =>
+            {
+                entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(5);
+                return (await _metadataRepo.GetAvailableYearsAsync(cancellationToken)).ToHashSet();
+            }) ?? new HashSet<int>();
             return availableYears.Contains(year);
         }
 

--- a/backend/Capstone.API/Controllers/CountryController.cs
+++ b/backend/Capstone.API/Controllers/CountryController.cs
@@ -59,12 +59,12 @@ namespace Capstone.API.Controllers
         [HttpGet("{code}")]
         public async Task<IActionResult> GetCountryProfile(string code, [FromQuery] int year = 2021, CancellationToken cancellationToken = default)
         {
-            var validationError = await ValidateInputsAsync(code, year);
-            if (validationError != null)
-                return BadRequest(new { message = validationError });
-
             try
             {
+                var validationError = await ValidateInputsAsync(code, year, cancellationToken);
+                if (validationError != null)
+                    return BadRequest(new { message = validationError });
+
                 var normalizedCode = code.ToUpperInvariant();
                 var cacheKey = BuildPresentationCacheKey("country-profile", normalizedCode, year);
                 var cached = await _presentationDataCache.GetAsync(cacheKey, cancellationToken);
@@ -79,11 +79,9 @@ namespace Capstone.API.Controllers
 
                 var favoriteArtists = BuildFavoriteArtists(result);
                 if (favoriteArtists.Count > 0)
-                {
-                    await _discoverySampleCache.SaveFavoriteArtistsAsync(normalizedCode, year, favoriteArtists, cancellationToken);
-                }
+                    _ = _discoverySampleCache.SaveFavoriteArtistsAsync(normalizedCode, year, favoriteArtists);
 
-                await _presentationDataCache.SaveAsync(cacheKey, result, cancellationToken);
+                _ = _presentationDataCache.SaveAsync(cacheKey, result);
                 return Ok(result);
             }
             catch (SqlException ex)
@@ -111,14 +109,14 @@ namespace Capstone.API.Controllers
         [HttpGet("{code}/hidden-gems/preview")]
         public async Task<IActionResult> GetHiddenGemsPreview(string code, [FromQuery] int year = 2021, [FromQuery] int limit = DefaultPreviewLimit, CancellationToken cancellationToken = default)
         {
-            var validationError = await ValidateInputsAsync(code, year);
-            if (validationError != null)
-                return BadRequest(new { message = validationError });
-
             var normalizedLimit = Math.Clamp(limit, 1, MaxPreviewLimit);
 
             try
             {
+                var validationError = await ValidateInputsAsync(code, year, cancellationToken);
+                if (validationError != null)
+                    return BadRequest(new { message = validationError });
+
                 var normalizedCode = code.ToUpperInvariant();
                 var cacheKey = BuildPresentationCacheKey("country-hidden-gems-preview", normalizedCode, year, normalizedLimit);
                 var cached = await _presentationDataCache.GetAsync(cacheKey, cancellationToken);
@@ -128,7 +126,7 @@ namespace Capstone.API.Controllers
                 }
 
                 var result = await _repo.GetHiddenGemsPreviewAsync(normalizedCode, year, normalizedLimit, cancellationToken);
-                await _presentationDataCache.SaveAsync(cacheKey, result, cancellationToken);
+                _ = _presentationDataCache.SaveAsync(cacheKey, result);
                 return Ok(result);
             }
             catch (SqlException ex)
@@ -165,10 +163,6 @@ namespace Capstone.API.Controllers
             [FromQuery] int pageSize = DefaultSongsPageSize,
             CancellationToken cancellationToken = default)
         {
-            var validationError = await ValidateInputsAsync(code, year);
-            if (validationError != null)
-                return BadRequest(new { message = validationError });
-
             var normalizedListType = listType.Trim().ToLowerInvariant();
             if (normalizedListType != "shared" && normalizedListType != "unique")
                 return BadRequest(new { message = "listType must be either 'shared' or 'unique'." });
@@ -178,6 +172,10 @@ namespace Capstone.API.Controllers
 
             try
             {
+                var validationError = await ValidateInputsAsync(code, year, cancellationToken);
+                if (validationError != null)
+                    return BadRequest(new { message = validationError });
+
                 var normalizedCode = code.ToUpperInvariant();
                 var cacheKey = BuildPresentationCacheKey("country-songs", normalizedCode, year, normalizedListType, normalizedPage, normalizedPageSize);
                 var cached = await _presentationDataCache.GetAsync(cacheKey, cancellationToken);
@@ -193,7 +191,7 @@ namespace Capstone.API.Controllers
                     normalizedPage,
                     normalizedPageSize,
                     cancellationToken);
-                await _presentationDataCache.SaveAsync(cacheKey, result, cancellationToken);
+                _ = _presentationDataCache.SaveAsync(cacheKey, result);
                 return Ok(result);
             }
             catch (SqlException ex)
@@ -222,32 +220,22 @@ namespace Capstone.API.Controllers
             [FromQuery] string codes = "",
             CancellationToken cancellationToken = default)
         {
-            var availableYears = await _memoryCache.GetOrCreateAsync(AvailableYearsCacheKey, async (entry) =>
-            {
-                entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(5);
-                return (await _metadataRepo.GetAvailableYearsAsync()).ToHashSet();
-            }) ?? new HashSet<int>();
-
-            if (!availableYears.Contains(year))
-            {
-                return BadRequest(new { message = $"Year {year} is unavailable in this dataset." });
-            }
-
             var normalizedCodes = codes
                 .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-                .Select((value) => value.ToUpperInvariant())
-                .Where((value) => CountryCodeRegex.IsMatch(value))
+                .Select(value => value.ToUpperInvariant())
+                .Where(value => CountryCodeRegex.IsMatch(value))
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .Take(MaxGenreSampleCodes)
                 .ToList();
 
             if (normalizedCodes.Count == 0)
-            {
                 return BadRequest(new { message = "At least one valid 2-letter country code is required." });
-            }
 
             try
             {
+                if (!await IsAvailableYearAsync(year, cancellationToken))
+                    return BadRequest(new { message = $"Year {year} is unavailable in this dataset." });
+
                 var tasks = normalizedCodes.Select(async (countryCode) =>
                 {
                     cancellationToken.ThrowIfCancellationRequested();
@@ -260,9 +248,7 @@ namespace Capstone.API.Controllers
                             ? cachedGenres
                             : await _repo.GetCountryGenreSampleAsync(countryCode, year, cancellationToken);
                         if (genres.Count > 0 && cachedGenres.Count == 0)
-                        {
-                            await _discoverySampleCache.SaveGenresAsync(countryCode, year, genres, cancellationToken);
-                        }
+                            _ = _discoverySampleCache.SaveGenresAsync(countryCode, year, genres);
                         return new Capstone.API.Models.Country.CountryGenreSample
                         {
                             CountryCode = countryCode,
@@ -303,32 +289,22 @@ namespace Capstone.API.Controllers
             [FromQuery] string codes = "",
             CancellationToken cancellationToken = default)
         {
-            var availableYears = await _memoryCache.GetOrCreateAsync(AvailableYearsCacheKey, async (entry) =>
-            {
-                entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(5);
-                return (await _metadataRepo.GetAvailableYearsAsync()).ToHashSet();
-            }) ?? new HashSet<int>();
-
-            if (!availableYears.Contains(year))
-            {
-                return BadRequest(new { message = $"Year {year} is unavailable in this dataset." });
-            }
-
             var normalizedCodes = codes
                 .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-                .Select((value) => value.ToUpperInvariant())
-                .Where((value) => CountryCodeRegex.IsMatch(value))
+                .Select(value => value.ToUpperInvariant())
+                .Where(value => CountryCodeRegex.IsMatch(value))
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .Take(MaxLanguageSampleCodes)
                 .ToList();
 
             if (normalizedCodes.Count == 0)
-            {
                 return BadRequest(new { message = "At least one valid 2-letter country code is required." });
-            }
 
             try
             {
+                if (!await IsAvailableYearAsync(year, cancellationToken))
+                    return BadRequest(new { message = $"Year {year} is unavailable in this dataset." });
+
                 var tasks = normalizedCodes.Select(async (countryCode) =>
                 {
                     cancellationToken.ThrowIfCancellationRequested();
@@ -341,9 +317,7 @@ namespace Capstone.API.Controllers
                             ? cachedLanguages
                             : await _repo.GetCountryLanguageSampleAsync(countryCode, year, cancellationToken);
                         if (languages.Count > 0 && cachedLanguages.Count == 0)
-                        {
-                            await _discoverySampleCache.SaveLanguagesAsync(countryCode, year, languages, cancellationToken);
-                        }
+                            _ = _discoverySampleCache.SaveLanguagesAsync(countryCode, year, languages);
                         return new Capstone.API.Models.Country.CountryLanguageSample
                         {
                             CountryCode = countryCode,
@@ -374,25 +348,25 @@ namespace Capstone.API.Controllers
             }
         }
 
-        private async Task<string?> ValidateInputsAsync(string code, int year)
+        private async Task<string?> ValidateInputsAsync(string code, int year, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(code) || !CountryCodeRegex.IsMatch(code))
-            {
                 return "Country code must be exactly 2 letters (ISO format, e.g. 'US').";
-            }
 
+            if (!await IsAvailableYearAsync(year, cancellationToken))
+                return $"Year {year} is unavailable in this dataset.";
+
+            return null;
+        }
+
+        private async Task<bool> IsAvailableYearAsync(int year, CancellationToken cancellationToken = default)
+        {
             var availableYears = await _memoryCache.GetOrCreateAsync(AvailableYearsCacheKey, async (entry) =>
             {
                 entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(5);
-                return (await _metadataRepo.GetAvailableYearsAsync()).ToHashSet();
+                return (await _metadataRepo.GetAvailableYearsAsync(cancellationToken)).ToHashSet();
             }) ?? new HashSet<int>();
-
-            if (!availableYears.Contains(year))
-            {
-                return $"Year {year} is unavailable in this dataset.";
-            }
-
-            return null;
+            return availableYears.Contains(year);
         }
 
         private static List<Capstone.API.Models.Country.FavoriteArtistSample> BuildFavoriteArtists(Capstone.API.Models.Country.CountryProfile profile)

--- a/backend/Capstone.API/Controllers/DiscoveryController.cs
+++ b/backend/Capstone.API/Controllers/DiscoveryController.cs
@@ -1,6 +1,7 @@
 using Capstone.API.Infrastructure.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace Capstone.API.Controllers
 {
@@ -12,17 +13,22 @@ namespace Capstone.API.Controllers
     [Route("api/discovery")]
     public class DiscoveryController : ControllerBase
     {
+        private const string AvailableYearsCacheKey = "discovery-controller-available-years";
+
         private readonly IGlobeRepository _repo;
         private readonly IMetadataRepository _metadataRepo;
+        private readonly IMemoryCache _memoryCache;
         private readonly ILogger<DiscoveryController> _logger;
 
         public DiscoveryController(
             IGlobeRepository repo,
             IMetadataRepository metadataRepo,
+            IMemoryCache memoryCache,
             ILogger<DiscoveryController> logger)
         {
             _repo = repo;
             _metadataRepo = metadataRepo;
+            _memoryCache = memoryCache;
             _logger = logger;
         }
 
@@ -35,13 +41,20 @@ namespace Capstone.API.Controllers
         {
             try
             {
-                var availableYears = (await _metadataRepo.GetAvailableYearsAsync(cancellationToken)).ToHashSet();
-                if (!availableYears.Contains(year))
+                var availableYears = await _memoryCache.GetOrCreateAsync(AvailableYearsCacheKey, async entry =>
                 {
-                    return BadRequest(new { message = $"Year {year} is unavailable in this dataset." });
-                }
+                    entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(5);
+                    return (await _metadataRepo.GetAvailableYearsAsync(cancellationToken)).ToHashSet();
+                }) ?? new HashSet<int>();
 
-                var result = await _repo.GetGlobeSummaryAsync(year, cancellationToken);
+                if (!availableYears.Contains(year))
+                    return BadRequest(new { message = $"Year {year} is unavailable in this dataset." });
+
+                var result = await _memoryCache.GetOrCreateAsync($"discovery-globe::{year}", async entry =>
+                {
+                    entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(30);
+                    return await _repo.GetGlobeSummaryAsync(year, cancellationToken);
+                });
                 return Ok(result);
             }
             catch (SqlException ex)

--- a/backend/Capstone.API/Controllers/HiddenGemsController.cs
+++ b/backend/Capstone.API/Controllers/HiddenGemsController.cs
@@ -61,7 +61,7 @@ namespace Capstone.API.Controllers
                 }
 
                 var result = await _repo.GetHiddenGemsAsync(normalizedCode, year, minCountries, page, pageSize, cancellationToken);
-                await _presentationDataCache.SaveAsync(cacheKey, result, cancellationToken);
+                _ = _presentationDataCache.SaveAsync(cacheKey, result);
                 return Ok(result);
             }
             catch (SqlException ex)

--- a/backend/Capstone.API/Controllers/MetadataController.cs
+++ b/backend/Capstone.API/Controllers/MetadataController.cs
@@ -1,6 +1,7 @@
 using Capstone.API.Infrastructure.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace Capstone.API.Controllers
 {
@@ -11,15 +12,19 @@ namespace Capstone.API.Controllers
     [Route("api/metadata")]
     public class MetadataController : ControllerBase
     {
+        private const string AvailableYearsCacheKey = "metadata-controller-available-years";
+
         private readonly IMetadataRepository _repo;
+        private readonly IMemoryCache _memoryCache;
         private readonly ILogger<MetadataController> _logger;
 
         /// <summary>
         /// Initializes a new instance of MetadataController.
         /// </summary>
-        public MetadataController(IMetadataRepository repo, ILogger<MetadataController> logger)
+        public MetadataController(IMetadataRepository repo, IMemoryCache memoryCache, ILogger<MetadataController> logger)
         {
             _repo = repo;
+            _memoryCache = memoryCache;
             _logger = logger;
         }
 
@@ -32,7 +37,11 @@ namespace Capstone.API.Controllers
         {
             try
             {
-                var years = await _repo.GetAvailableYearsAsync(cancellationToken);
+                var years = await _memoryCache.GetOrCreateAsync(AvailableYearsCacheKey, async entry =>
+                {
+                    entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(5);
+                    return await _repo.GetAvailableYearsAsync(cancellationToken);
+                });
                 return Ok(years);
             }
             catch (SqlException ex)

--- a/backend/Capstone.API/Infrastructure/Repositories/CountryRepository.cs
+++ b/backend/Capstone.API/Infrastructure/Repositories/CountryRepository.cs
@@ -14,7 +14,6 @@ namespace Capstone.API.Infrastructure.Repositories
         private static readonly string[] PreferredGenrePrefixes = ["B", "I", "Y"];
         private const int RawSongBatchSize = 100;
         private const int GenreSampleScanCapPerList = 200;
-        private const int LanguageDuplicateSkipLimit = 12;
 
         private readonly IDataRepository _db;
         private readonly IDeezerSongEnrichmentService _deezerSongEnrichmentService;
@@ -191,22 +190,20 @@ namespace Capstone.API.Infrastructure.Repositories
         /// <inheritdoc/>
         public async Task<IReadOnlyList<string>> GetCountryGenreSampleAsync(string countryCode, int year, CancellationToken cancellationToken = default)
         {
-            var prefixTasks = PreferredGenrePrefixes
-                .Select(prefix => FindDistinctGenreForPrefixAsync(countryCode, year, prefix, new HashSet<string>(StringComparer.OrdinalIgnoreCase), cancellationToken));
-            var prefixResults = await Task.WhenAll(prefixTasks);
-
             var selectedGenres = new List<string>(3);
             var seenGenres = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            foreach (var genre in prefixResults)
+
+            foreach (var prefix in PreferredGenrePrefixes)
             {
+                var genre = await FindDistinctGenreForPrefixAsync(countryCode, year, prefix, seenGenres, cancellationToken);
                 if (!string.IsNullOrWhiteSpace(genre) && seenGenres.Add(genre))
                     selectedGenres.Add(genre);
+                if (selectedGenres.Count >= 3)
+                    return selectedGenres;
             }
 
             if (selectedGenres.Count < 3)
-            {
                 await FillRemainingDistinctGenresAsync(countryCode, year, selectedGenres, seenGenres, cancellationToken);
-            }
 
             return selectedGenres;
         }
@@ -396,67 +393,6 @@ namespace Capstone.API.Infrastructure.Repositories
             item.Contributors = metadata.Contributors;
             item.ArtistAlbumCount = metadata.ArtistAlbumCount;
             return item;
-        }
-
-        private async Task<string?> FindDistinctGenreForPrefixAsync(
-            string countryCode,
-            int year,
-            string prefix,
-            HashSet<string> seenGenres,
-            CancellationToken cancellationToken)
-        {
-            foreach (var listType in new[] { "shared", "unique" })
-            {
-                var inspectedRows = 0;
-                var scanOffset = 0;
-
-                while (inspectedRows < GenreSampleScanCapPerList)
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    var rows = (await _db.GetDataAsync("sp_GetCountrySongsPaged", new Dictionary<string, object?>
-                    {
-                        { "@CountryCode", countryCode },
-                        { "@Year", year },
-                        { "@ListType", listType },
-                        { "@Offset", scanOffset },
-                        { "@PageSize", RawSongBatchSize }
-                    }, cancellationToken)).ToList();
-
-                    if (rows.Count == 0)
-                    {
-                        break;
-                    }
-
-                    var totalRawCount = RowValueReader.AsIntAny(rows[0], "total_count", "TotalCount");
-                    foreach (var row in rows)
-                    {
-                        cancellationToken.ThrowIfCancellationRequested();
-                        inspectedRows++;
-                        var mapped = MapSong(row);
-                        if (!SongStartsWithPrefix(mapped.SongName, prefix))
-                        {
-                            continue;
-                        }
-
-                        var enriched = await EnrichSongAsync(mapped, cancellationToken);
-                        var primaryGenre = GetPrimaryGenre(enriched);
-                        if (string.IsNullOrWhiteSpace(primaryGenre) || seenGenres.Contains(primaryGenre))
-                        {
-                            continue;
-                        }
-
-                        return primaryGenre;
-                    }
-
-                    scanOffset += rows.Count;
-                    if (scanOffset >= totalRawCount)
-                    {
-                        break;
-                    }
-                }
-            }
-
-            return null;
         }
 
         private async Task FillRemainingDistinctGenresAsync(

--- a/backend/Capstone.API/Infrastructure/Repositories/CountryRepository.cs
+++ b/backend/Capstone.API/Infrastructure/Repositories/CountryRepository.cs
@@ -395,6 +395,67 @@ namespace Capstone.API.Infrastructure.Repositories
             return item;
         }
 
+        private async Task<string?> FindDistinctGenreForPrefixAsync(
+            string countryCode,
+            int year,
+            string prefix,
+            HashSet<string> seenGenres,
+            CancellationToken cancellationToken)
+        {
+            foreach (var listType in new[] { "shared", "unique" })
+            {
+                var inspectedRows = 0;
+                var scanOffset = 0;
+
+                while (inspectedRows < GenreSampleScanCapPerList)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var rows = (await _db.GetDataAsync("sp_GetCountrySongsPaged", new Dictionary<string, object?>
+                    {
+                        { "@CountryCode", countryCode },
+                        { "@Year", year },
+                        { "@ListType", listType },
+                        { "@Offset", scanOffset },
+                        { "@PageSize", RawSongBatchSize }
+                    }, cancellationToken)).ToList();
+
+                    if (rows.Count == 0)
+                    {
+                        break;
+                    }
+
+                    var totalRawCount = RowValueReader.AsIntAny(rows[0], "total_count", "TotalCount");
+                    foreach (var row in rows)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        inspectedRows++;
+                        var mapped = MapSong(row);
+                        if (!SongStartsWithPrefix(mapped.SongName, prefix))
+                        {
+                            continue;
+                        }
+
+                        var enriched = await EnrichSongAsync(mapped, cancellationToken);
+                        var primaryGenre = GetPrimaryGenre(enriched);
+                        if (string.IsNullOrWhiteSpace(primaryGenre) || seenGenres.Contains(primaryGenre))
+                        {
+                            continue;
+                        }
+
+                        return primaryGenre;
+                    }
+
+                    scanOffset += rows.Count;
+                    if (scanOffset >= totalRawCount)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            return null;
+        }
+
         private async Task FillRemainingDistinctGenresAsync(
             string countryCode,
             int year,

--- a/backend/Capstone.API/Infrastructure/Repositories/CountryRepository.cs
+++ b/backend/Capstone.API/Infrastructure/Repositories/CountryRepository.cs
@@ -58,13 +58,19 @@ namespace Capstone.API.Infrastructure.Repositories
                 OverlapPct = RowValueReader.AsDecimalAny(stats, "overlap_pct")
             };
 
-            if (sets.Count > 1)
-                profile.TopSharedSongs = await EnrichSongRowsAsync(sets[1].Select(MapSong), limit: 10, cancellationToken);
+            var sharedSongsTask = sets.Count > 1
+                ? EnrichSongRowsAsync(sets[1].Select(MapSong), limit: 10, cancellationToken)
+                : Task.FromResult(new List<Song>());
+            var uniqueSongsTask = sets.Count > 2
+                ? EnrichSongRowsAsync(sets[2].Select(MapSong), limit: 10, cancellationToken)
+                : Task.FromResult(new List<Song>());
+            var genresTask = GetCountryGenreSampleAsync(countryCode, year, cancellationToken);
 
-            if (sets.Count > 2)
-                profile.TopUniqueSongs = await EnrichSongRowsAsync(sets[2].Select(MapSong), limit: 10, cancellationToken);
+            await Task.WhenAll(sharedSongsTask, uniqueSongsTask, genresTask);
 
-            profile.SampleGenres = (await GetCountryGenreSampleAsync(countryCode, year, cancellationToken)).ToList();
+            profile.TopSharedSongs = sharedSongsTask.Result;
+            profile.TopUniqueSongs = uniqueSongsTask.Result;
+            profile.SampleGenres = genresTask.Result.ToList();
 
             return profile;
         }
@@ -82,30 +88,24 @@ namespace Capstone.API.Infrastructure.Repositories
                 { "@Limit", rawLimit }
             }, cancellationToken);
 
-            var results = new List<CountryHiddenGemPreviewItem>();
-            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            foreach (var row in rows)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                var enriched = await EnrichPreviewItemAsync(MapHiddenGem(row), cancellationToken);
-                if (enriched is null)
-                {
-                    continue;
-                }
+            var enrichedItems = await Task.WhenAll(rows.Select(row => EnrichPreviewItemAsync(MapHiddenGem(row), cancellationToken)));
 
-                var songName = enriched.SongName?.Trim();
-                var artistName = enriched.ArtistName?.Trim();
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var results = new List<CountryHiddenGemPreviewItem>();
+            foreach (var item in enrichedItems)
+            {
+                if (item is null)
+                    continue;
+
+                var songName = item.SongName?.Trim();
+                var artistName = item.ArtistName?.Trim();
                 var duplicateKey = $"{songName?.ToLowerInvariant()}||{artistName?.ToLowerInvariant()}";
                 if (string.IsNullOrWhiteSpace(songName) || string.IsNullOrWhiteSpace(artistName) || !seen.Add(duplicateKey))
-                {
                     continue;
-                }
 
-                results.Add(enriched);
+                results.Add(item);
                 if (results.Count >= requestedLimit)
-                {
                     break;
-                }
             }
 
             return results;
@@ -191,19 +191,16 @@ namespace Capstone.API.Infrastructure.Repositories
         /// <inheritdoc/>
         public async Task<IReadOnlyList<string>> GetCountryGenreSampleAsync(string countryCode, int year, CancellationToken cancellationToken = default)
         {
+            var prefixTasks = PreferredGenrePrefixes
+                .Select(prefix => FindDistinctGenreForPrefixAsync(countryCode, year, prefix, new HashSet<string>(StringComparer.OrdinalIgnoreCase), cancellationToken));
+            var prefixResults = await Task.WhenAll(prefixTasks);
+
             var selectedGenres = new List<string>(3);
             var seenGenres = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-            foreach (var prefix in PreferredGenrePrefixes)
+            foreach (var genre in prefixResults)
             {
-                var genre = await FindDistinctGenreForPrefixAsync(countryCode, year, prefix, seenGenres, cancellationToken);
-                if (string.IsNullOrWhiteSpace(genre))
-                {
-                    continue;
-                }
-
-                seenGenres.Add(genre);
-                selectedGenres.Add(genre);
+                if (!string.IsNullOrWhiteSpace(genre) && seenGenres.Add(genre))
+                    selectedGenres.Add(genre);
             }
 
             if (selectedGenres.Count < 3)
@@ -325,24 +322,8 @@ namespace Capstone.API.Infrastructure.Repositories
 
         private async Task<List<Song>> EnrichSongRowsAsync(IEnumerable<Song> songs, int limit, CancellationToken cancellationToken)
         {
-            var results = new List<Song>();
-            foreach (var song in songs)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                var enriched = await EnrichSongAsync(song, cancellationToken);
-                if (enriched is null)
-                {
-                    continue;
-                }
-
-                results.Add(enriched);
-                if (results.Count >= limit)
-                {
-                    break;
-                }
-            }
-
-            return results;
+            var enriched = await Task.WhenAll(songs.Select(song => EnrichSongAsync(song, cancellationToken)));
+            return enriched.Where(song => song is not null).Take(limit).ToList()!;
         }
 
         private async Task<Song?> EnrichSongAsync(Song song, CancellationToken cancellationToken)
@@ -522,160 +503,6 @@ namespace Capstone.API.Infrastructure.Repositories
                         seenGenres.Add(primaryGenre);
                         selectedGenres.Add(primaryGenre);
                         if (selectedGenres.Count >= 3)
-                        {
-                            return;
-                        }
-                    }
-
-                    scanOffset += rows.Count;
-                    if (scanOffset >= totalRawCount)
-                    {
-                        break;
-                    }
-                }
-            }
-        }
-
-        private async Task<string?> FindDistinctLanguageForPrefixAsync(
-            string countryCode,
-            int year,
-            string prefix,
-            HashSet<string> seenLanguages,
-            CancellationToken cancellationToken)
-        {
-            var duplicateSkips = 0;
-            foreach (var listType in new[] { "shared", "unique" })
-            {
-                var inspectedRows = 0;
-                var scanOffset = 0;
-
-                while (inspectedRows < GenreSampleScanCapPerList && duplicateSkips < LanguageDuplicateSkipLimit)
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    var rows = (await _db.GetDataAsync("sp_GetCountrySongsPaged", new Dictionary<string, object?>
-                    {
-                        { "@CountryCode", countryCode },
-                        { "@Year", year },
-                        { "@ListType", listType },
-                        { "@Offset", scanOffset },
-                        { "@PageSize", RawSongBatchSize }
-                    }, cancellationToken)).ToList();
-
-                    if (rows.Count == 0)
-                    {
-                        break;
-                    }
-
-                    var totalRawCount = RowValueReader.AsIntAny(rows[0], "total_count", "TotalCount");
-                    foreach (var row in rows)
-                    {
-                        cancellationToken.ThrowIfCancellationRequested();
-                        inspectedRows++;
-                        var mapped = MapSong(row);
-                        if (!SongStartsWithPrefix(mapped.SongName, prefix))
-                        {
-                            continue;
-                        }
-
-                        var match = _languageLookupService.FindMatch(mapped);
-                        if (match is null)
-                        {
-                            continue;
-                        }
-
-                        foreach (var language in match.Languages)
-                        {
-                            var trimmed = language.Trim();
-                            if (string.IsNullOrWhiteSpace(trimmed))
-                            {
-                                continue;
-                            }
-
-                            if (seenLanguages.Contains(trimmed))
-                            {
-                                duplicateSkips++;
-                                continue;
-                            }
-
-                            return trimmed;
-                        }
-                    }
-
-                    scanOffset += rows.Count;
-                    if (scanOffset >= totalRawCount)
-                    {
-                        break;
-                    }
-                }
-            }
-
-            return null;
-        }
-
-        private async Task FillRemainingDistinctLanguagesAsync(
-            string countryCode,
-            int year,
-            List<string> selectedLanguages,
-            HashSet<string> seenLanguages,
-            CancellationToken cancellationToken)
-        {
-            var duplicateSkips = 0;
-            foreach (var listType in new[] { "shared", "unique" })
-            {
-                var inspectedRows = 0;
-                var scanOffset = 0;
-
-                while (selectedLanguages.Count < 3 && inspectedRows < GenreSampleScanCapPerList && duplicateSkips < LanguageDuplicateSkipLimit)
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    var rows = (await _db.GetDataAsync("sp_GetCountrySongsPaged", new Dictionary<string, object?>
-                    {
-                        { "@CountryCode", countryCode },
-                        { "@Year", year },
-                        { "@ListType", listType },
-                        { "@Offset", scanOffset },
-                        { "@PageSize", RawSongBatchSize }
-                    }, cancellationToken)).ToList();
-
-                    if (rows.Count == 0)
-                    {
-                        break;
-                    }
-
-                    var totalRawCount = RowValueReader.AsIntAny(rows[0], "total_count", "TotalCount");
-                    foreach (var row in rows)
-                    {
-                        cancellationToken.ThrowIfCancellationRequested();
-                        inspectedRows++;
-                        var match = _languageLookupService.FindMatch(MapSong(row));
-                        if (match is null)
-                        {
-                            continue;
-                        }
-
-                        foreach (var language in match.Languages)
-                        {
-                            var trimmed = language.Trim();
-                            if (string.IsNullOrWhiteSpace(trimmed))
-                            {
-                                continue;
-                            }
-
-                            if (seenLanguages.Contains(trimmed))
-                            {
-                                duplicateSkips++;
-                                continue;
-                            }
-
-                            seenLanguages.Add(trimmed);
-                            selectedLanguages.Add(trimmed);
-                            if (selectedLanguages.Count >= 3)
-                            {
-                                return;
-                            }
-                        }
-
-                        if (duplicateSkips >= LanguageDuplicateSkipLimit)
                         {
                             return;
                         }

--- a/backend/Capstone.API/Infrastructure/Repositories/FileBackedDiscoverySampleCacheService.cs
+++ b/backend/Capstone.API/Infrastructure/Repositories/FileBackedDiscoverySampleCacheService.cs
@@ -132,9 +132,17 @@ namespace Capstone.API.Infrastructure.Repositories
                 return;
             }
 
-            await using var stream = File.OpenRead(_cachePath);
-            var entries = await JsonSerializer.DeserializeAsync<List<DiscoverySampleCacheEntry>>(stream, JsonOptions, cancellationToken)
-                ?? new List<DiscoverySampleCacheEntry>();
+            List<DiscoverySampleCacheEntry> entries;
+            try
+            {
+                await using var stream = File.OpenRead(_cachePath);
+                entries = await JsonSerializer.DeserializeAsync<List<DiscoverySampleCacheEntry>>(stream, JsonOptions, cancellationToken)
+                    ?? new List<DiscoverySampleCacheEntry>();
+            }
+            catch (JsonException)
+            {
+                entries = new List<DiscoverySampleCacheEntry>();
+            }
 
             _entriesByKey = entries
                 .Where(entry => !string.IsNullOrWhiteSpace(entry.CountryCode) && entry.Year > 0)
@@ -153,8 +161,12 @@ namespace Capstone.API.Infrastructure.Repositories
                 .ThenBy(entry => entry.CountryCode)
                 .ToList();
 
-            await using var stream = File.Create(_cachePath);
-            await JsonSerializer.SerializeAsync(stream, entries, JsonOptions, cancellationToken);
+            var tempPath = _cachePath + ".tmp";
+            await using (var stream = File.Create(tempPath))
+            {
+                await JsonSerializer.SerializeAsync(stream, entries, JsonOptions, cancellationToken);
+            }
+            File.Move(tempPath, _cachePath, overwrite: true);
         }
 
         private static string BuildKey(string countryCode, int year)

--- a/backend/Capstone.API/Infrastructure/Repositories/FileBackedPresentationDataCacheService.cs
+++ b/backend/Capstone.API/Infrastructure/Repositories/FileBackedPresentationDataCacheService.cs
@@ -86,9 +86,19 @@ namespace Capstone.API.Infrastructure.Repositories
                 return;
             }
 
-            await using var stream = File.OpenRead(_cachePath);
-            var entries = await JsonSerializer.DeserializeAsync<List<PresentationDataCacheEntry>>(stream, JsonOptions, cancellationToken)
-                ?? new List<PresentationDataCacheEntry>();
+            List<PresentationDataCacheEntry> entries;
+            try
+            {
+                await using var stream = File.OpenRead(_cachePath);
+                entries = await JsonSerializer.DeserializeAsync<List<PresentationDataCacheEntry>>(stream, JsonOptions, cancellationToken)
+                    ?? new List<PresentationDataCacheEntry>();
+            }
+            catch (JsonException)
+            {
+                // File was truncated mid-write (e.g. server stopped between File.Create and flush).
+                // Discard it and start fresh.
+                entries = new List<PresentationDataCacheEntry>();
+            }
 
             _entriesByKey = entries
                 .Where(entry => !string.IsNullOrWhiteSpace(entry.Key))
@@ -106,8 +116,13 @@ namespace Capstone.API.Infrastructure.Repositories
                 .OrderBy(entry => entry.Key)
                 .ToList();
 
-            await using var stream = File.Create(_cachePath);
-            await JsonSerializer.SerializeAsync(stream, entries, JsonOptions, cancellationToken);
+            // Write to a temp file first so an interrupted write never corrupts the real cache.
+            var tempPath = _cachePath + ".tmp";
+            await using (var stream = File.Create(tempPath))
+            {
+                await JsonSerializer.SerializeAsync(stream, entries, JsonOptions, cancellationToken);
+            }
+            File.Move(tempPath, _cachePath, overwrite: true);
         }
     }
 }

--- a/backend/Capstone.API/Infrastructure/Repositories/HiddenGemsRepository.cs
+++ b/backend/Capstone.API/Infrastructure/Repositories/HiddenGemsRepository.cs
@@ -57,10 +57,11 @@ namespace Capstone.API.Infrastructure.Repositories
 
                 totalRawCount = RowValueReader.AsIntAny(rows[0], "total_count", "TotalCount");
 
-                foreach (var row in rows)
+                var enrichedBatch = await Task.WhenAll(
+                    rows.Select(row => _deezerSongEnrichmentService.EnrichHiddenGemAsync(MapRow(row), cancellationToken)));
+
+                foreach (var enriched in enrichedBatch)
                 {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    var enriched = await _deezerSongEnrichmentService.EnrichHiddenGemAsync(MapRow(row), cancellationToken);
                     if (enriched is null)
                     {
                         continue;

--- a/backend/Capstone.API/database/population/sp_PopulateCountryYearStats.sql
+++ b/backend/Capstone.API/database/population/sp_PopulateCountryYearStats.sql
@@ -24,6 +24,7 @@ BEGIN
             ce.song_id
         FROM ChartEntry ce
         WHERE ce.country_id IS NOT NULL
+          AND ce.chart_type_id != 2
         GROUP BY
             ce.country_id,
             YEAR(ce.snapshot_date),

--- a/backend/Capstone.API/database/population/sp_PopulateSongCountryChart.sql
+++ b/backend/Capstone.API/database/population/sp_PopulateSongCountryChart.sql
@@ -1,0 +1,62 @@
+-- =============================================
+-- Author:      Leena Komenski
+-- Create date: 05/21/2026
+-- Description: Pre-computes which songs charted in which countries per year.
+--              Used by sp_GetCountryProfile, sp_GetCountrySongsPaged, and
+--              sp_GetCountryComparison to verify country-specific charting
+--              without querying ChartEntry at runtime.
+--              Excludes Viral 50 (chart_type_id = 2) for consistency with
+--              sp_PopulateSongCountryPresence.
+-- EXEC sp_PopulateSongCountryChart;
+-- =============================================
+
+-- =============================================
+-- Step 1: Create table and index (run once)
+-- =============================================
+
+/*
+CREATE TABLE SongCountryChart (
+    song_id    INT NOT NULL,
+    country_id INT NOT NULL,
+    chart_year INT NOT NULL,
+    CONSTRAINT PK_SongCountryChart PRIMARY KEY (song_id, country_id, chart_year),
+    CONSTRAINT FK_SCC_Song    FOREIGN KEY (song_id)    REFERENCES DIM_Song(song_id),
+    CONSTRAINT FK_SCC_Country FOREIGN KEY (country_id) REFERENCES Country(country_id)
+);
+
+-- Covers country-first lookups in sp_GetCountryComparison CTEs.
+-- PK already covers song-first EXISTS / JOIN in profile and paged SPs.
+CREATE INDEX IX_SongCountryChart_Country_Year
+    ON SongCountryChart (country_id, chart_year);
+*/
+
+-- =============================================
+-- Step 2: Create / update the population SP
+-- =============================================
+
+USE HiddenGemMusic;
+GO
+
+CREATE OR ALTER PROCEDURE sp_PopulateSongCountryChart
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    TRUNCATE TABLE SongCountryChart;
+
+    INSERT INTO SongCountryChart (song_id, country_id, chart_year)
+    SELECT DISTINCT
+        ce.song_id,
+        ce.country_id,
+        YEAR(ce.snapshot_date)
+    FROM ChartEntry ce
+    WHERE ce.country_id IS NOT NULL
+      AND ce.chart_type_id != 2;
+
+    -- Sanity check: row counts per year
+    SELECT chart_year, COUNT(*) AS song_country_pairs
+    FROM SongCountryChart
+    GROUP BY chart_year
+    ORDER BY chart_year;
+END;
+GO

--- a/backend/Capstone.API/database/read/sp_GetCountryComparison.sql
+++ b/backend/Capstone.API/database/read/sp_GetCountryComparison.sql
@@ -2,8 +2,11 @@
 -- Author:      Leena Komenski
 -- Create date: 04/23/2026
 -- Updated:     04/26/2026 — Star schema rewrite
--- Changes:     Song → DIM_Song, ArtistSong → Bridge_SongArtist (artist_order=1),
---              Artist → DIM_Artist, Album join removed (album_name on DIM_Song)
+--              05/19/2026 — Performance pass: index IX_HiddenGems_Country_Year_Song
+--                           added separately; country_count carried through InA CTE
+--                           to eliminate redundant SongCountryPresence join in RS3;
+--                           NOT EXISTS rewritten as LEFT JOIN anti-join so the
+--                           optimizer can use the index as a seek in all result sets.
 -- Description: Side-by-side KPIs and song lists for two countries. Returns five result sets:
 -- (1) Country A stats, (2) Country B stats, (3) shared songs,
 -- (4) unique to A, (5) unique to B.
@@ -44,32 +47,30 @@ BEGIN
 
     -- ── Result Set 3: Songs in BOTH countries ───────────────
     WITH InA AS (
-        SELECT scp.song_id
+        SELECT scp.song_id, scp.country_count
         FROM SongCountryPresence scp
+        LEFT JOIN HiddenGems hgA
+            ON hgA.country_id = @CountryIdA
+           AND hgA.song_id    = scp.song_id
+           AND hgA.chart_year = @Year
         WHERE scp.chart_year = @Year
-          AND NOT EXISTS (
-              SELECT 1 FROM HiddenGems hg
-              WHERE hg.country_id = @CountryIdA
-                AND hg.song_id    = scp.song_id
-                AND hg.chart_year = @Year
-          )
+          AND hgA.song_id IS NULL
     ),
     InB AS (
         SELECT scp.song_id
         FROM SongCountryPresence scp
+        LEFT JOIN HiddenGems hgB
+            ON hgB.country_id = @CountryIdB
+           AND hgB.song_id    = scp.song_id
+           AND hgB.chart_year = @Year
         WHERE scp.chart_year = @Year
-          AND NOT EXISTS (
-              SELECT 1 FROM HiddenGems hg
-              WHERE hg.country_id = @CountryIdB
-                AND hg.song_id    = scp.song_id
-                AND hg.chart_year = @Year
-          )
+          AND hgB.song_id IS NULL
     )
     SELECT
         s.song_id,
         s.title             AS song_title,
         a.artist_name,
-        scp.country_count   AS global_presence
+        InA.country_count   AS global_presence
     FROM InA
     JOIN InB ON InB.song_id = InA.song_id
     JOIN DIM_Song s ON s.song_id = InA.song_id
@@ -77,22 +78,18 @@ BEGIN
         ON bsa.song_id      = s.song_id
        AND bsa.artist_order = 1
     LEFT JOIN DIM_Artist a ON a.artist_id = bsa.artist_id
-    JOIN SongCountryPresence scp
-        ON scp.song_id    = InA.song_id
-       AND scp.chart_year = @Year
-    ORDER BY scp.country_count DESC;
+    ORDER BY InA.country_count DESC;
 
     -- ── Result Set 4: Songs unique to Country A ─────────────
     WITH InA AS (
         SELECT scp.song_id
         FROM SongCountryPresence scp
+        LEFT JOIN HiddenGems hgA
+            ON hgA.country_id = @CountryIdA
+           AND hgA.song_id    = scp.song_id
+           AND hgA.chart_year = @Year
         WHERE scp.chart_year = @Year
-          AND NOT EXISTS (
-              SELECT 1 FROM HiddenGems hg
-              WHERE hg.country_id = @CountryIdA
-                AND hg.song_id    = scp.song_id
-                AND hg.chart_year = @Year
-          )
+          AND hgA.song_id IS NULL
     ),
     NotInB AS (
         SELECT song_id
@@ -123,13 +120,12 @@ BEGIN
     InB AS (
         SELECT scp.song_id
         FROM SongCountryPresence scp
+        LEFT JOIN HiddenGems hgB
+            ON hgB.country_id = @CountryIdB
+           AND hgB.song_id    = scp.song_id
+           AND hgB.chart_year = @Year
         WHERE scp.chart_year = @Year
-          AND NOT EXISTS (
-              SELECT 1 FROM HiddenGems hg
-              WHERE hg.country_id = @CountryIdB
-                AND hg.song_id    = scp.song_id
-                AND hg.chart_year = @Year
-          )
+          AND hgB.song_id IS NULL
     )
     SELECT TOP 20
         s.song_id,

--- a/backend/Capstone.API/database/read/sp_GetCountryComparison.sql
+++ b/backend/Capstone.API/database/read/sp_GetCountryComparison.sql
@@ -3,10 +3,12 @@
 -- Create date: 04/23/2026
 -- Updated:     04/26/2026 — Star schema rewrite
 --              05/19/2026 — Performance pass: index IX_HiddenGems_Country_Year_Song
---                           added separately; country_count carried through InA CTE
---                           to eliminate redundant SongCountryPresence join in RS3;
---                           NOT EXISTS rewritten as LEFT JOIN anti-join so the
---                           optimizer can use the index as a seek in all result sets.
+--                           added separately; country_count carried through InA CTE;
+--                           NOT EXISTS rewritten as LEFT JOIN anti-join.
+--              05/21/2026 — Replaced HiddenGems proxy with SongCountryChart in all
+--                           result sets; RS4/RS5 use direct anti-join on SongCountryChart
+--                           instead of HiddenGems membership. Requires SongCountryChart
+--                           table (see sp_PopulateSongCountryChart.sql).
 -- Description: Side-by-side KPIs and song lists for two countries. Returns five result sets:
 -- (1) Country A stats, (2) Country B stats, (3) shared songs,
 -- (4) unique to A, (5) unique to B.
@@ -47,24 +49,19 @@ BEGIN
 
     -- ── Result Set 3: Songs in BOTH countries ───────────────
     WITH InA AS (
-        SELECT scp.song_id, scp.country_count
-        FROM SongCountryPresence scp
-        LEFT JOIN HiddenGems hgA
-            ON hgA.country_id = @CountryIdA
-           AND hgA.song_id    = scp.song_id
-           AND hgA.chart_year = @Year
-        WHERE scp.chart_year = @Year
-          AND hgA.song_id IS NULL
+        SELECT scc.song_id, scp.country_count
+        FROM SongCountryChart scc
+        JOIN SongCountryPresence scp
+            ON scp.song_id    = scc.song_id
+           AND scp.chart_year = @Year
+        WHERE scc.country_id = @CountryIdA
+          AND scc.chart_year = @Year
     ),
     InB AS (
-        SELECT scp.song_id
-        FROM SongCountryPresence scp
-        LEFT JOIN HiddenGems hgB
-            ON hgB.country_id = @CountryIdB
-           AND hgB.song_id    = scp.song_id
-           AND hgB.chart_year = @Year
-        WHERE scp.chart_year = @Year
-          AND hgB.song_id IS NULL
+        SELECT scc.song_id
+        FROM SongCountryChart scc
+        WHERE scc.country_id = @CountryIdB
+          AND scc.chart_year = @Year
     )
     SELECT
         s.song_id,
@@ -82,62 +79,56 @@ BEGIN
 
     -- ── Result Set 4: Songs unique to Country A ─────────────
     WITH InA AS (
-        SELECT scp.song_id
-        FROM SongCountryPresence scp
-        LEFT JOIN HiddenGems hgA
-            ON hgA.country_id = @CountryIdA
-           AND hgA.song_id    = scp.song_id
-           AND hgA.chart_year = @Year
-        WHERE scp.chart_year = @Year
-          AND hgA.song_id IS NULL
+        SELECT scc.song_id
+        FROM SongCountryChart scc
+        WHERE scc.country_id = @CountryIdA
+          AND scc.chart_year = @Year
     ),
     NotInB AS (
-        SELECT song_id
-        FROM HiddenGems
-        WHERE country_id = @CountryIdB
-          AND chart_year = @Year
+        SELECT scc.song_id
+        FROM SongCountryChart scc
+        WHERE scc.country_id = @CountryIdB
+          AND scc.chart_year = @Year
     )
     SELECT TOP 20
         s.song_id,
         s.title         AS song_title,
         a.artist_name
     FROM InA
-    JOIN NotInB ON NotInB.song_id = InA.song_id
+    LEFT JOIN NotInB ON NotInB.song_id = InA.song_id
     JOIN DIM_Song s ON s.song_id = InA.song_id
     LEFT JOIN Bridge_SongArtist bsa
         ON bsa.song_id      = s.song_id
        AND bsa.artist_order = 1
     LEFT JOIN DIM_Artist a ON a.artist_id = bsa.artist_id
+    WHERE NotInB.song_id IS NULL
     ORDER BY s.title;
 
     -- ── Result Set 5: Songs unique to Country B ─────────────
     WITH NotInA AS (
-        SELECT song_id
-        FROM HiddenGems
-        WHERE country_id = @CountryIdA
-          AND chart_year = @Year
+        SELECT scc.song_id
+        FROM SongCountryChart scc
+        WHERE scc.country_id = @CountryIdA
+          AND scc.chart_year = @Year
     ),
     InB AS (
-        SELECT scp.song_id
-        FROM SongCountryPresence scp
-        LEFT JOIN HiddenGems hgB
-            ON hgB.country_id = @CountryIdB
-           AND hgB.song_id    = scp.song_id
-           AND hgB.chart_year = @Year
-        WHERE scp.chart_year = @Year
-          AND hgB.song_id IS NULL
+        SELECT scc.song_id
+        FROM SongCountryChart scc
+        WHERE scc.country_id = @CountryIdB
+          AND scc.chart_year = @Year
     )
     SELECT TOP 20
         s.song_id,
         s.title         AS song_title,
         a.artist_name
     FROM InB
-    JOIN NotInA ON NotInA.song_id = InB.song_id
+    LEFT JOIN NotInA ON NotInA.song_id = InB.song_id
     JOIN DIM_Song s ON s.song_id = InB.song_id
     LEFT JOIN Bridge_SongArtist bsa
         ON bsa.song_id      = s.song_id
        AND bsa.artist_order = 1
     LEFT JOIN DIM_Artist a ON a.artist_id = bsa.artist_id
+    WHERE NotInA.song_id IS NULL
     ORDER BY s.title;
 END;
 GO

--- a/backend/Capstone.API/database/read/sp_GetCountryProfile.sql
+++ b/backend/Capstone.API/database/read/sp_GetCountryProfile.sql
@@ -4,6 +4,10 @@
 -- Updated:     04/26/2026 — Star schema rewrite
 -- Changes:     Song → DIM_Song, ArtistSong → Bridge_SongArtist (artist_order=1),
 --              Artist → DIM_Artist, Album join removed (album_name on DIM_Song)
+-- Updated:     05/19/2026 — Bug fix: added country_id filter to unique songs NOT EXISTS
+-- Updated:     05/21/2026 — Replaced HiddenGems proxy with SongCountryChart join for both
+--              shared and unique songs; added @CountryId variable; requires SongCountryChart
+--              table (see sp_PopulateSongCountryChart.sql)
 -- Description: Full summary stats for one country and year. Returns three result sets:
 -- (1) KPI summary, (2) top 10 shared songs, (3) top 10 unique songs.
 -- EXEC sp_GetCountryProfile @CountryCode = 'US', @Year = 2021;
@@ -18,6 +22,8 @@ CREATE OR ALTER PROCEDURE sp_GetCountryProfile
 AS
 BEGIN
     SET NOCOUNT ON;
+
+    DECLARE @CountryId INT = (SELECT country_id FROM Country WHERE iso_code = @CountryCode);
 
     -- ── Summary Stats ───────────────────────────────────────
     SELECT
@@ -42,6 +48,10 @@ BEGIN
         s.album_name,
         scp.country_count   AS countries_charted_in
     FROM SongCountryPresence scp
+    JOIN SongCountryChart scc
+        ON scc.song_id    = scp.song_id
+       AND scc.country_id = @CountryId
+       AND scc.chart_year = @Year
     JOIN DIM_Song s ON s.song_id = scp.song_id
     LEFT JOIN Bridge_SongArtist bsa
         ON bsa.song_id      = s.song_id
@@ -49,12 +59,6 @@ BEGIN
     LEFT JOIN DIM_Artist a ON a.artist_id = bsa.artist_id
     WHERE scp.chart_year  = @Year
       AND scp.country_count > 1
-      AND NOT EXISTS (
-          SELECT 1 FROM HiddenGems hg2
-          WHERE hg2.country_id = (SELECT country_id FROM Country WHERE iso_code = @CountryCode)
-            AND hg2.song_id    = scp.song_id
-            AND hg2.chart_year = @Year
-      )
     ORDER BY scp.country_count DESC;
 
     -- ── Top 10 Unique Songs ──────────────────────────────────
@@ -64,6 +68,10 @@ BEGIN
         a.artist_name,
         s.album_name
     FROM SongCountryPresence scp
+    JOIN SongCountryChart scc
+        ON scc.song_id    = scp.song_id
+       AND scc.country_id = @CountryId
+       AND scc.chart_year = @Year
     JOIN DIM_Song s ON s.song_id = scp.song_id
     LEFT JOIN Bridge_SongArtist bsa
         ON bsa.song_id      = s.song_id
@@ -71,12 +79,6 @@ BEGIN
     LEFT JOIN DIM_Artist a ON a.artist_id = bsa.artist_id
     WHERE scp.chart_year    = @Year
       AND scp.country_count = 1
-      AND NOT EXISTS (
-          SELECT 1 FROM HiddenGems hg3
-          WHERE hg3.country_id = (SELECT country_id FROM Country WHERE iso_code = @CountryCode)
-            AND hg3.song_id    = scp.song_id
-            AND hg3.chart_year = @Year
-      )
     ORDER BY NEWID();
 END;
 GO

--- a/backend/Capstone.API/database/read/sp_GetCountryProfile.sql
+++ b/backend/Capstone.API/database/read/sp_GetCountryProfile.sql
@@ -73,7 +73,8 @@ BEGIN
       AND scp.country_count = 1
       AND NOT EXISTS (
           SELECT 1 FROM HiddenGems hg3
-          WHERE hg3.song_id    = scp.song_id
+          WHERE hg3.country_id = (SELECT country_id FROM Country WHERE iso_code = @CountryCode)
+            AND hg3.song_id    = scp.song_id
             AND hg3.chart_year = @Year
       )
     ORDER BY NEWID();

--- a/backend/Capstone.API/database/read/sp_GetCountrySongsPaged.sql
+++ b/backend/Capstone.API/database/read/sp_GetCountrySongsPaged.sql
@@ -40,25 +40,17 @@ BEGIN
         LEFT JOIN DIM_Artist a
             ON a.artist_id = bsa.artist_id
         WHERE scp.chart_year = @Year
+          AND EXISTS (
+                SELECT 1
+                FROM SongCountryChart scc
+                WHERE scc.song_id    = scp.song_id
+                  AND scc.country_id = @CountryId
+                  AND scc.chart_year = @Year
+              )
           AND (
-                (@ListType = 'shared'
-                 AND scp.country_count > 1
-                 AND NOT EXISTS (
-                    SELECT 1
-                    FROM HiddenGems hg
-                    WHERE hg.country_id = @CountryId
-                      AND hg.song_id = scp.song_id
-                      AND hg.chart_year = @Year
-                 ))
+                (@ListType = 'shared' AND scp.country_count > 1)
                 OR
-                (@ListType = 'unique'
-                 AND scp.country_count = 1
-                 AND NOT EXISTS (
-                    SELECT 1
-                    FROM HiddenGems hg
-                    WHERE hg.song_id = scp.song_id
-                      AND hg.chart_year = @Year
-                 ))
+                (@ListType = 'unique' AND scp.country_count = 1)
               )
     )
     SELECT

--- a/backend/Capstone.API/database/read/sp_GetDiscoverPageInfo.sql
+++ b/backend/Capstone.API/database/read/sp_GetDiscoverPageInfo.sql
@@ -11,10 +11,14 @@
 --              05/19/2026 — Added top_song_name to SELECT (issue #148).
 --                           Requires ALTER TABLE + sp_PopulateTopSongByCountryYear
 --                           re-run before deploying — see populate SP header.
+--              05/21/2026 — Added SongCountryChart EXISTS filter to exclude countries
+--                           with no Top 200 data for the requested year (e.g. Andorra,
+--                           Viral-50-only).
 -- Description: One lightweight row per country for the Discovery Map and country
 --              sidebar list. Returns country metadata, hidden gem count for the year,
 --              and most-charted song/album/artist from TopSongByCountryYear.
---              Reads only pre-computed tables (Country, HiddenGems, TopSongByCountryYear).
+--              Reads only pre-computed tables (Country, HiddenGems, TopSongByCountryYear,
+--              SongCountryChart).
 -- EXEC sp_GetDiscoverPageInfo @Year = 2021;
 -- =============================================
 
@@ -48,5 +52,10 @@ BEGIN
         ON tscy.country_id = c.country_id
        AND tscy.chart_year = @Year
     WHERE c.iso_code IS NOT NULL
+      AND EXISTS (
+            SELECT 1 FROM SongCountryChart scc
+            WHERE scc.country_id = c.country_id
+              AND scc.chart_year = @Year
+          )
     ORDER BY c.full_name;
 END;

--- a/backend/Capstone.API/database/run-all-population.sql
+++ b/backend/Capstone.API/database/run-all-population.sql
@@ -3,6 +3,7 @@
 -- Create date: 04/23/2026
 -- Updated:     05/15/2026 — Added sp_PopulateTopSongByCountryYear (step 9)
 --                           and TopSongByCountryYear to the row count check.
+--              05/21/2026 — Added sp_PopulateSongCountryChart (step 2, after SongCountryPresence).
 -- Description: Runs all population stored procedures in the correct
 --              execution order. Run once after initial data ingestion,
 --              or any time the pre-computed summary tables need to be rebuilt.
@@ -16,6 +17,8 @@ USE HiddenGemMusic;
 GO
 
 EXEC sp_PopulateSongCountryPresence;
+GO
+EXEC sp_PopulateSongCountryChart;
 GO
 EXEC sp_PopulateCountryYearStats;
 GO
@@ -55,4 +58,6 @@ SELECT 'PeakReachBySong',         COUNT(*) FROM PeakReachBySong
 UNION ALL
 SELECT 'HiddenGems',              COUNT(*) FROM HiddenGems
 UNION ALL
-SELECT 'TopSongByCountryYear',    COUNT(*) FROM TopSongByCountryYear;
+SELECT 'TopSongByCountryYear',    COUNT(*) FROM TopSongByCountryYear
+UNION ALL
+SELECT 'SongCountryChart',        COUNT(*) FROM SongCountryChart;

--- a/hidden-gem-music-app/src/screens/CreditsScreen.tsx
+++ b/hidden-gem-music-app/src/screens/CreditsScreen.tsx
@@ -59,7 +59,7 @@ const creditSections: CreditSection[] = [
       "Migrated the database mid-project from a transactional structure to a star-schema data warehouse — redesigning the schema, moving all data without loss, and rebuilding the stored procedure suite against the new structure.",
       "Designed and implemented the index strategy and pre-computation architecture that makes the app fast — including all summary tables populated once and read instantly at runtime.",
       "Authored the full SQL stored procedure suite powering every data insight in the app, and maintained sole ownership of database health throughout the project.",
-      "Ran multiple systematic data quality investigations — diagnosing aggregation mismatches, left-censored artifacts, date-parameter bugs, and Viral 50 / Top 200 conflation across the discovery gap pipeline.",
+      "Ran multiple systematic data quality investigations across the pipeline — diagnosing structural and correctness flaws end-to-end, from aggregation errors and schema mismatches to wrong data surfacing in live screens.",
       "Resolved each investigation end-to-end: live schema changes, stored procedure rewrites, and full summary-table repopulation in dependency order — often tracing root cause from a frontend symptom all the way back to the query layer.",
       "Optimized backend performance through pre-computed summary tables, backend parallelization, and frontend API caching — turning multi-second loads into near-instant responses.",
       "Scaffolded the complete .NET 9 backend — controllers, repository interfaces, data models, and DTOs — giving mp3li the foundation to build the app's feature endpoints on top of.",


### PR DESCRIPTION
## Summary

This PR resolves the core data correctness issues on the Country Profile and Country Comparison screens (Issue #147), and fixes two related bugs found during investigation: incorrect songs displaying on country profiles/comparisons (Japan, Brazil, USA), and Andorra appearing on the Discovery Map and in KPI cards despite having no Top 200 chart data.

### What changed

- **Country pages now show correct country-specific songs.** `sp_GetCountryProfile`, `sp_GetCountrySongsPaged`, and `sp_GetCountryComparison` were rewritten to use a new pre-computed lookup table (`SongCountryChart`) instead of `SongCountryPresence`, which aggregates across countries and caused globally popular songs to surface as "unique" to a given country.
- **CountryYearStats KPI numbers now exclude Viral 50 data.** `sp_PopulateCountryYearStats` previously included Viral 50 chart entries in `total_charted`, `shared_count`, and `overlap_pct`. For Andorra (Viral-50-only dataset), this produced inflated KPIs (682 total, 81% overlap) with zero songs displaying — the numbers looked valid but had no Top 200 data behind them.
- **Discovery Map no longer shows countries with no Top 200 data.** `sp_GetDiscoverPageInfo` now filters via `EXISTS (SELECT 1 FROM SongCountryChart ...)` to exclude countries where the selected year has only Viral 50 entries. Andorra is the only country in the dataset with chart data but no Top 200 rows (79,592 Viral 50 rows, 2017–2021).

---

## Database changes

### One-time DDL (run once if `SongCountryChart` does not exist in your environment)

```sql
CREATE TABLE SongCountryChart (
    song_id    INT NOT NULL,
    country_id INT NOT NULL,
    chart_year INT NOT NULL,
    CONSTRAINT PK_SongCountryChart PRIMARY KEY (song_id, country_id, chart_year),
    CONSTRAINT FK_SCC_Song    FOREIGN KEY (song_id)    REFERENCES DIM_Song(song_id),
    CONSTRAINT FK_SCC_Country FOREIGN KEY (country_id) REFERENCES Country(country_id)
);

CREATE INDEX IX_SongCountryChart_Country_Year
    ON SongCountryChart (country_id, chart_year);

-- HiddenGems index (if not already present)
CREATE INDEX IX_HiddenGems_Country_Year_Song
    ON HiddenGems (country_id, chart_year, song_id);
```

> Run this **before** running any SP definitions or population execs.

---

### Updated stored procedures

| SP | What changed |
|---|---|
| `sp_PopulateSongCountryChart` | **New.** Pre-computes `(song_id, country_id, chart_year)` from `ChartEntry`, excluding Viral 50 (`chart_type_id != 2`). Replaces runtime `ChartEntry` joins in read SPs. |
| `sp_PopulateTopSongByCountryYear` | Updated to include `song_name` in the pre-computed row. Powers the Discovery Map hover/list song display for DS1 years. |
| `sp_PopulateCountryYearStats` | Added `AND ce.chart_type_id != 2` to the `SongsPerCountryYear` CTE. Prevents Viral 50 entries from inflating KPIs for countries with no Top 200 data. |
| `sp_GetCountryProfile` | Rewritten to join `SongCountryChart` for country-specific song filtering. Fixes Japan/Brazil/USA showing songs from other countries. |
| `sp_GetCountrySongsPaged` | Rewritten to join `SongCountryChart`. Same correctness fix — paged song lists were reading from `SongCountryPresence` which aggregates across countries. |
| `sp_GetCountryComparison` | Rewritten to join `SongCountryChart`. Comparison overlap sets now reflect actual country-specific charting. |
| `sp_GetDiscoverPageInfo` | Added `EXISTS (SELECT 1 FROM SongCountryChart ...)` to the `WHERE` clause. Hides countries with no Top 200 data for the requested year from the Discovery Map. |
| `run-all-population.sql` | Added `EXEC sp_PopulateSongCountryChart` as step 2 (after `sp_PopulateSongCountryPresence`). |

---

### Run order to apply locally

**Step 1 — One-time DDL** (skip if `SongCountryChart` already exists):
Run the `CREATE TABLE` / `CREATE INDEX` block above against `HiddenGemMusic`.

**Step 2 — Apply SP definitions:**
Run the 7 updated SP files listed above via SSMS (exclude run-all-population.sql). All use `CREATE OR ALTER` — safe to re-run.

**Step 3 — Run only the affected population SPs:**

```sql
EXEC sp_PopulateSongCountryChart;
EXEC sp_PopulateCountryYearStats;
EXEC sp_PopulateTopSongByCountryYear;
```

> You do not need to re-run the full `run-all-population.sql`. Only these three tables changed. After running, Andorra will have no row in `CountryYearStats` (correct — no Top 200 data).

**Step 4 — Clear caches and restart:**
- Delete `backend/Capstone.API/presentation_data_cache.json` (and `.tmp` if present)
- Delete `backend/Capstone.API/discovery_samples_cache.json` (and `.tmp` if present)
- Restart the API server

> These file-backed caches persist enriched data across restarts. After any SP change or DB re-population they must be manually deleted or old data will continue serving. See QA log entry "Cache Clearing Required After Every Backend or SP Change."

---

## Backend C# changes

| File | What changed |
|---|---|
| `CountryRepository.cs` | `GetCountryProfileAsync` and `GetCountrySongsPaged` rewritten to call refactored SPs. Genre sampling restored to `GetCountryGenreSampleAsync` (Eli's original prefix-based approach). |
| `DeezerSongEnrichmentService.cs` | Minor enrichment path cleanup. |
| `ComparisonRepository.cs` | Updated to call rewritten `sp_GetCountryComparison`. |
| `CountryController.cs` | Routing and response mapping updates for new SP result shapes. |
| `ComparisonController.cs` | Routing and cancellation token updates. |
| `DiscoveryController.cs` | Updated for `sp_GetDiscoverPageInfo` result shape (`top_song_name` field). |

---

## Flagged for Eli

### 1. Profile page genre source — review requested

`GetCountryProfileAsync` currently calls `GetCountryGenreSampleAsync` (your original prefix-based approach) for `SampleGenres`. An alternative was prototyped during this investigation and reverted. Both options are documented in the QA log:

- **Option A (current — your original):** `GetCountryGenreSampleAsync` — prefix heuristic samples from the full catalog for genre diversity. Costs extra Deezer calls on profile load; genres reflect the broader catalog, not specifically the top songs shown on screen.
- **Option B (reverted prototype):** `ExtractSampleGenres` — derives genres directly from the already-enriched top shared/unique songs. No extra Deezer calls; genres always match what's on screen. Risk: top songs skew globally popular and may underrepresent local genre character.

Option A is retained as the safer default. No action needed unless you prefer Option B.

### 2. Dev cache bypass — consider adding

The two file-backed caches (`presentation_data_cache.json`, `discovery_samples_cache.json`) must be manually deleted after every SP change or DB re-population during local QA. A flag (e.g. `DisablePresentationCache: true` in `appsettings.Development.json`) that disables or shortens cache TTLs in development would eliminate this step without affecting production behavior.

### 3. KPI card copy — frontend changes needed

The KPI card labels on the country profile page need clearer copy. Full details and suggested replacements are in the QA log entry "Country Profile KPI Card Label Improvements" (2026-05-21). Summary:

| Current label | Issue |
|---|---|
| Songs in this view | Ambiguous — doesn't clarify it's the total for the country/year |
| Loved in This Country | Reads like a section heading, not a stat |
| Loved Here and Elsewhere | Same — should lead with the count |
| % of this view | Doesn't explain what the overlap percentage represents |

No backend changes needed — all values are already returned in the profile response.

---

## Testing

### Verified by author

- **Country Profile — Japan 2020, Brazil 2020, USA 2021:** Confirmed top shared and unique song lists now show country-specific charted songs. Prior to fix, Swedish and Polish artists (Maximillian, Szpaku, TIX) were appearing as "top unique songs" for Japan and Brazil.
- **Country Comparison:** Verified shared/unique overlap sets reflect actual country-specific charting after `sp_GetCountryComparison` rewrite.
- **Discovery Map — Andorra:** Confirmed Andorra no longer appears on the map for any year after adding the `SongCountryChart` EXISTS filter to `sp_GetDiscoverPageInfo`.
- **KPI cards — Andorra:** Confirmed `CountryYearStats` has no row for Andorra after re-running `sp_PopulateCountryYearStats` with Viral 50 excluded.
- **`SongCountryChart` population:** Confirmed non-zero row count after `EXEC sp_PopulateSongCountryChart`. Confirmed Andorra returns 0 rows (expected — no Top 200 data). Confirmed all other countries with Viral 50 data also have Top 200 rows.
- **Cache clearing:** Verified that deleting both cache files and restarting the server picks up the updated SP results correctly.

---

### Checklist for reviewer

**Database**
- [ ] `SongCountryChart` exists and has rows after running DDL + `EXEC sp_PopulateSongCountryChart`
- [ ] `CountryYearStats` has no row for Andorra after re-running `EXEC sp_PopulateCountryYearStats`
- [ ] `TopSongByCountryYear` includes `song_name` values after re-running `EXEC sp_PopulateTopSongByCountryYear`

**Country Profile**
- [ ] A country known to have been affected (e.g. Japan 2020 or Brazil 2020) now shows only songs that actually charted in that country
- [ ] Genre and language samples load on the profile page
- [ ] Top shared and unique song lists are non-empty for a healthy country/year

**Country Comparison**
- [ ] Selecting two countries produces a non-empty result with shared and unique song lists
- [ ] Overlap percentage looks reasonable

**Discovery Map**
- [ ] Andorra does not appear on the map for any year
- [ ] Countries that previously loaded correctly (e.g. USA, UK, Australia) still appear and show song data

**Cache**
- [ ] After deleting both cache files and restarting, country profile and comparison data loads correctly (may be slow on first load — expected)
