### PR TITLE
Completed Issue 39 QA End to End Flow, Slight UI Text Changes, and Fixed Search Only Showing 25 Countries

### DIFF
--- a/Documentation/QA-log.md
+++ b/Documentation/QA-log.md
@@ -3,6 +3,83 @@
 
 ---
 
+## 2026-05-22 — Branch 39 End-to-End QA Flow and Frontend Follow-Through
+
+**Tester:** mp3li / Codex-assisted verification
+**Fix owner:** mp3li for frontend follow-up; Leena Komenski for the merged Issue 147 SQL/backend correctness changes
+**Branch:** `39-qa-end-to-end-flow`
+**Scope:** Local SSMS follow-through for Leena's Issue 147 merge, cache clearing, Country Profile KPI copy, Discovery Map hover card sizing, header search country coverage, and full app navigation flow testing
+
+### What was handled
+
+This branch followed up on Leena's merged Issue 147 work. The SQL/backend stored-procedure changes are Leena's work; this branch applied the required local database steps, validated the results, cleared stale caches, and completed a small set of frontend readiness fixes.
+
+### Database follow-through completed
+
+- Ran the one-time `SongCountryChart` DDL/index setup in SSMS against `HiddenGemMusic`.
+- Ran the affected stored-procedure definition files in SSMS:
+  - `sp_PopulateSongCountryChart.sql`
+  - `sp_PopulateCountryYearStats.sql`
+  - `sp_PopulateTopSongByCountryYear.sql`
+  - `sp_GetCountryProfile.sql`
+  - `sp_GetCountrySongsPaged.sql`
+  - `sp_GetCountryComparison.sql`
+  - `sp_GetDiscoverPageInfo.sql`
+- Ran only the affected population procedures:
+  - `EXEC sp_PopulateSongCountryChart;`
+  - `EXEC sp_PopulateCountryYearStats;`
+  - `EXEC sp_PopulateTopSongByCountryYear;`
+- Did not run the full `run-all-population.sql`.
+- Cleared stale file-backed caches so old country/song data would not continue serving after the stored-procedure changes:
+  - `backend/Capstone.API/Data/presentation_data_cache.json`
+  - `backend/Capstone.API/Data/discovery_samples_cache.json`
+
+### SSMS validation results
+
+- `SongCountryChart` populated successfully with `518452` rows.
+- Confirmed Andorra has `0` Top 200 rows in `SongCountryChart`.
+- Confirmed Andorra returns no rows from `CountryYearStats`, which is expected because the available dataset only contains Viral 50 rows for Andorra.
+- Confirmed `TopSongByCountryYear` includes `song_name` values after population.
+- Confirmed population sanity outputs returned year/country coverage for populated years.
+
+### Frontend changes completed
+
+- Increased the desktop/web Discovery Map glassy hover blurb height so the third country hover row, `Top album`, is visible instead of clipped.
+- Kept mobile Discovery Map blurb sizing unchanged by leaving the mobile-specific height/body overrides untouched.
+- Updated two Country Profile KPI labels:
+  - `Songs in This View` -> `Songs in Selected View`
+  - `% of this view` -> `% of selected view`
+- Kept `Loved in This Country` and `Loved Here and Elsewhere` unchanged because those KPI labels intentionally mirror the matching song sections lower on the page, helping users connect summary numbers to the detailed lists.
+- Updated header search to use an all-years API-valid country pool instead of only the currently selected year's pool.
+- Removed the search overlay's 25-result cap so the full valid country list can display.
+- Preserved the corrected behavior where countries without Top 200 app data, such as Andorra, should not be selectable search results.
+
+### KPI copy decision note
+
+The two changed KPI labels were adjusted because they could be clarified without changing the existing information hierarchy. The wording now ties the stat to the user's active country/year selection, which is the context used to reach the page and generate the displayed stats.
+
+From a frontend UX perspective, `Loved in This Country` and `Loved Here and Elsewhere` were kept because those KPI labels intentionally mirror the matching song sections lower on the page. Longer labels such as "total songs in this country/year" were avoided because the stat represents songs in the selected app dataset, not every song that exists for that country and year, and the cards are compact responsive UI elements across multiple layout widths. A future iteration could add longer explanatory text, but that would require broader UI changes and web/mobile QA beyond a small label update.
+
+### End-to-end flow testing completed
+
+- Completed a full end-to-end navigation flow test across the app.
+- Verified that the main user paths route to the expected screens.
+- Verified that country/year context is preserved where applicable.
+- Verified that pages bring users to the intended destination screens during normal navigation.
+
+### Verification
+
+- `dotnet build` passed after stale cache files were cleared.
+- `npm run typecheck` passed after frontend changes.
+
+### Follow-up not included
+
+- No change was made to the Country Profile genre source. The current `GetCountryGenreSampleAsync` behavior remains in place for deadline stability.
+- No dev cache bypass setting was added.
+- No additional backend ownership is claimed for Leena's Issue 147 SQL/backend implementation.
+
+---
+
 ## 2026-05-21 — Cache Clearing Required After Every Backend or SP Change
 
 **Tester:** Leena Komenski

