### PR TITLE
Finalize Documentation Indexes

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -4,7 +4,7 @@
 **Author:** mp3li
 **Contributors:** Leena Komenski
 **Date:** 2026-05-15
-**Last updated:** 2026-05-25
+**Last updated:** 2026-05-31
 **Status:** Active
 
 ---
@@ -58,6 +58,23 @@ Shared visual documentation assets live in:
 
 - `Documentation/Screenshots/` for app screenshots
 - `Documentation/GIFs/` for app flow GIFs
+
+### Capstone planning and review documents
+
+Capstone planning, proposal, mockup, and grading-support documents live in:
+
+- `Documents/`
+- `Documents/README.md`
+
+Current scope there includes:
+
+- project outline and track deliverables
+- mp3li Software Development track requirements evidence
+- mp3li UI planning and research notes
+- original web UI mockup index
+- historical proposal/reference PDFs
+
+Current implementation architecture docs should still live near the code they describe.
 
 ### Frontend documentation
 
@@ -154,4 +171,5 @@ When adding documentation:
 - put tool usage docs in the relevant tool folder
 - put business deliverables in `business-report/`
 - put data findings, dashboard methodology, and BDA decision records in `backend/Capstone.API/database/Documentation/Data Findings and Updates/`
+- put capstone planning, proposal, mockup, and grading-support documents in `Documents/`
 - use this shared folder only for cross-stack or repository-wide orientation

--- a/Documentation/final-documentation-audit.md
+++ b/Documentation/final-documentation-audit.md
@@ -4,7 +4,7 @@
 **Issue:** 55 - Final documentation audit
 **Audit owner:** mp3li
 **Initial audit date:** 2026-05-25
-**Final audit date:** 2026-05-25
+**Final audit date:** 2026-05-31
 **Status:** Complete
 
 ---
@@ -23,7 +23,7 @@ The audit verifies three areas:
 
 **Overall status:** Complete.
 
-Issue 54 has landed into `development`, so the final audit could be completed. The repository now has a full root README, a standalone deployment guide, accepted backend/deployment ADRs, frontend/backend/database/tool/business documentation, README media assets, project tracking links, and final review-oriented documentation maps.
+Issue 54 has landed into `development`, so the final audit could be completed. The repository now has a full root README, a standalone deployment guide, accepted backend/deployment ADRs, frontend/backend/database/tool/business documentation, capstone planning/review documentation, README media assets, project tracking links, and final review-oriented documentation maps.
 
 The remaining notes in this file are follow-up review notes, not blockers for Issue 55:
 
@@ -48,6 +48,7 @@ The remaining notes in this file are follow-up review notes, not blockers for Is
 | --- | --- | --- |
 | Root project README | `README.md` | Complete |
 | Repository-wide documentation map | `Documentation/README.md` | Covered |
+| Capstone planning and review documents | `Documents/README.md` and `Documents/` | Covered |
 | Deployment guide | `Documentation/deployment-guide.md` | Covered |
 | Deployment plan and deployment ADR | `Documentation/deployment-platform-selection-plan.md`, `Documentation/ADR-DEPLOYMENT-001-Deployment-Decisions.md` | Covered |
 | QA/regression history | `Documentation/QA-log.md` | Covered |
@@ -92,6 +93,7 @@ Confirmed README coverage:
 - deployment guide link
 - developer reference and environment variable notes
 - documentation map links
+- capstone planning and review document links
 - project tracking board link
 - challenges and solutions section
 - dataset/provider credits
@@ -123,12 +125,13 @@ Confirmed deployment coverage:
 | Confirm README links to deployment guide | Passed |
 | Confirm README links to API/provider docs | Passed |
 | Confirm README links to documentation map and major component docs | Passed |
+| Confirm README links to capstone planning and review documents | Passed |
 | Confirm README links to project tracker | Passed |
 | Confirm screenshots/GIFs are referenced from stable documentation paths | Passed |
 | Confirm deployment branch-source wording is documented | Passed |
 | Confirm environment variable documentation avoids secret values | Passed |
 | Confirm major decision records are discoverable | Passed |
-| Confirm frontend, backend, database, business/data, and tools docs are discoverable | Passed |
+| Confirm frontend, backend, database, business/data, tools, and capstone review docs are discoverable | Passed |
 | Confirm Issue 54 no longer blocks Issue 55 | Passed |
 
 ## Follow-Up Notes

