### PR TITLE
Completed Issue 166 Added Access Code Entry and Other Deployment Prep

### DIFF
--- a/Documentation/QA-log.md
+++ b/Documentation/QA-log.md
@@ -3,6 +3,47 @@
 
 ---
 
+## 2026-05-24 — Deployment Prep Access Code Entry Gate
+
+**Tester:** mp3li / Codex-assisted deployment prep
+**Fix owner:** mp3li
+**Branch:** `deployment`
+**Scope:** Limited early-access welcome flow, mobile launch fallback, search/input focus polish, and deployment PR preparation
+
+### What was handled
+
+This branch added a limited early-access code layer to the existing Welcome popup for deployment day. The gate keeps invited tester/supporter access in front of the normal Welcome experience while preserving the same popup shell, logo, title, helper text, app styling, and mobile/web layout rules.
+
+### Access code behavior
+
+- Added a frontend access-code config module at `hidden-gem-music-app/src/config/accessGate.ts`.
+- Set the current deployment prep code to `COMMENCEMENT`.
+- Stored the accepted code value in local storage instead of a generic boolean so changing the code automatically locks out users who entered an older code.
+- Kept invalid attempts inside the popup with reserved error space so the input/button layout does not jump when the error appears.
+- Updated the invalid-code message to `Access code invalid.`
+
+### Welcome flow and UI polish
+
+- Reused the existing Welcome popup layout for the access-code layer instead of introducing a separate modal shape.
+- Kept the normal Welcome content visible only after the access code is accepted.
+- Preserved the Hidden Gem Music title/helper text styling across both access and normal Welcome layers.
+- Applied app-owned colors and existing hover/focus styling rather than default browser input outlines.
+- Updated the reusable `ActionButton` so default border/label colors use the app's dark text color instead of the previous border tone.
+- Updated app search inputs to use the same pink/list-hover-style focus treatment requested during deployment prep.
+
+### Mobile deployment readiness
+
+- Added mobile keyboard handling so the access popup raises when the code input is focused.
+- Kept mobile-specific Welcome/access spacing separate from web spacing.
+- Added a mobile-only `Loading...` fallback after leaving Welcome for Discovery so the app area is not a blank background while the native Discovery route finishes appearing.
+
+### Verification
+
+- Ran `npm run typecheck`; passed.
+- Confirmed the deployment branch contains the access gate work and local untracked screenshot/archive artifacts remain untracked.
+
+---
+
 ## 2026-05-23 — Issue 160 README Screenshots and GIF Assets
 
 **Tester:** mp3li / Codex-assisted asset preparation

--- a/Documents/mp3li implementation timeline document.txt
+++ b/Documents/mp3li implementation timeline document.txt
@@ -1,6 +1,50 @@
 mp3li implementation timeline document
 
-Updated: May 23, 2026
+Updated: May 24, 2026
+
+Deployment Prep Access Code Entry Gate (May 24, 2026)
+- Objective:
+  - Prepare the app for official deployment-day limited early access.
+  - Add an access-code entry layer before the normal Welcome experience.
+  - Keep the access layer visually identical to the existing Welcome popup structure so the transition from access entry to normal Welcome feels like a second layer of the same experience.
+  - Preserve separate mobile and web spacing rules after mobile testing showed the two layouts needed different vertical treatment.
+
+- Access-code gate completed:
+  - Added `hidden-gem-music-app/src/config/accessGate.ts`.
+  - Set the current deployment prep access code to `COMMENCEMENT`.
+  - Stored the accepted code value in local storage instead of storing a simple accepted/not-accepted flag.
+  - Made code changes automatically invalidate older accepted codes, so users who entered a previous code are locked out again when the code changes.
+  - Added the access layer inside the existing Welcome popup flow before the normal Welcome view appears.
+  - Kept the same logo, Hidden Gem Music title, and helper/about text in both the access layer and the normal Welcome layer.
+  - Added the deployment-facing message: Hidden Gem Music is currently in limited early access and is only available to invited testers and supporters who are given an access code.
+  - Styled only the words `limited early access` with the app's existing pink accent.
+  - Added the `Access code:` label, code input, invalid-code message area, and `Enter Hidden Gems Music` action.
+  - Changed the invalid-code message to `Access code invalid.`
+  - Reserved permanent space for the invalid-code message so a wrong code does not move the input or button.
+
+- Welcome/access styling completed:
+  - Reworked the access layer spacing through the existing Welcome popup instead of using a new modal size or shape.
+  - Kept web and mobile popup sizing separate so the mobile fixes do not change the approved web layout.
+  - Adjusted mobile Welcome sizing so both the access-code layer and normal Welcome layer have enough vertical room for the button.
+  - Added mobile keyboard avoidance so the popup lifts when the code input is focused.
+  - Updated the access input focus state to use the app's existing pink/list-hover-style treatment instead of a browser/default green outline.
+  - Updated the reusable welcome/action button defaults so borders and label text use the app's existing dark text color.
+  - Updated app search input focus styling to match the same app-owned pink/list-hover focus treatment.
+
+- Mobile Discovery launch fallback completed:
+  - Investigated the mobile-only moment after leaving Welcome for Discovery where the app header and mobile nav appeared before the Discovery screen content.
+  - Avoided adding a new modal overlay on top of the access popup.
+  - Added a mobile-only plain `Loading...` fallback in the screen area after Welcome closes and before Discovery finishes appearing, so the app area is not just the background during that short native route transition.
+
+- Deployment branch prep completed:
+  - Continued work on the dedicated `deployment` branch.
+  - Kept local screenshot archive artifacts untracked.
+  - Prepared local-only issue and PR markdown drafts in `my txts/` for the deployment access-code work and broader deployment-prep branch summary.
+
+- Verification completed:
+  - Ran `npm run typecheck`; passed.
+  - Confirmed the code gate can be retested by changing the configured code because previous accepted codes no longer count.
+  - Confirmed the docs/PR/issue drafts are separate from the app commit scope where requested.
 
 README Screenshot/GIF Assets and Documentation Header Correction (May 23, 2026)
 - Objective:

--- a/hidden-gem-music-app/App.tsx
+++ b/hidden-gem-music-app/App.tsx
@@ -17,6 +17,7 @@ import { DiscoveryScreen } from "./src/screens/DiscoveryScreen";
 import { HiddenGemsScreen } from "./src/screens/HiddenGemsScreen";
 import { WelcomeScreen } from "./src/screens/WelcomeScreen";
 import { worldMapCountries } from "./src/assets/maps/worldMap50m";
+import { readAccessGranted } from "./src/config/accessGate";
 import { loadDiscoveryCountries } from "./src/data/discoveryApi";
 import { loadAvailableYears } from "./src/data/countryApi";
 import { isCountryWithAppData } from "./src/data/countryDisplay";
@@ -285,6 +286,7 @@ export default function App() {
       ? initialNavigationSeed.countryId ?? initialFeaturedCountry.id
       : initialFeaturedCountry.id;
 
+  const [accessGranted, setAccessGranted] = useState(readAccessGranted);
   const [navigationReady, setNavigationReady] = useState(false);
   const [currentRoute, setCurrentRoute] = useState<ScreenRoute>(initialNavigationSeed.route);
   const [selectedYear, setSelectedYear] = useState(initialYear);
@@ -298,6 +300,7 @@ export default function App() {
   const [searchOpen, setSearchOpen] = useState(false);
   const [apiAvailableYears, setApiAvailableYears] = useState<number[]>([]);
   const [isDiscoveryLoading, setIsDiscoveryLoading] = useState(true);
+  const [isWelcomeOpeningDiscovery, setIsWelcomeOpeningDiscovery] = useState(false);
   const [discoveryCountriesByYear, setDiscoveryCountriesByYear] = useState<Record<number, Country[]>>({});
 
   const countries = useMemo(() => getCountriesForYear(selectedYear), [selectedYear]);
@@ -539,6 +542,9 @@ export default function App() {
 
     switch (route) {
       case "discovery":
+        if (Platform.OS !== "web") {
+          setIsWelcomeOpeningDiscovery(true);
+        }
         navigationRef.dispatch(
           CommonActions.reset({
             index: 0,
@@ -844,6 +850,15 @@ export default function App() {
   }, [currentRoute, loadingMessage]);
 
   useEffect(() => {
+    if (!isWelcomeOpeningDiscovery || currentRoute !== "discovery") {
+      return;
+    }
+
+    const timer = setTimeout(() => setIsWelcomeOpeningDiscovery(false), 180);
+    return () => clearTimeout(timer);
+  }, [currentRoute, isWelcomeOpeningDiscovery]);
+
+  useEffect(() => {
     const controller = new AbortController();
 
     loadAvailableYears(controller.signal)
@@ -1127,7 +1142,7 @@ export default function App() {
         linking={linking}
         onReady={() => {
           setNavigationReady(true);
-          if (initialNavigationSeed.route === "welcome") {
+          if (!accessGranted || initialNavigationSeed.route === "welcome") {
             navigationRef.dispatch(
               CommonActions.reset({
                 index: 1,
@@ -1179,6 +1194,8 @@ export default function App() {
               >
                 {() => (
                   <WelcomeScreen
+                    accessGranted={accessGranted}
+                    onAccessGranted={() => setAccessGranted(true)}
                     onDismiss={() => {
                       if (navigationRef.canGoBack()) {
                         navigationRef.goBack();
@@ -1314,6 +1331,11 @@ export default function App() {
 
               <Stack.Screen name="credits" component={CreditsScreen} options={{ title: "Credits" }} />
             </Stack.Navigator>
+            {Platform.OS !== "web" && isWelcomeOpeningDiscovery ? (
+              <View style={styles.mobileScreenLoadingFallback} pointerEvents="none">
+                <Text style={styles.mobileScreenLoadingText}>Loading...</Text>
+              </View>
+            ) : null}
             <LoadingOverlay
               visible={Boolean(loadingMessage)}
               message={loadingMessage ?? undefined}
@@ -1370,5 +1392,19 @@ const styles = StyleSheet.create({
     flex: 1,
     position: "relative",
     overflow: "hidden",
+  },
+  mobileScreenLoadingFallback: {
+    ...StyleSheet.absoluteFillObject,
+    zIndex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: colors.background,
+  },
+  mobileScreenLoadingText: {
+    color: colors.textLight,
+    fontFamily: typefaces.display,
+    fontSize: 28,
+    lineHeight: 34,
+    textAlign: "center",
   },
 });

--- a/hidden-gem-music-app/src/components/ActionButton.tsx
+++ b/hidden-gem-music-app/src/components/ActionButton.tsx
@@ -1,6 +1,6 @@
 import { LinearGradient } from "expo-linear-gradient";
 import { useEffect, useRef, useState } from "react";
-import { Platform, Pressable, StyleSheet, Text, View } from "react-native";
+import { Platform, Pressable, StyleProp, StyleSheet, Text, TextStyle, View, ViewStyle } from "react-native";
 
 import { colors } from "../theme/colors";
 import { typefaces } from "../theme/typography";
@@ -9,12 +9,14 @@ type Props = {
   label: string;
   onPress: () => void;
   size?: "default" | "compact" | "small";
+  buttonStyle?: StyleProp<ViewStyle>;
+  labelStyle?: StyleProp<TextStyle>;
 };
 
 const activeGradient = [colors.navGradient, colors.backgroundRaised, colors.backgroundRaised] as const;
 const hoverGradient = ["rgba(117,82,107,0.52)", "rgba(108,119,142,0.44)", "rgba(108,119,142,0.36)"] as const;
 
-export function ActionButton({ label, onPress, size = "default" }: Props) {
+export function ActionButton({ label, onPress, size = "default", buttonStyle, labelStyle }: Props) {
   const [isHovered, setIsHovered] = useState(false);
   const [isPressed, setIsPressed] = useState(false);
   const nativeReleaseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -76,9 +78,12 @@ export function ActionButton({ label, onPress, size = "default" }: Props) {
           Platform.OS !== "web" && isPressed ? styles.buttonPressedNative : null,
           size === "compact" ? styles.buttonCompact : null,
           size === "small" ? styles.buttonSmall : null,
+          buttonStyle,
         ]}
       >
-        <Text style={[styles.label, showGradient ? styles.labelActive : null]}>{label}</Text>
+        <Text style={[styles.label, showGradient ? styles.labelActive : null, labelStyle]}>
+          {label}
+        </Text>
       </View>
     </Pressable>
   );
@@ -113,7 +118,7 @@ const styles = StyleSheet.create({
     paddingVertical: 11,
     borderRadius: 17,
     borderWidth: 2,
-    borderColor: colors.border,
+    borderColor: colors.textDark,
     backgroundColor: colors.button,
     shadowColor: colors.shadow,
     shadowOpacity: 0.18,
@@ -135,7 +140,7 @@ const styles = StyleSheet.create({
     paddingVertical: 8,
   },
   label: {
-    color: colors.border,
+    color: colors.textDark,
     fontFamily: typefaces.condensed,
     fontSize: 15,
     fontWeight: "800",

--- a/hidden-gem-music-app/src/components/SearchOverlay.tsx
+++ b/hidden-gem-music-app/src/components/SearchOverlay.tsx
@@ -18,6 +18,7 @@ export function SearchOverlay({ visible, countries, onClose, onOpenCountry }: Pr
   const isMobileWidth = width < 980;
   const isNative = Platform.OS !== "web";
   const [query, setQuery] = useState("");
+  const [inputFocused, setInputFocused] = useState(false);
   const containerRef = useRef<View>(null);
 
   const results = useMemo(() => {
@@ -81,7 +82,9 @@ export function SearchOverlay({ visible, countries, onClose, onOpenCountry }: Pr
           onChangeText={setQuery}
           placeholder="Search for a country"
           placeholderTextColor={colors.textLight}
-          style={styles.input}
+          onFocus={() => setInputFocused(true)}
+          onBlur={() => setInputFocused(false)}
+          style={[styles.input, inputFocused ? styles.inputFocused : null]}
           autoFocus
         />
 
@@ -222,6 +225,17 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
     fontFamily: typefaces.body,
     fontSize: 17,
+    ...(Platform.OS === "web"
+      ? ({
+          outlineColor: "rgba(169,176,209,0.92)",
+          outlineStyle: "none",
+          outlineWidth: 0,
+        } as any)
+      : null),
+  },
+  inputFocused: {
+    borderColor: "rgba(169,176,209,0.92)",
+    backgroundColor: "rgba(117,82,107,0.12)",
   },
   resultScroll: {
     maxHeight: 360,

--- a/hidden-gem-music-app/src/config/accessGate.ts
+++ b/hidden-gem-music-app/src/config/accessGate.ts
@@ -1,0 +1,27 @@
+export const ACCESS_CODE = "COMMENCEMENT";
+
+const ACCESS_STORAGE_KEY = "hidden-gem-access-granted-v1";
+
+export function readAccessGranted() {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  try {
+    return window.localStorage.getItem(ACCESS_STORAGE_KEY) === ACCESS_CODE;
+  } catch {
+    return false;
+  }
+}
+
+export function writeAccessGranted() {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(ACCESS_STORAGE_KEY, ACCESS_CODE);
+  } catch {
+    // Ignore localStorage failures; access still works for the current session state.
+  }
+}

--- a/hidden-gem-music-app/src/screens/SearchScreen.tsx
+++ b/hidden-gem-music-app/src/screens/SearchScreen.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { Pressable, StyleSheet, Text, TextInput, View } from "react-native";
+import { Platform, Pressable, StyleSheet, Text, TextInput, View } from "react-native";
 
 import { Country } from "../types/content";
 import { Panel } from "../components/Panel";
@@ -32,6 +32,7 @@ export function SearchScreen({
   onOpenSong,
 }: Props) {
   const [query, setQuery] = useState("");
+  const [inputFocused, setInputFocused] = useState(false);
   const results = useMemo(() => searchLibrary(query, selectedYear), [query, searchLibrary, selectedYear]);
 
   return (
@@ -42,7 +43,9 @@ export function SearchScreen({
         onChangeText={setQuery}
         placeholder="Search countries, albums, artists, songs, or genres"
         placeholderTextColor={colors.textLight}
-        style={styles.input}
+        onFocus={() => setInputFocused(true)}
+        onBlur={() => setInputFocused(false)}
+        style={[styles.input, inputFocused ? styles.inputFocused : null]}
       />
       <Panel style={styles.panel}>
         <Text style={styles.sectionHeading}>Country Matches</Text>
@@ -91,6 +94,17 @@ const styles = StyleSheet.create({
     paddingVertical: 14,
     fontFamily: typefaces.body,
     fontSize: 18,
+    ...(Platform.OS === "web"
+      ? ({
+          outlineColor: "rgba(169,176,209,0.92)",
+          outlineStyle: "none",
+          outlineWidth: 0,
+        } as any)
+      : null),
+  },
+  inputFocused: {
+    borderColor: "rgba(169,176,209,0.92)",
+    backgroundColor: "rgba(117,82,107,0.12)",
   },
   panel: {
     minHeight: 420,

--- a/hidden-gem-music-app/src/screens/WelcomeScreen.tsx
+++ b/hidden-gem-music-app/src/screens/WelcomeScreen.tsx
@@ -1,14 +1,26 @@
 import { LinearGradient } from "expo-linear-gradient";
 import { useEffect, useRef, useState } from "react";
-import { Platform, Pressable, StyleSheet, Text, useWindowDimensions, View } from "react-native";
+import {
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  useWindowDimensions,
+  View,
+} from "react-native";
 
 import { ActionButton } from "../components/ActionButton";
 import { Panel } from "../components/Panel";
+import { ACCESS_CODE, writeAccessGranted } from "../config/accessGate";
 import { ScreenRoute } from "../types/navigation";
 import { colors } from "../theme/colors";
 import { typefaces } from "../theme/typography";
 
 export type Props = {
+  accessGranted: boolean;
+  onAccessGranted: () => void;
   onDismiss: () => void;
   onSelectRoute: (route: ScreenRoute) => void;
 };
@@ -50,9 +62,11 @@ function interpolateHexColor(startHex: string, endHex: string, ratio: number) {
   )}`;
 }
 
-function WelcomeGradientTitle() {
+function WelcomeGradientTitle({ compact = false }: { compact?: boolean }) {
+  const titleStyle = [styles.brand, compact ? styles.brandCompact : null];
+
   if (Platform.OS === "web") {
-    return <Text style={[styles.brand, welcomeTitleWebGradientStyle as any]}>Hidden Gem Music</Text>;
+    return <Text style={[titleStyle, welcomeTitleWebGradientStyle as any]}>Hidden Gem Music</Text>;
   }
 
   const title = "Hidden Gem Music";
@@ -60,7 +74,7 @@ function WelcomeGradientTitle() {
   const maxIndex = Math.max(characters.length - 1, 1);
 
   return (
-    <Text style={styles.brand}>
+    <Text style={titleStyle}>
       {characters.map((character, index) => {
         const progress = index / maxIndex;
         const color =
@@ -80,10 +94,14 @@ function WelcomeGradientTitle() {
   );
 }
 
-export function WelcomeScreen({ onDismiss, onSelectRoute }: Props) {
+export function WelcomeScreen({ accessGranted, onAccessGranted, onDismiss, onSelectRoute }: Props) {
   const { width } = useWindowDimensions();
   const isCompactWelcome = width < 980;
+  const isMobileWelcome = Platform.OS !== "web";
   const useFullScreenBackdrop = Platform.OS === "web" && !isCompactWelcome;
+  const [accessCodeInput, setAccessCodeInput] = useState("");
+  const [accessError, setAccessError] = useState("");
+  const [accessInputFocused, setAccessInputFocused] = useState(false);
   const [isClosing, setIsClosing] = useState(false);
   const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isClosingRef = useRef(false);
@@ -101,6 +119,35 @@ export function WelcomeScreen({ onDismiss, onSelectRoute }: Props) {
     }, closeDelay);
   };
 
+  const handleAccessSubmit = () => {
+    if (accessCodeInput.trim().toUpperCase() !== ACCESS_CODE) {
+      setAccessError("Access code invalid.");
+      return;
+    }
+
+    writeAccessGranted();
+    setAccessError("");
+    onAccessGranted();
+  };
+
+  const renderWelcomeButtons = (hidden = false) => (
+    <View style={[styles.buttonStack, isMobileWelcome ? styles.buttonStackMobile : null]} pointerEvents={hidden ? "none" : "auto"}>
+      <ActionButton label="Discovery Map" size="compact" onPress={() => dismissWithAction(() => onSelectRoute("discovery"))} />
+      <ActionButton label="Discovery Dashboard" size="compact" onPress={() => dismissWithAction(() => onSelectRoute("dashboard"))} />
+      <ActionButton
+        label="Comparison Mode"
+        size="compact"
+        onPress={() => dismissWithAction(() => onSelectRoute("comparisonSelect"))}
+      />
+      <ActionButton
+        label="Hidden Gems"
+        size="compact"
+        onPress={() => dismissWithAction(() => onSelectRoute("hiddenGems"))}
+      />
+      <ActionButton label="Credits" size="compact" onPress={() => dismissWithAction(() => onSelectRoute("credits"))} />
+    </View>
+  );
+
   useEffect(() => {
     return () => {
       if (closeTimerRef.current) {
@@ -115,7 +162,10 @@ export function WelcomeScreen({ onDismiss, onSelectRoute }: Props) {
   }
 
   return (
-    <View
+    <KeyboardAvoidingView
+      behavior={isMobileWelcome && Platform.OS === "ios" ? "padding" : undefined}
+      enabled={isMobileWelcome}
+      keyboardVerticalOffset={isMobileWelcome ? 18 : 0}
       style={[styles.overlay, isCompactWelcome ? styles.overlayCompact : null]}
       pointerEvents={useFullScreenBackdrop ? "auto" : "box-none"}
       onStartShouldSetResponder={useFullScreenBackdrop ? () => true : undefined}
@@ -126,7 +176,9 @@ export function WelcomeScreen({ onDismiss, onSelectRoute }: Props) {
           style={styles.overlayBackdropPressTarget}
           onPress={(event) => {
             event.stopPropagation();
-            dismissWithAction(onDismiss);
+            if (accessGranted) {
+              dismissWithAction(onDismiss);
+            }
           }}
         >
           <WelcomeBackdrop style={styles.overlayBackdrop} />
@@ -135,7 +187,7 @@ export function WelcomeScreen({ onDismiss, onSelectRoute }: Props) {
         <WelcomeBackdrop style={styles.overlayBackdrop} pointerEvents="none" useGradient />
       )}
       <Pressable style={styles.modalPressTarget} onPress={(event) => event.stopPropagation()}>
-        <Panel style={styles.modal}>
+        <Panel style={[styles.modal, isMobileWelcome ? styles.modalMobile : null]}>
           <LinearGradient
             colors={popupBottomDepthGradient}
             locations={[0, 0.72, 1]}
@@ -143,34 +195,74 @@ export function WelcomeScreen({ onDismiss, onSelectRoute }: Props) {
             end={{ x: 0.5, y: 1 }}
             style={styles.modalDepthFill}
           />
-          <View style={styles.modalContent}>
-            <WelcomeGradientTitle />
-            <Text style={styles.summary}>
+          <View style={[styles.modalContent, isMobileWelcome ? styles.modalContentMobile : null]}>
+            <WelcomeGradientTitle compact={isMobileWelcome} />
+            <Text style={[styles.summary, isMobileWelcome ? styles.summaryMobile : null]}>
               The purpose of this app is to find and display the 'Discovery Gap' — What music is most loved in each
               country, and how much was that country's most loved music spread, shared, and loved by other countries?
               Explore the Discovery Gap multiple ways: the discovery map, country detail pages, comparison mode,
               listen to 30 second previews of hidden gems, and the Discovery Dashboard. Utilize filters in
               multiple areas of the app to fine tune your discovery.
             </Text>
-            <View style={styles.buttonStack}>
-              <ActionButton label="Discovery Map" size="compact" onPress={() => dismissWithAction(() => onSelectRoute("discovery"))} />
-              <ActionButton label="Discovery Dashboard" size="compact" onPress={() => dismissWithAction(() => onSelectRoute("dashboard"))} />
-              <ActionButton
-                label="Comparison Mode"
-                size="compact"
-                onPress={() => dismissWithAction(() => onSelectRoute("comparisonSelect"))}
-              />
-              <ActionButton
-                label="Hidden Gems"
-                size="compact"
-                onPress={() => dismissWithAction(() => onSelectRoute("hiddenGems"))}
-              />
-              <ActionButton label="Credits" size="compact" onPress={() => dismissWithAction(() => onSelectRoute("credits"))} />
-            </View>
+            {accessGranted ? (
+              renderWelcomeButtons()
+            ) : (
+              <View style={[styles.accessLayerSlot, isMobileWelcome ? styles.accessLayerSlotMobile : null]}>
+                <View style={[styles.buttonStackSpacer, isMobileWelcome ? styles.buttonStackSpacerMobile : null]} pointerEvents="none" />
+                <View style={[styles.accessContent, isMobileWelcome ? styles.accessContentMobile : styles.accessContentWeb]}>
+                  <View style={[styles.accessSummarySlot, isMobileWelcome ? styles.accessSummarySlotMobile : null]}>
+                    <Text style={[styles.accessSummary, isMobileWelcome ? styles.accessSummaryMobile : null]}>
+                      Hidden Gem Music is currently in{" "}
+                      <Text style={styles.accessSummaryAccent}>limited early access</Text>, and is only available to
+                      invited testers and supporters who are given an access code.
+                    </Text>
+                  </View>
+                  <View
+                    style={[
+                      styles.accessFieldGroup,
+                      isMobileWelcome ? styles.accessFieldGroupMobile : styles.accessFieldGroupWeb,
+                    ]}
+                  >
+                    <Text style={styles.accessLabel}>Access code:</Text>
+                    <TextInput
+                      value={accessCodeInput}
+                      onChangeText={(value) => {
+                        setAccessCodeInput(value);
+                        if (accessError) {
+                          setAccessError("");
+                        }
+                      }}
+                    onSubmitEditing={handleAccessSubmit}
+                    onFocus={() => setAccessInputFocused(true)}
+                    onBlur={() => setAccessInputFocused(false)}
+                    autoCapitalize="characters"
+                    autoCorrect={false}
+                    spellCheck={false}
+                    returnKeyType="done"
+                    placeholder="Enter access code"
+                    placeholderTextColor="rgba(169, 176, 209, 0.62)"
+                    style={[styles.accessInput, accessInputFocused ? styles.accessInputFocused : null]}
+                  />
+                    <Text style={[styles.accessError, accessError ? null : styles.accessErrorHidden]}>
+                      {accessError || "Access code invalid."}
+                    </Text>
+                  </View>
+                  <View style={[styles.accessButtonOffset, isMobileWelcome ? styles.accessButtonOffsetMobile : styles.accessButtonOffsetWeb]}>
+                    <ActionButton
+                      label="Enter Hidden Gems Music"
+                      size="compact"
+                      buttonStyle={styles.accessButton}
+                      labelStyle={styles.accessButtonLabel}
+                      onPress={handleAccessSubmit}
+                    />
+                  </View>
+                </View>
+              </View>
+            )}
           </View>
         </Panel>
       </Pressable>
-    </View>
+    </KeyboardAvoidingView>
   );
 }
 
@@ -229,6 +321,10 @@ const styles = StyleSheet.create({
     borderColor: "rgba(169, 176, 209, 0.24)",
     overflow: "hidden",
   },
+  modalMobile: {
+    paddingVertical: 24,
+    paddingHorizontal: 18,
+  },
   modalDepthFill: {
     ...StyleSheet.absoluteFillObject,
   },
@@ -236,12 +332,19 @@ const styles = StyleSheet.create({
     alignItems: "center",
     gap: 22,
   },
+  modalContentMobile: {
+    gap: 14,
+  },
   brand: {
     color: colors.textLight,
     fontFamily: typefaces.display,
     fontSize: 48,
     fontWeight: "700",
     textAlign: "center",
+  },
+  brandCompact: {
+    fontSize: 38,
+    lineHeight: 42,
   },
   summary: {
     color: colors.textLight,
@@ -252,8 +355,143 @@ const styles = StyleSheet.create({
     textAlign: "center",
     maxWidth: 620,
   },
+  summaryMobile: {
+    fontSize: 15,
+    lineHeight: 22,
+  },
   buttonStack: {
     gap: 14,
     alignItems: "center",
+  },
+  buttonStackMobile: {
+    minHeight: 292,
+    justifyContent: "center",
+  },
+  buttonStackSpacer: {
+    width: 224,
+    height: 236,
+  },
+  buttonStackSpacerMobile: {
+    height: 292,
+  },
+  accessLayerSlot: {
+    position: "relative",
+    width: "100%",
+    maxWidth: 620,
+    alignItems: "center",
+  },
+  accessLayerSlotMobile: {
+    maxWidth: 360,
+  },
+  accessContent: {
+    position: "absolute",
+    inset: 0,
+    width: "100%",
+    alignItems: "center",
+    justifyContent: "flex-start",
+    minHeight: 236,
+  },
+  accessContentMobile: {
+    minHeight: 292,
+  },
+  accessContentWeb: {
+    transform: [{ translateY: -10 }],
+  },
+  accessSummarySlot: {
+    height: 90,
+    width: "100%",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  accessSummarySlotMobile: {
+    height: 88,
+  },
+  accessSummary: {
+    color: colors.textLight,
+    fontFamily: typefaces.display,
+    fontSize: 19,
+    fontWeight: "700",
+    lineHeight: 27,
+    textAlign: "center",
+    width: "100%",
+  },
+  accessSummaryMobile: {
+    fontSize: 17,
+    lineHeight: 23,
+  },
+  accessSummaryAccent: {
+    color: colors.accent,
+  },
+  accessFieldGroup: {
+    width: "100%",
+    maxWidth: 330,
+    gap: 8,
+    marginTop: 22,
+  },
+  accessFieldGroupMobile: {
+    transform: [{ translateY: -12 }],
+  },
+  accessFieldGroupWeb: {
+    marginTop: 10,
+  },
+  accessLabel: {
+    color: colors.textStrong,
+    fontFamily: typefaces.condensed,
+    fontSize: 15,
+    fontWeight: "800",
+    textAlign: "center",
+  },
+  accessInput: {
+    width: "100%",
+    maxWidth: 330,
+    borderWidth: 2,
+    borderColor: "rgba(169, 176, 209, 0.34)",
+    borderRadius: 17,
+    backgroundColor: colors.panelAlt,
+    color: colors.textLight,
+    fontFamily: typefaces.condensed,
+    fontSize: 17,
+    fontWeight: "800",
+    paddingHorizontal: 16,
+    paddingVertical: 11,
+    textAlign: "center",
+    ...(Platform.OS === "web"
+      ? ({
+          outlineColor: "rgba(169,176,209,0.92)",
+          outlineStyle: "none",
+          outlineWidth: 0,
+        } as any)
+      : null),
+  },
+  accessInputFocused: {
+    borderColor: "rgba(169,176,209,0.92)",
+    backgroundColor: "rgba(117,82,107,0.12)",
+  },
+  accessButtonOffset: {
+    marginTop: 30,
+  },
+  accessButtonOffsetMobile: {
+    marginTop: 18,
+  },
+  accessButtonOffsetWeb: {
+    marginTop: 18,
+  },
+  accessButton: {
+    borderColor: colors.textDark,
+  },
+  accessButtonLabel: {
+    color: colors.textDark,
+  },
+  accessError: {
+    color: colors.textStrong,
+    fontFamily: typefaces.condensed,
+    fontSize: 13,
+    fontWeight: "800",
+    lineHeight: 16,
+    minHeight: 16,
+    textAlign: "center",
+  },
+  accessErrorHidden: {
+    opacity: 0,
   },
 });


### PR DESCRIPTION
# PR: Add Access Code Entry and Deployment Prep

_This PR completes Issue 166 - Added Access Code Entry, and Other Deployment Prep._

## Summary

This PR prepares Hidden Gem Music for official deployment-day limited early access. It adds an access-code layer before the normal Welcome popup, keeps the Welcome experience visually consistent across the locked and unlocked layers, adds mobile-specific behavior for the deployment flow, and records the deployment prep work in the professional QA log and personal implementation timeline.

## What changed

- Added a front-end access-code config module:
  - `hidden-gem-music-app/src/config/accessGate.ts`
- Set the current access code to:
  - `COMMENCEMENT`
- Added an access-code layer inside the existing Welcome popup.
- Kept the same logo, app title, helper/about text, modal shape, and app styling across the access layer and normal Welcome layer.
- Added the limited early-access message for invited testers/supporters.
- Styled only `limited early access` with the app's existing pink accent.
- Added:
  - `Access code:`
  - Access-code input
  - Reserved invalid-code message area
  - `Enter Hidden Gems Music` button
- Updated invalid-code copy to:
  - `Access code invalid.`
- Stored the accepted code value in local storage, so changing the configured code automatically locks out users who entered an older code.
- Prevented backdrop dismissal before access is granted.
- Added mobile keyboard handling so the access popup raises when the code input is focused.
- Kept mobile Welcome/access spacing separate from web spacing.
- Added a mobile-only `Loading...` fallback for the short transition after leaving Welcome for Discovery, so the app area is not blank while the native Discovery screen finishes appearing.
- Updated reusable action button defaults so welcome/action button borders and labels use the app's existing dark text color.
- Updated access-code and search input focus styling to match the app's existing pink/list-hover interaction style.
- Updated documentation:
  - `Documentation/QA-log.md`
  - `Documents/mp3li implementation timeline document.txt`

## Deployment prep context included in this branch

- Continued from the dedicated `deployment` branch created for official deployment work.
- Builds on the already merged deployment platform plan:
  - Cloudflare Pages for the Expo web frontend.
  - Cloudflare Tunnel for the iMac-hosted .NET API.
  - Private SQL Server database behind the backend.
- Keeps local screenshot/archive artifacts out of this commit unless separately requested:
  - `Documentation/Screenshots/Archive.zip`
  - `Documents/Hidden Gem Music Web Screenshots (Pre-Presentation-Release)/`
- Keeps local issue/PR markdown drafts in `my txts/` untracked.

## Verification

- Ran `npm run typecheck`; passed.
- Confirmed the configured access code can be changed to force users to re-enter the new code.
- Confirmed invalid-code feedback uses reserved space and does not shift the input/button layout.
- Confirmed mobile/web Welcome spacing is handled separately.

## Notes

This access-code gate is intended as a lightweight deployment-day limited-access step. It is not a replacement for a full account/authentication system.