--- a/Documents/mp3li implementation timeline document.txt
+++ b/Documents/mp3li implementation timeline document.txt
@@ -1,6 +1,61 @@
 mp3li implementation timeline document
 
-Updated: May 21, 2026
+Updated: May 22, 2026
+
+End-to-End QA Flow, Leena PR Follow-Through, and Frontend Polish (May 22, 2026)
+- Objective:
+  - Bring the new `39-qa-end-to-end-flow` branch into a verified state after Leena's Issue 147 PR was merged into development.
+  - Apply and validate the required local database follow-through from Leena's PR without claiming ownership of the SQL/backend stored-procedure changes.
+  - Complete the small frontend follow-up items that were appropriate to handle before deployment while keeping larger UX changes out of scope.
+
+- Database and cache follow-through completed from Leena's merge:
+  - Confirmed the branch includes Leena's Issue 147 database/backend work for country profile, country comparison, Discovery Map, and Top-200-only country/year correctness.
+  - Walked through the required SSMS application order for the new/updated stored procedures and affected population procedures.
+  - Ran the one-time `SongCountryChart` DDL/index setup in SSMS.
+  - Ran the affected stored-procedure definitions in SSMS.
+  - Ran only the required population procedures:
+    - `EXEC sp_PopulateSongCountryChart;`
+    - `EXEC sp_PopulateCountryYearStats;`
+    - `EXEC sp_PopulateTopSongByCountryYear;`
+  - Cleared stale file-backed presentation/discovery caches so the app would not continue serving old incorrect country/song data after the stored-procedure updates.
+
+- SSMS validation completed:
+  - `SongCountryChart` populated successfully with `518452` rows.
+  - Confirmed Andorra returns `0` Top 200 rows in `SongCountryChart`.
+  - Confirmed Andorra returns no rows in `CountryYearStats`, which is correct because the dataset only has Viral 50 rows for Andorra.
+  - Confirmed `TopSongByCountryYear` now includes `song_name` values for populated country/year rows.
+  - Confirmed the population sanity outputs returned expected year coverage for `SongCountryChart` and `TopSongByCountryYear`.
+
+- Frontend updates completed:
+  - Increased the desktop/web Discovery Map glassy blurb height so the third hover row, `Top album`, is visible instead of clipped.
+  - Kept the mobile Discovery Map blurb sizing unchanged by only adjusting the default/web styles; mobile continues to use its existing mobile-specific height/body overrides.
+  - Updated two Country Profile KPI labels:
+    - `Songs in This View` -> `Songs in Selected View`
+    - `% of this view` -> `% of selected view`
+  - Kept `Loved in This Country` and `Loved Here and Elsewhere` unchanged because those KPI labels intentionally mirror the matching song sections lower on the page and help connect summary cards to the detailed lists.
+  - Broadened header search so it can include all API-valid countries across available years instead of only the currently selected year's country pool.
+  - Removed the search overlay's 25-result display cap so the search list can show the full country list rather than truncating valid countries.
+  - Preserved the corrected behavior where countries with no Top 200 app data, such as Andorra, should not appear as selectable search results.
+
+- KPI label rationale documented:
+  - The changed labels now refer to the user's selected country/year view, which is the context used to reach the Country Profile page and generate the displayed stats.
+  - Longer labels such as "total songs in this country/year" were intentionally avoided because the stat represents songs in the app's selected dataset, not every song that exists for that country and year.
+  - The cards are compact responsive UI elements across multiple layout widths, so broader explanatory text should be treated as a future UI iteration requiring web/mobile QA rather than a small label-only change.
+
+- End-to-end flow testing completed:
+  - Completed a full end-to-end navigation flow test across the app.
+  - Verified that the main user paths route to the expected screens.
+  - Verified that selected country/year context is preserved where applicable.
+  - Verified that pages bring users to the intended destination screens during normal app navigation.
+
+- Verification completed:
+  - Ran `dotnet build` after clearing stale cache files; backend build passed.
+  - Ran `npm run typecheck` after frontend updates; frontend TypeScript checking passed.
+
+- PR/documentation artifacts updated:
+  - Updated professional QA documentation with this branch's database follow-through, frontend fixes, and end-to-end test notes.
+  - Updated this personal implementation timeline.
+  - Added the PR-ready branch summary in `my txts/PR_39_QA_End_To_End_Flow.md`.
 
 Issue 135 - 2023 Data Disclaimer (May 21, 2026)
 - Objective:

--- a/hidden-gem-music-app/App.tsx
+++ b/hidden-gem-music-app/App.tsx
@@ -370,6 +370,10 @@ export default function App() {
     () => apiCountryPool,
     [apiCountryPool]
   );
+  const searchCountryPool = useMemo(
+    () => (allYearsDiscoveryCountries.length > 0 ? allYearsDiscoveryCountries : comparisonCountryPool),
+    [allYearsDiscoveryCountries, comparisonCountryPool]
+  );
   const selectedComparisonCountries = useMemo(
     () =>
       comparisonIds
@@ -869,6 +873,53 @@ export default function App() {
   }, []);
 
   useEffect(() => {
+    if (apiAvailableYears.length === 0) {
+      return;
+    }
+
+    const missingYears = apiAvailableYears.filter((year) => !discoveryCountriesByYear[year]);
+    if (missingYears.length === 0) {
+      return;
+    }
+
+    const controller = new AbortController();
+
+    Promise.all(
+      missingYears.map((year) =>
+        loadDiscoveryCountries(year, getCountriesForYear(year), controller.signal)
+          .then((apiCountries) => ({ year, apiCountries }))
+          .catch((error) => {
+            if (!controller.signal.aborted) {
+              console.warn(`Failed to load discovery countries for search year ${year}.`, error);
+            }
+            return null;
+          })
+      )
+    ).then((results) => {
+      if (controller.signal.aborted) {
+        return;
+      }
+
+      const loadedResults = results.filter((result): result is { year: number; apiCountries: Country[] } => Boolean(result));
+      if (loadedResults.length === 0) {
+        return;
+      }
+
+      setDiscoveryCountriesByYear((current) => {
+        const next = { ...current };
+        loadedResults.forEach(({ year, apiCountries }) => {
+          next[year] = apiCountries;
+        });
+        return next;
+      });
+    });
+
+    return () => {
+      controller.abort();
+    };
+  }, [apiAvailableYears, discoveryCountriesByYear]);
+
+  useEffect(() => {
     if (apiAvailableYears.length === 0 || apiAvailableYears.includes(selectedYear)) {
       return;
     }
@@ -1114,7 +1165,7 @@ export default function App() {
             searchOpen={searchOpen}
             onToggleSearch={() => setSearchOpen((open) => !open)}
             onCloseSearch={() => setSearchOpen(false)}
-            countries={comparisonCountryPool}
+            countries={searchCountryPool}
             onOpenCountry={openCountry}
           />
           <View style={styles.screenArea}>

--- a/hidden-gem-music-app/src/components/SearchOverlay.tsx
+++ b/hidden-gem-music-app/src/components/SearchOverlay.tsx
@@ -23,10 +23,10 @@ export function SearchOverlay({ visible, countries, onClose, onOpenCountry }: Pr
   const results = useMemo(() => {
     const normalized = query.trim().toLowerCase();
     if (!normalized) {
-      return countries.slice(0, 25);
+      return countries;
     }
 
-    return countries.filter((country) => country.name.toLowerCase().includes(normalized)).slice(0, 25);
+    return countries.filter((country) => country.name.toLowerCase().includes(normalized));
   }, [countries, query]);
 
   useEffect(() => {

--- a/hidden-gem-music-app/src/components/globe/GlobeView.tsx
+++ b/hidden-gem-music-app/src/components/globe/GlobeView.tsx
@@ -1256,8 +1256,8 @@ const styles = StyleSheet.create({
           WebkitBackdropFilter: "blur(18px)",
         } as any)
       : null),
-    minHeight: 58,
-    height: 58,
+    minHeight: 72,
+    height: 72,
   },
   infoPanelShellMobile: {
     height: MOBILE_HELPER_INFO_PANEL_HEIGHT,
@@ -1298,8 +1298,8 @@ const styles = StyleSheet.create({
     backgroundColor: "rgba(240,232,241,0.82)",
   },
   infoPanelBodyWrap: {
-    minHeight: 16,
-    maxHeight: 16,
+    minHeight: 30,
+    maxHeight: 30,
     marginTop: 7,
     justifyContent: "flex-start",
     paddingTop: 0,

--- a/hidden-gem-music-app/src/screens/CountryScreen.tsx
+++ b/hidden-gem-music-app/src/screens/CountryScreen.tsx
@@ -2168,7 +2168,7 @@ export function CountryScreen({
           <View style={[styles.statSquaresBlock, !splitStatsAndInsights ? styles.statSquaresBlockWide : null]}>
             <View style={[styles.statSquaresGrid, statsTwoByTwo ? styles.statSquaresGridTwoByTwo : styles.statSquaresGridSingleRow]}>
               <StatSquare
-                label="Songs in This View"
+                label="Songs in Selected View"
                 value={areProfileStatsLoading ? loadingText : `${profileStats.totalCharted}`}
                 note="songs"
                 valueOffsetY={6}
@@ -2200,7 +2200,7 @@ export function CountryScreen({
                     <Text style={styles.statSquareValuePercentSymbol}>%</Text>
                   </>
                 )}
-                note="% of this view"
+                note="% of selected view"
                 useLoadingStyle={areProfileStatsLoading}
                 style={splitStatsAndInsights && !statsTwoByTwo ? styles.statSquareWide : statsTwoByTwo ? styles.statSquareHalf : null}
               />


### PR DESCRIPTION
# PR: 39 QA End-to-End Flow

## Summary

_This branch completes Issue 39 QA End to End Flow, and the local follow-through and final frontend QA work after Leena's Issue 147 PR was merged into development._

Leena's PR owns the SQL/backend correctness changes for Country Profile, Country Comparison, Discovery Map filtering, and the new `SongCountryChart` lookup path. The work here was to apply the required local SSMS steps, validate the database state, clear stale caches, make small frontend readiness fixes, and complete end-to-end flow testing.

## Completed In This Branch

### Leena PR follow-through

- Switched onto the new `39-qa-end-to-end-flow` branch after the Issue 147 PR was merged.
- Applied the required local SSMS setup for `SongCountryChart`.
- Ran the affected stored-procedure definition files in SSMS.
- Ran only the affected population procedures:
  - `EXEC sp_PopulateSongCountryChart;`
  - `EXEC sp_PopulateCountryYearStats;`
  - `EXEC sp_PopulateTopSongByCountryYear;`
- Cleared stale file-backed cache files so the app would not continue serving old country/song data after the stored-procedure changes:
  - `backend/Capstone.API/Data/presentation_data_cache.json`
  - `backend/Capstone.API/Data/discovery_samples_cache.json`

### SSMS validation

- Confirmed `SongCountryChart` populated with `518452` rows.
- Confirmed Andorra has `0` Top 200 rows.
- Confirmed Andorra has no `CountryYearStats` row after Viral 50 was excluded from the KPI population path.
- Confirmed `TopSongByCountryYear` includes `song_name` values after repopulation.

### Frontend updates

- Increased the desktop/web Discovery Map glassy blurb height so the third hover row, `Top album`, is visible instead of clipped.
- Kept mobile Discovery Map blurb sizing unchanged by leaving the mobile-specific overrides untouched.
- Updated two Country Profile KPI labels:
  - `Songs in This View` -> `Songs in Selected View`
  - `% of this view` -> `% of selected view`
- Updated header search to include all API-valid countries across available years instead of only the currently selected year's country pool.
- Removed the search overlay's 25-result cap so the full valid country list can display.
- Preserved the corrected behavior where countries without Top 200 app data, such as Andorra, should not appear as selectable search results.

## KPI Copy Rationale

I adjusted the two KPI labels that could be clarified without changing the intended information hierarchy: “Songs in This View” is now “Songs in Selected View,” and “% of this view” is now “% of selected view.” This keeps the labels tied to the user’s active country/year selection, which is the context used to reach the page and generate the displayed stats.

From a frontend UX perspective, I kept “Loved in This Country” and “Loved Here and Elsewhere” because those KPI labels intentionally mirror the matching song sections lower on the page, helping users connect the summary numbers to the detailed lists. I also avoided longer labels such as “total songs in this country/year” because the stat represents songs in our selected app dataset, not every song that exists for that country and year, and these cards are compact responsive UI elements across multiple layout widths. In a future iteration, these cards could support longer explanatory text, but that would require broader UI changes and web/mobile QA beyond a small label update.

## End-to-End Flow Testing

Completed an end-to-end navigation flow test across the app. Verified that the main user paths route to the expected screens and preserve the intended country/year context where applicable.

## Not Included

- Did not change the Country Profile genre source. The current `GetCountryGenreSampleAsync` approach remains in place for deadline stability.
- Did not add a dev cache bypass setting after being advised by PM that can wait for future iterations. 
- Did not rerun the full `run-all-population.sql`.

## Verification

- `dotnet build`
- `npm run typecheck`

## Reviewer Checks

- Restart the API after SSMS changes and cache clearing.
- Open Discovery Map and confirm Andorra does not appear.
- Hover a Discovery Map country with album data and confirm the `Top album` row is visible.
- Open Country Profile and confirm the KPI labels read `Songs in Selected View` and `% of selected view`.
- Confirm `Loved in This Country` and `Loved Here and Elsewhere` still match the related song sections lower on the page.
- Open search and confirm the country list is long enough to include valid countries across available years.
- Confirm countries without Top 200 app data, such as Andorra, are not selectable search results.
- Walk the main app navigation flow and confirm pages route to the expected screens.