--- a/Documents/README.md
+++ b/Documents/README.md
@@ -1,0 +1,48 @@
+# Capstone Planning and Review Documents
+
+**Project:** Hidden Gem Music Discovery Platform - SOFT290 Capstone
+**Owner:** mp3li
+**Last updated:** 2026-05-31
+**Status:** Active
+
+---
+
+## Purpose
+
+This folder contains capstone planning, proposal, UI planning, rubric-support, and review-support documents.
+
+Current implementation and architecture documentation should live near the code it describes. This folder is for supporting documents that explain planning history, track requirements, mockups, proposal materials, and grading evidence.
+
+## Current Review Documents
+
+| Document | Purpose |
+| --- | --- |
+| [Capstone project outline](capstone-project-outline.md) | Defines the project scope, 10-week timeline, track deliverables, and tools from the capstone outline. |
+| [mp3li grading Software Development track requirements](mp3li-grading-software-development-track-requirements.md) | Documents how mp3li met the Software Development track requirements for full-stack app work, API integration, and deployment. |
+| [mp3li capstone project UI plan](mp3li-capstone-project-ui-plan.md) | Preserves the UI plan in a readable Markdown format for review and project history. |
+| [mp3li UI research notes](mp3li-ui-research-notes.md) | Records UI research, design decisions, final implementation changes, and what changed between plan and result. |
+| [mp3li web UI mockups](mp3li-web-ui-mockups.md) | Indexes the original web mockups and explains how they relate to the finished app. |
+
+## Mockup Assets
+
+Original mockup images live in:
+
+- [Hidden Gem Music App Web Mockups](Hidden%20Gem%20Music%20App%20Web%20Mockups/)
+
+## Historical Proposal and Reference PDFs
+
+The remaining PDFs in this folder are historical proposal, brainstorming, reference, and teammate-provided materials. They are kept as supporting project evidence, not as the current source of implementation documentation.
+
+Current technical documentation should be maintained in:
+
+- [Repository documentation map](../Documentation/README.md)
+- [Frontend documentation index](../hidden-gem-music-app/Documentation/README.md)
+- [Backend documentation index](../backend/Capstone.API/Documentation/README.md)
+- [Database documentation index](../backend/Capstone.API/database/README.md)
+- [Business report index](../business-report/README.md)
+
+## What Does Not Belong Here
+
+Do not add private planning notes, local timeline files, issue drafts, PR drafts, runtime secrets, personal scratch notes, or current app architecture documents to this folder.
+
+Current app architecture belongs next to the code it describes. PR and issue drafts belong in local-only working folders, not in tracked repository documentation.

--- a/README.md
+++ b/README.md
@@ -683,6 +683,15 @@ Shared documentation:
 
 - [Repository documentation map](Documentation/README.md)
 - [QA log](Documentation/QA-log.md)
+- [Capstone planning and review documents](Documents/README.md)
+
+Capstone planning and grading-support documents:
+
+- [Capstone project outline](Documents/capstone-project-outline.md)
+- [mp3li Software Development track requirements evidence](Documents/mp3li-grading-software-development-track-requirements.md)
+- [mp3li UI plan](Documents/mp3li-capstone-project-ui-plan.md)
+- [mp3li UI research notes](Documents/mp3li-ui-research-notes.md)
+- [mp3li web UI mockups](Documents/mp3li-web-ui-mockups.md)
 
 Frontend documentation:
 


### PR DESCRIPTION
# PR: Final Planning Documentation Cleanup

## Summary

This PR finalizes the public-facing planning documentation cleanup for the capstone repository.

It replaces older PDF planning artifacts with polished Markdown documents, removes personal or misplaced documentation from tracked source, and keeps the maintained architecture and deployment documentation in the correct repo locations.

## What Changed

- Added polished Markdown versions of mp3li planning and grading documentation:
  - `Documents/capstone-project-outline.md`
  - `Documents/mp3li-capstone-project-ui-plan.md`
  - `Documents/mp3li-ui-research-notes.md`
  - `Documents/mp3li-web-ui-mockups.md`
  - `Documents/mp3li-grading-software-development-track-requirements.md`
- Removed the older tracked PDF versions of the mp3li planning documents.
- Renamed the Software Development requirements document to `mp3li-grading-software-development-track-requirements.md`.
- Stopped tracking the personal implementation timeline and added it to `.gitignore` so it can remain local-only.
- Removed outdated or misplaced documents from `Documents/`:
  - `Documents/mp3li-frontend-architecture.md`
  - `Documents/PR_Issue_128.md`
- Updated the maintained frontend architecture documentation in `hidden-gem-music-app/Documentation/frontend-architecture.md`.

## Why

The repository should contain professional documentation that is useful for reviewers, teammates, and final capstone grading.

The old PDF planning files were harder to review in GitHub, personal timeline notes should not be public repo artifacts, and frontend architecture documentation belongs with the frontend app documentation rather than in the general planning folder.

## Testing

- Reviewed the Markdown files for formatting and readability.
- Confirmed the personal implementation timeline is ignored and local-only.
- Confirmed the old PDF planning files were removed from tracked source.
- Ran:

```bash
git diff --check
```

## Notes

This is a documentation-only PR. It does not change frontend runtime behavior, backend API behavior, database configuration, deployment configuration, or Cloudflare secrets.
