### PR TITLE
Completed Issue 53 ADR Deployment Decisions

### DIFF
--- a/Documentation/ADR-DEPLOYMENT-001-Deployment-Decisions.md
+++ b/Documentation/ADR-DEPLOYMENT-001-Deployment-Decisions.md
@@ -1,0 +1,158 @@
+# ADR-DEPLOYMENT-001: Deployment Decisions
+
+**Project:** Hidden Gem Music Discovery Platform - SOFT290 Capstone
+**Team:** mp3li and Leena Komenski
+**Decision owner:** mp3li - Software Development deployment/integration deliverable
+**Date:** 2026-05-25
+**Status:** Accepted
+
+---
+
+## Context
+
+Hidden Gem Music needed a public deployment for final capstone review while preserving the existing application architecture:
+
+- Expo web frontend exported as static browser assets.
+- .NET 9 backend API.
+- SQL Server database with stored procedures, precomputed tables, and local restore/runtime expectations.
+- Presentation timeline near the end of the course.
+- Free or near-free hosting target.
+
+The deployment also needed to avoid exposing SQL Server directly and needed to support the deployed frontend calling the API over HTTPS.
+
+## Decision
+
+The project uses a hybrid Cloudflare deployment:
+
+- **Frontend:** Cloudflare Pages hosts the Expo web build at `https://hiddengemmusicapp.mp3li.online`.
+- **Backend API:** The .NET 9 API runs on the iMac and is exposed through Cloudflare Tunnel at `https://api-hiddengemmusicapp.mp3li.online`.
+- **Database:** SQL Server remains private on the iMac/local Docker setup and is only reached by the backend API.
+- **Repository branch:** The final intended production source branch is `main`. Initial deployment validation was completed from the dedicated `deployment` branch so the deployment path could be tested before the final team-approved `main` deployment cutover.
+
+This ADR records the final deployment decision. The earlier deployment platform selection plan remains the detailed planning and setup record.
+
+## Configuration Decisions
+
+### Branch Source
+
+The deployment branch strategy has two phases:
+
+- **Validation phase:** use the dedicated `deployment` branch to confirm Cloudflare Pages, custom domain routing, API configuration, Cloudflare Tunnel routing, and production smoke tests before the deadline.
+- **Final production phase:** move the frontend deployment source to `main` after team approval and after `main` contains the final deployable project state.
+
+This branch flow was chosen to reduce deadline risk while respecting the team preference that the final production deployment should come from `main`.
+
+### Frontend Build
+
+Cloudflare Pages builds from:
+
+```text
+hidden-gem-music-app
+```
+
+The selected frontend build command is:
+
+```text
+npm run export:web
+```
+
+The selected build output directory is:
+
+```text
+dist
+```
+
+The production frontend API base URL is:
+
+```text
+EXPO_PUBLIC_API_BASE_URL=https://api-hiddengemmusicapp.mp3li.online
+```
+
+The frontend includes `hidden-gem-music-app/public/_redirects` so direct route refreshes serve the Expo web single-page app entrypoint.
+
+### Backend API
+
+The API runs locally on the iMac and is reachable to the public only through Cloudflare Tunnel.
+
+The expected public API origin is:
+
+```text
+https://api-hiddengemmusicapp.mp3li.online
+```
+
+The expected production frontend origin allowed by CORS is:
+
+```text
+https://hiddengemmusicapp.mp3li.online
+```
+
+The backend keeps forwarded-header handling enabled for the local Cloudflare Tunnel path so the API can respect the original HTTPS request metadata.
+
+### Database
+
+SQL Server is not moved to a managed cloud database for the final capstone deployment. It remains private on the iMac/local Docker setup. Public users only interact with SQL Server through the backend API.
+
+## Alternatives Considered
+
+### GitHub Pages
+
+GitHub Pages can host the static frontend bundle, but it does not address the API routing and custom-domain workflow as cleanly as Cloudflare Pages plus Cloudflare Tunnel.
+
+### Full Cloud Backend and Database
+
+A full cloud deployment for the frontend, backend, and database was deferred. It would add database migration risk, hosting cost, and new runtime configuration work late in the capstone timeline.
+
+### iMac-Only Hosting
+
+Hosting the entire app directly from the iMac was not selected as the primary deployment because the capstone deliverable required a cloud deployment path. Cloudflare Pages provides the cloud-hosted frontend while Cloudflare Tunnel provides managed HTTPS routing to the local backend.
+
+## Consequences
+
+Positive outcomes:
+
+- The frontend is hosted through a public cloud platform with managed HTTPS.
+- The API is reachable through a public HTTPS hostname without opening inbound router ports.
+- SQL Server stays private.
+- The deployment uses the current working app architecture instead of requiring a late database redesign.
+- The setup can stay within the project budget target.
+
+Tradeoffs:
+
+- The iMac, SQL Server container, backend API, and Cloudflare Tunnel must stay running for API-backed screens to work.
+- Cloudflare Pages may still serve the frontend even if the backend stack is down.
+- Runtime operations now include local machine health checks in addition to cloud dashboard checks.
+- Future maintainers need documentation for both the Cloudflare side and the local iMac runtime side.
+
+## Lessons Learned
+
+- Transfer and ownership details matter for deployment tooling. Cloudflare/GitHub integration depends on repository access under the account or organization authorized in Cloudflare.
+- Project tracking and repository ownership are separate in GitHub. Moving the repository does not automatically guarantee the project board appears under the new organization.
+- Static frontend hosting is still valid for an interactive Expo web app because the browser JavaScript calls the API after the static bundle loads.
+- Cloudflare Tunnel solves public HTTPS routing, but it does not host or supervise the backend process. Local runtime reliability remains part of deployment operations.
+- Keeping SQL Server private reduced deployment risk, but it made smoke testing and runtime handoff documentation more important.
+
+## Verification Expectations
+
+Minimum production smoke tests:
+
+```text
+https://hiddengemmusicapp.mp3li.online
+https://api-hiddengemmusicapp.mp3li.online/api/metadata/years
+https://api-hiddengemmusicapp.mp3li.online/api/discovery/countries?year=2020
+```
+
+Minimum app screens to verify after deployment changes:
+
+- Welcome
+- Discovery
+- Country Profile
+- Hidden Gems
+- Comparison
+- Dashboard
+
+## Related Documentation
+
+- `Documentation/deployment-platform-selection-plan.md`
+- `Documentation/QA-log.md`
+- `backend/Capstone.API/Documentation/ADR-BACKEND-001-API-Architecture.md`
+- `backend/Capstone.API/Documentation/ADR-BACKEND-002-Routes-Controllers-DTOs.md`

--- a/Documentation/QA-log.md
+++ b/Documentation/QA-log.md
@@ -3,6 +3,36 @@
 
 ---
 
+## 2026-05-25 - Issue 53 Deployment ADR
+
+**Tester:** mp3li / Codex-assisted documentation update
+**Fix owner:** mp3li
+**Branch:** `144-deployment`
+**Scope:** Deployment decision ADR for platform choice, configuration, consequences, and lessons learned
+
+### What was handled
+
+This branch added the accepted deployment ADR for the final hybrid Cloudflare deployment. The ADR records the final deployment decision separately from the earlier platform selection plan so the repo has both the planning document and the final decision record. It also documents the branch-source plan clearly: deployment validation used the dedicated `deployment` branch, while the intended final frontend production source is `main` after team approval and once `main` contains the final deployable state.
+
+### Documentation added
+
+- Added `Documentation/ADR-DEPLOYMENT-001-Deployment-Decisions.md`.
+- Documented the selected frontend, API, database, validation branch, and intended final production branch deployment decisions.
+- Documented frontend build settings, production API base URL, backend public API origin, production CORS origin, database privacy decision, alternatives considered, consequences, lessons learned, and smoke-test expectations.
+- Updated `Documentation/README.md` so the accepted deployment ADR appears in the shared documentation map.
+
+### Not included
+
+- No frontend, backend, database, Cloudflare, or deployment runtime behavior changed.
+- No README/deployment guide rewrite was completed as part of this issue.
+- No final documentation audit was completed as part of this issue.
+
+### Verification
+
+- Confirmed the branch only changes shared documentation files.
+
+---
+
 ## 2026-05-23 — Issue 160 README Screenshots and GIF Assets
 
 **Tester:** mp3li / Codex-assisted asset preparation

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -4,7 +4,7 @@
 **Author:** mp3li
 **Contributors:** Leena Komenski
 **Date:** 2026-05-15
-**Last updated:** 2026-05-19
+**Last updated:** 2026-05-25
 **Status:** Active
 
 ---
@@ -26,10 +26,15 @@ Shared repository-level documentation lives in:
 Current scope here includes:
 
 - repository documentation map
+- accepted deployment decision record
 - deployment platform selection and setup plan
 - shared QA/regression log used by project contributors
 
-The deployment platform decision record is:
+The accepted deployment decision record is:
+
+- `Documentation/ADR-DEPLOYMENT-001-Deployment-Decisions.md`
+
+The deployment platform selection and setup plan is:
 
 - `Documentation/deployment-platform-selection-plan.md`
 


### PR DESCRIPTION
# PR: Issue 53 ADR Deployment Decisions

## Summary

_This branch completes Issue 53 by adding a deployment ADR for Hidden Gem Music._

The ADR records the final deployment decision, the current deployment configuration, the alternatives considered, the operational consequences, and the lessons learned during deployment preparation.

The selected deployment approach is a hybrid Cloudflare setup:

- Cloudflare Pages hosts the Expo web frontend at `https://hiddengemmusicapp.mp3li.online`.
- Cloudflare Tunnel routes public HTTPS API requests to the iMac-hosted .NET 9 backend at `https://api-hiddengemmusicapp.mp3li.online`.
- SQL Server remains private on the iMac/local Docker setup and is only reached by the backend API.

The ADR also documents the branch-source plan clearly: the dedicated `deployment` branch was used for initial deployment validation because `main` was not yet ready at the time, while the intended final production frontend source is `main` after team approval and once `main` contains the final deployable project state.

## Completed In This Branch

### Deployment ADR

- Added `Documentation/ADR-DEPLOYMENT-001-Deployment-Decisions.md`.
- Documented the final hybrid Cloudflare deployment choice.
- Documented frontend, backend API, database, and production branch-source decisions.
- Documented the validation-phase branch and the intended final `main` deployment source.
- Documented Cloudflare Pages frontend build settings:
  - root/build location: `hidden-gem-music-app`
  - build command: `npm run export:web`
  - output directory: `dist`
  - production API env var: `EXPO_PUBLIC_API_BASE_URL=https://api-hiddengemmusicapp.mp3li.online`
- Documented Cloudflare Tunnel/API configuration expectations.
- Documented the production frontend origin allowed by backend CORS.
- Documented why SQL Server stays private instead of being exposed or migrated for this deployment.
- Documented rejected/deferred alternatives:
  - GitHub Pages
  - full cloud backend and database hosting
  - iMac-only hosting
- Documented deployment consequences and tradeoffs.
- Documented lessons learned from the deployment process.
- Documented production smoke-test URLs and minimum app screens to verify.

### Documentation map updates

- Updated `Documentation/README.md`.
- Added the new deployment ADR to the shared repository documentation map.
- Kept the earlier deployment platform selection plan listed separately as the detailed setup/planning record.

### QA log updates

- Updated `Documentation/QA-log.md`.
- Added an Issue 53 entry explaining what was added, what was intentionally not included, and how this issue relates to later README/deployment guide work.

## Not Included

- No frontend app behavior changes.
- No backend API behavior changes.
- No database changes.
- No Cloudflare account-side changes.
- No generated deployment output committed.
- No root README rewrite.
- No deployment guide rewrite.
- No final documentation audit completion.

Issue 54 will handle the root README and deployment guide. Issue 55 will complete the final documentation audit after Issue 54 lands.

## Verification

- Confirmed the commit only includes shared documentation files:
  - `Documentation/ADR-DEPLOYMENT-001-Deployment-Decisions.md`
  - `Documentation/README.md`
  - `Documentation/QA-log.md`
- Ran `git diff --check`; passed.
- Confirmed the branch pushed successfully to `origin/144-deployment`.

## Reviewer Checks

- Confirm the ADR clearly records the deployment platform choice and configuration.
- Confirm the branch-source wording is respectful and accurate:
  - deployment validation happened from `deployment`
  - final intended production source is `main` after team approval
- Confirm no runtime behavior changed.
- Confirm the ADR is discoverable from `Documentation/README.md`.
- Confirm the QA log accurately scopes Issue 53 and leaves README/deployment guide work for Issue 54.
